### PR TITLE
Exit early if build.sh already exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ PACKAGE := github.com/travis-ci/worker
 SUBPACKAGES := \
 	$(PACKAGE)/cmd/travis-worker \
 	$(PACKAGE)/lib \
-	$(PACKAGE)/lib/backend
+	$(PACKAGE)/lib/backend \
+	$(PACKAGE)/lib/context \
+	$(PACKAGE)/lib/metrics
 
 VERSION_VAR := $(PACKAGE)/lib.VersionString
 VERSION_VALUE ?= $(shell git describe --always --dirty --tags 2>/dev/null)

--- a/lib/backend/docker.go
+++ b/lib/backend/docker.go
@@ -234,6 +234,11 @@ func (i *DockerInstance) UploadScript(ctx gocontext.Context, script []byte) erro
 	}
 	defer sftp.Close()
 
+	_, err = sftp.Lstat("build.sh")
+	if err == nil {
+		return ErrStaleVM
+	}
+
 	f, err := sftp.Create("build.sh")
 	if err != nil {
 		return err

--- a/lib/backend/jupiterbrain.go
+++ b/lib/backend/jupiterbrain.go
@@ -23,7 +23,9 @@ import (
 	"golang.org/x/net/context"
 )
 
-var nonAlphaNumRegexp = regexp.MustCompile(`[^a-zA-Z0-9_]+`)
+var (
+	nonAlphaNumRegexp = regexp.MustCompile(`[^a-zA-Z0-9_]+`)
+)
 
 const wrapperSh = `#!/bin/bash
 
@@ -305,6 +307,11 @@ func (i *JupiterBrainInstance) UploadScript(ctx context.Context, script []byte) 
 		return err
 	}
 	defer sftp.Close()
+
+	_, err = sftp.Lstat("build.sh")
+	if err == nil {
+		return ErrStaleVM
+	}
 
 	f, err := sftp.Create("build.sh")
 	if err != nil {

--- a/lib/backend/package.go
+++ b/lib/backend/package.go
@@ -7,6 +7,10 @@ import (
 	"golang.org/x/net/context"
 )
 
+var (
+	ErrStaleVM = fmt.Errorf("previous build artifacts found on stale vm")
+)
+
 // Provider represents some kind of instance provider. It can point to an
 // external HTTP API, or some process locally, or something completely
 // different.

--- a/lib/backend/sauce_labs.go
+++ b/lib/backend/sauce_labs.go
@@ -217,6 +217,11 @@ func (i *SauceLabsInstance) UploadScript(ctx context.Context, script []byte) err
 	}
 	defer sftp.Close()
 
+	_, err = sftp.Lstat("build.sh")
+	if err == nil {
+		return ErrStaleVM
+	}
+
 	f, err := sftp.Create("build.sh")
 	if err != nil {
 		return err

--- a/lib/job_queue.go
+++ b/lib/job_queue.go
@@ -5,10 +5,10 @@ import (
 	"time"
 
 	"github.com/bitly/go-simplejson"
-	"github.com/rcrowley/go-metrics"
 	"github.com/streadway/amqp"
 	"github.com/travis-ci/worker/lib/backend"
 	"github.com/travis-ci/worker/lib/context"
+	"github.com/travis-ci/worker/lib/metrics"
 	gocontext "golang.org/x/net/context"
 )
 
@@ -57,7 +57,7 @@ func (j *amqpJob) Error(ctx gocontext.Context, errMessage string) error {
 }
 
 func (j *amqpJob) Requeue() error {
-	metrics.GetOrRegisterMeter("worker.job.requeue", metrics.DefaultRegistry).Mark(1)
+	metrics.Mark("worker.job.requeue")
 
 	amqpChan, err := j.conn.Channel()
 	if err != nil {

--- a/lib/metrics/package.go
+++ b/lib/metrics/package.go
@@ -2,8 +2,9 @@
 package metrics
 
 import (
-	"github.com/rcrowley/go-metrics"
 	"time"
+
+	"github.com/rcrowley/go-metrics"
 )
 
 // Mark increases the meter metric with the given name by 1


### PR DESCRIPTION
however improbable it may be.  Testing for this alone is not exhaustive, but
leaves the door open for a use case where the VM/machine is recycled.