### PR TITLE
docker: fix a panic by reversing a loop

### DIFF
--- a/src/github.com/travis-ci/worker/backend/docker.go
+++ b/src/github.com/travis-ci/worker/backend/docker.go
@@ -271,9 +271,9 @@ func (p *DockerProvider) checkoutCPUSets() (string, error) {
 
 	cpuSetsString := []string{}
 
-	for i := len(cpuSets); i > 0; i-- {
-		p.cpuSets[cpuSets[i]] = true
-		cpuSetsString = append(cpuSetsString, fmt.Sprintf("%d", cpuSets[i]))
+	for _, cpuSet := range cpuSets {
+		p.cpuSets[cpuSet] = true
+		cpuSetsString = append(cpuSetsString, fmt.Sprintf("%d", cpuSet))
 	}
 
 	return strings.Join(cpuSetsString, ","), nil


### PR DESCRIPTION
The old loop seems to have gone from len(cpuSets) to 1, which seems like an off-by-one error (I think it should've gone from len(cpuSets)-1 to 0). I couldn't see a reason for the loop to go backwards, so I changed the loop to go from 0 to len(cpuSets)-1 in order to use the more standard Go loop.

/cc @meatballhat, who wrote the original loop (main question: any reason to go through the slice in reverse?)