### PR TITLE
Add support for per-job configurable timeouts in payload

### DIFF
--- a/src/github.com/travis-ci/worker/job.go
+++ b/src/github.com/travis-ci/worker/job.go
@@ -17,6 +17,7 @@ type JobPayload struct {
 	Repository RepositoryPayload      `json:"repository"`
 	UUID       string                 `json:"uuid"`
 	Config     map[string]interface{} `json:"config"`
+	Timeouts   TimeoutsPayload        `json:"timeouts,omitempty"`
 }
 
 type JobJobPayload struct {
@@ -32,6 +33,11 @@ type BuildPayload struct {
 type RepositoryPayload struct {
 	ID   uint64 `json:"id"`
 	Slug string `json:"slug"`
+}
+
+type TimeoutsPayload struct {
+	HardLimit  uint64 `json:"hard_limit"`
+	LogSilence uint64 `json:"log_silence"`
 }
 
 // FinishState is the state that a job finished with (such as pass/fail/etc.).

--- a/src/github.com/travis-ci/worker/processor.go
+++ b/src/github.com/travis-ci/worker/processor.go
@@ -142,7 +142,7 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 		&stepUploadScript{},
 		&stepUpdateState{},
 		&stepRunScript{
-			logTimeout:               p.logTimeout,
+			logTimeout:               logTimeout,
 			maxLogLength:             4500000,
 			hardTimeout:              p.hardTimeout,
 			skipShutdownOnLogTimeout: p.SkipShutdownOnLogTimeout,


### PR DESCRIPTION
These timeouts come from hub and are used in certain cases. This is more work to get to feature parity with the Ruby worker.