### PR TITLE
Redoing version checking logic to skip package building earlier

### DIFF
--- a/utils/pkg/pkg_run
+++ b/utils/pkg/pkg_run
@@ -15,7 +15,18 @@ fi
 # set the version file before anything else, because
 # we need it in our build env and inside the docker
 # containers we'll run some stuff in
+if [[ ! -n $PACKAGECLOUD_TOKEN ]]; then
+  echo "you must set a PACKAGECLOUD_TOKEN env variable for this to run"
+  exit 1
+fi
 git tag|tail -n 1|cut -d'v' -f 2 > VERSION
+LATEST_PUBLISHED_VERSION=$(curl -s https://$(echo $PACKAGECLOUD_TOKEN):@packagecloud.io/api/v1/repos/travisci/worker/package/rpm/el/7/travis-worker/x86_64/versions.json | jq .[].version | tail -n 1 | tr -d '"')
+
+if [[ $(cat VERSION) == $LATEST_PUBLISHED_VERSION ]]; then
+  echo "Version: $(cat VERSION) is the same as what's on packagecloud.io, not publishing again."
+  # We exit with 0 because this shouldn't trigger a build failure.
+  exit 0
+fi
 
 if [[ ! -n $CHECKOUT_ROOT ]]; then
   source /code/utils/pkg/includes/common
@@ -36,7 +47,6 @@ docker_pull_images () {
 }
 
 docker_run () {
-  LATEST_PUBLISHED_VERSION=$(curl -s https://$(echo $PACKAGECLOUD_TOKEN):@packagecloud.io/api/v1/repos/travisci/worker/package/rpm/el/7/travis-worker/x86_64/versions.json | jq .[].version | tail -n 1 | tr -d '"')
   pkgtype="1"
   build_docker_image="1"
   test_docker_image="1"
@@ -94,10 +104,8 @@ docker_run () {
       test-$platform_release-$pkgtype-$DATE \
       /code/utils/pkg/pkg_test $platform $pkgtype
 
-    if [[ ! -n $NO_PUSH && $VERSION != $LATEST_PUBLISHED_VERSION ]]; then
+    if [[ ! -n $NO_PUSH ]]; then
       package_cloud_push
-    else
-      echo "Version: $VERSION is the same as what's published, not publishing again."
     fi
     # fin
   done
@@ -118,6 +126,7 @@ package_cloud_push () {
 }
 
 docker_pull_images
+
 if [[ ! -n $NO_RUN ]]; then
   docker_run
 fi


### PR DESCRIPTION
Redoing version checking logic to skip package building earlier in the build when a new version doesn't exist yet