### PR TITLE
Fix lint errors

### DIFF
--- a/src/github.com/travis-ci/worker/amqp_job.go
+++ b/src/github.com/travis-ci/worker/amqp_job.go
@@ -75,17 +75,18 @@ func (j *amqpJob) Requeue() error {
 		return err
 	}
 
-	amqpChan.Publish("", "reporting.jobs.builds", false, false, amqp.Publishing{
+	err = amqpChan.Publish("", "reporting.jobs.builds", false, false, amqp.Publishing{
 		ContentType:  "application/json",
 		DeliveryMode: amqp.Persistent,
 		Timestamp:    time.Now().UTC(),
 		Type:         "job:test:reset",
 		Body:         bodyBytes,
 	})
+	if err != nil {
+		return err
+	}
 
-	j.delivery.Ack(false)
-
-	return nil
+	return j.delivery.Ack(false)
 }
 
 func (j *amqpJob) Received() error {
@@ -143,15 +144,13 @@ func (j *amqpJob) Started() error {
 		return err
 	}
 
-	amqpChan.Publish("", "reporting.jobs.builds", false, false, amqp.Publishing{
+	return amqpChan.Publish("", "reporting.jobs.builds", false, false, amqp.Publishing{
 		ContentType:  "application/json",
 		DeliveryMode: amqp.Persistent,
 		Timestamp:    time.Now().UTC(),
 		Type:         "job:test:start",
 		Body:         bodyBytes,
 	})
-
-	return nil
 }
 
 func (j *amqpJob) Finish(state FinishState) error {
@@ -177,17 +176,18 @@ func (j *amqpJob) Finish(state FinishState) error {
 		return err
 	}
 
-	amqpChan.Publish("", "reporting.jobs.builds", false, false, amqp.Publishing{
+	err = amqpChan.Publish("", "reporting.jobs.builds", false, false, amqp.Publishing{
 		ContentType:  "application/json",
 		DeliveryMode: amqp.Persistent,
 		Timestamp:    time.Now().UTC(),
 		Type:         "job:test:finish",
 		Body:         bodyBytes,
 	})
+	if err != nil {
+		return err
+	}
 
-	j.delivery.Ack(false)
-
-	return nil
+	return j.delivery.Ack(false)
 }
 
 func (j *amqpJob) LogWriter(ctx gocontext.Context) (LogWriter, error) {

--- a/src/github.com/travis-ci/worker/build_script_generator.go
+++ b/src/github.com/travis-ci/worker/build_script_generator.go
@@ -48,7 +48,7 @@ type s3BuildCacheOptions struct {
 	scheme          string
 	region          string
 	bucket          string
-	accessKeyId     string
+	accessKeyID     string
 	secretAccessKey string
 }
 
@@ -68,7 +68,7 @@ func NewBuildScriptGenerator(cfg *config.Config) BuildScriptGenerator {
 			scheme:          cfg.BuildCacheS3Scheme,
 			region:          cfg.BuildCacheS3Region,
 			bucket:          cfg.BuildCacheS3Bucket,
-			accessKeyId:     cfg.BuildCacheS3AccessKeyID,
+			accessKeyID:     cfg.BuildCacheS3AccessKeyID,
 			secretAccessKey: cfg.BuildCacheS3SecretAccessKey,
 		},
 		httpClient: &http.Client{
@@ -100,7 +100,7 @@ func (g *webBuildScriptGenerator) Generate(ctx gocontext.Context, payload *simpl
 		payload.SetPath([]string{"cache_options", "s3", "scheme"}, g.s3CacheOptions.scheme)
 		payload.SetPath([]string{"cache_options", "s3", "region"}, g.s3CacheOptions.region)
 		payload.SetPath([]string{"cache_options", "s3", "bucket"}, g.s3CacheOptions.bucket)
-		payload.SetPath([]string{"cache_options", "s3", "access_key_id"}, g.s3CacheOptions.accessKeyId)
+		payload.SetPath([]string{"cache_options", "s3", "access_key_id"}, g.s3CacheOptions.accessKeyID)
 		payload.SetPath([]string{"cache_options", "s3", "secret_access_key"}, g.s3CacheOptions.secretAccessKey)
 	}
 

--- a/src/github.com/travis-ci/worker/canceller.go
+++ b/src/github.com/travis-ci/worker/canceller.go
@@ -79,7 +79,10 @@ func (d *CommandDispatcher) Run() {
 
 	for delivery := range deliveries {
 		d.processCommand(delivery)
-		delivery.Ack(false)
+		err := delivery.Ack(false)
+		if err != nil {
+			context.LoggerFromContext(d.ctx).WithField("err", err).WithField("delivery", delivery).Error("couldn't ack delivery")
+		}
 	}
 }
 

--- a/src/github.com/travis-ci/worker/log_writer.go
+++ b/src/github.com/travis-ci/worker/log_writer.go
@@ -123,7 +123,10 @@ func (w *amqpLogWriter) Write(p []byte) (int, error) {
 
 	w.bytesWritten += len(p)
 	if w.bytesWritten > w.maxLength {
-		w.WriteAndClose([]byte(fmt.Sprintf("\n\nThe log length has exceeded the limit of %d MB (this usually means that the test suite is raising the same exception over and over).\n\nThe job has been terminated\n", w.maxLength/1000/1000)))
+		_, err := w.WriteAndClose([]byte(fmt.Sprintf("\n\nThe log length has exceeded the limit of %d MB (this usually means that the test suite is raising the same exception over and over).\n\nThe job has been terminated\n", w.maxLength/1000/1000)))
+		if err != nil {
+			context.LoggerFromContext(w.ctx).WithField("err", err).Error("couldn't write 'log length exceeded' error message to log")
+		}
 		return 0, fmt.Errorf("wrote past max length")
 	}
 

--- a/src/github.com/travis-ci/worker/log_writer.go
+++ b/src/github.com/travis-ci/worker/log_writer.go
@@ -16,9 +16,9 @@ import (
 var (
 	LogWriterTick = 500 * time.Millisecond
 
-	// This is a bit of a magic number, calculated like this: The maximum
-	// Pusher payload is 10 kB (or 10 KiB, who knows, but let's go with 10
-	// kB since that is smaller). Looking at the travis-logs source, the
+	// LogChunkSize is a bit of a magic number, calculated like this: The
+	// maximum Pusher payload is 10 kB (or 10 KiB, who knows, but let's go with
+	// 10 kB since that is smaller). Looking at the travis-logs source, the
 	// current message overhead (i.e. the part of the payload that isn't
 	// the content of the log part) is 42 bytes + the length of the JSON-
 	// encoded ID and the length of the JSON-encoded sequence number. A 64-

--- a/src/github.com/travis-ci/worker/log_writer.go
+++ b/src/github.com/travis-ci/worker/log_writer.go
@@ -303,7 +303,7 @@ func (w *amqpLogWriter) reopenChannel() error {
 	// reopenChannel() shouldn't be called if the channel isn't already closed.
 	// but we're closing the channel again, just in case, to avoid leaking
 	// channels.
-	w.amqpChan.Close()
+	_ = w.amqpChan.Close()
 
 	w.amqpChan = amqpChan
 

--- a/src/github.com/travis-ci/worker/step_generate_script.go
+++ b/src/github.com/travis-ci/worker/step_generate_script.go
@@ -18,12 +18,19 @@ func (s *stepGenerateScript) Run(state multistep.StateBag) multistep.StepAction 
 	if err != nil {
 		if genErr, ok := err.(BuildScriptGeneratorError); ok && genErr.Recover {
 			context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't generate build script, requeueing job")
-			buildJob.Requeue()
+			err := buildJob.Requeue()
+			if err != nil {
+				context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't requeue job")
+			}
 			return multistep.ActionHalt
 		}
 
 		context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't generate build script, erroring job")
-		buildJob.Error(ctx, "An error occurred while generating the build script.")
+		err := buildJob.Error(ctx, "An error occurred while generating the build script.")
+		if err != nil {
+			context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't error job")
+		}
+
 		return multistep.ActionHalt
 	}
 

--- a/src/github.com/travis-ci/worker/step_run_script.go
+++ b/src/github.com/travis-ci/worker/step_run_script.go
@@ -26,7 +26,10 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 	logWriter, err := buildJob.LogWriter(ctx)
 	if err != nil {
 		context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't open a log writer")
-		buildJob.Requeue()
+		err := buildJob.Requeue()
+		if err != nil {
+			context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't requeue job")
+		}
 		return multistep.ActionHalt
 	}
 
@@ -85,7 +88,10 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 			context.LoggerFromContext(ctx).WithField("err", r.err).WithField("completed", r.result.Completed).Error("couldn't run script")
 
 			if !r.result.Completed {
-				buildJob.Requeue()
+				err := buildJob.Requeue()
+				if err != nil {
+					context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't requeue job")
+				}
 			}
 
 			return multistep.ActionHalt

--- a/src/github.com/travis-ci/worker/step_run_script.go
+++ b/src/github.com/travis-ci/worker/step_run_script.go
@@ -46,7 +46,7 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 
 	go func() {
 		if hostname, ok := state.Get("hostname").(string); ok && hostname != "" {
-			logWriter.Write([]byte(fmt.Sprintf("Using worker: %s (%s)\n\n", hostname, instance.ID())))
+			_, _ = logWriter.Write([]byte(fmt.Sprintf("Using worker: %s (%s)\n\n", hostname, instance.ID())))
 		}
 		result, err := instance.RunScript(ctx, logWriter)
 		resultChan <- struct {

--- a/src/github.com/travis-ci/worker/step_start_instance.go
+++ b/src/github.com/travis-ci/worker/step_start_instance.go
@@ -29,7 +29,10 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 	instance, err := s.provider.Start(ctx, buildJob.StartAttributes())
 	if err != nil {
 		context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't start instance")
-		buildJob.Requeue()
+		err := buildJob.Requeue()
+		if err != nil {
+			context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't requeue job")
+		}
 
 		return multistep.ActionHalt
 	}

--- a/src/github.com/travis-ci/worker/step_subscribe_cancellation.go
+++ b/src/github.com/travis-ci/worker/step_subscribe_cancellation.go
@@ -19,7 +19,10 @@ func (s *stepSubscribeCancellation) Run(state multistep.StateBag) multistep.Step
 	err := s.canceller.Subscribe(buildJob.Payload().Job.ID, ch)
 	if err != nil {
 		context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't subscribe to canceller")
-		buildJob.Requeue()
+		err := buildJob.Requeue()
+		if err != nil {
+			context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't requeue job")
+		}
 		return multistep.ActionHalt
 	}
 

--- a/src/github.com/travis-ci/worker/step_upload_script.go
+++ b/src/github.com/travis-ci/worker/step_upload_script.go
@@ -26,7 +26,10 @@ func (s *stepUploadScript) Run(state multistep.StateBag) multistep.StepAction {
 		metrics.Mark(errMetric)
 
 		context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't upload script")
-		buildJob.Requeue()
+		err := buildJob.Requeue()
+		if err != nil {
+			context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't requeue job")
+		}
 
 		return multistep.ActionHalt
 	}

--- a/src/github.com/travis-ci/worker/version.go
+++ b/src/github.com/travis-ci/worker/version.go
@@ -18,9 +18,9 @@ var (
 
 func init() {
 	cli.VersionPrinter = customVersionPrinter
-	os.Setenv("VERSION", VersionString)
-	os.Setenv("REVISION", RevisionString)
-	os.Setenv("GENERATED", GeneratedString)
+	_ = os.Setenv("VERSION", VersionString)
+	_ = os.Setenv("REVISION", RevisionString)
+	_ = os.Setenv("GENERATED", GeneratedString)
 }
 
 func customVersionPrinter(c *cli.Context) {


### PR DESCRIPTION
This fixes all errors reported by `gometalinter` except:

- "Should have comment or be unexported"
- `errcheck` warnings on `defer`-ed calls