### PR TITLE
Fix more lint warnings/errors

### DIFF
--- a/src/github.com/travis-ci/worker/backend/bluebox.go
+++ b/src/github.com/travis-ci/worker/backend/bluebox.go
@@ -259,15 +259,7 @@ func (i *BlueBoxInstance) Stop(ctx gocontext.Context) error {
 	return i.client.Blocks.Destroy(i.block.ID)
 }
 
-func (i *BlueBoxInstance) Refresh() (err error) {
-	i.block, err = i.client.Blocks.Get(i.block.ID)
-	return
-}
-
-func (i *BlueBoxInstance) Ready() bool {
-	return i.block.Status == "running"
-}
-
+// ID is an implementation of Instance.ID.
 func (i *BlueBoxInstance) ID() string {
 	return i.block.ID
 }

--- a/src/github.com/travis-ci/worker/backend/bluebox.go
+++ b/src/github.com/travis-ci/worker/backend/bluebox.go
@@ -40,19 +40,19 @@ func init() {
 	config.SetProviderHelp("BlueBox", blueBoxHelp)
 }
 
-type BlueBoxProvider struct {
+type blueBoxProvider struct {
 	client *goblueboxapi.Client
 	cfg    *config.ProviderConfig
 }
 
-func NewBlueBoxProvider(cfg *config.ProviderConfig) (*BlueBoxProvider, error) {
-	return &BlueBoxProvider{
+func newBlueBoxProvider(cfg *config.ProviderConfig) (*blueBoxProvider, error) {
+	return &blueBoxProvider{
 		client: goblueboxapi.NewClient(cfg.Get("CUSTOMER_ID"), cfg.Get("API_KEY")),
 		cfg:    cfg,
 	}, nil
 }
 
-func (b *BlueBoxProvider) Start(ctx gocontext.Context, startAttributes *StartAttributes) (Instance, error) {
+func (b *blueBoxProvider) Start(ctx gocontext.Context, startAttributes *StartAttributes) (Instance, error) {
 	password := generatePassword()
 	params := goblueboxapi.BlockParams{
 		Product:  b.cfg.Get("PRODUCT_ID"),
@@ -87,7 +87,7 @@ func (b *BlueBoxProvider) Start(ctx gocontext.Context, startAttributes *StartAtt
 	select {
 	case <-blockReady:
 		metrics.TimeSince("worker.vm.provider.bluebox.boot", startBooting)
-		return &BlueBoxInstance{
+		return &blueBoxInstance{
 			client:   b.client,
 			block:    block,
 			password: password,
@@ -107,7 +107,7 @@ func (b *BlueBoxProvider) Start(ctx gocontext.Context, startAttributes *StartAtt
 	}
 }
 
-func (b *BlueBoxProvider) templateIDForLanguageGroup(language, group string) string {
+func (b *blueBoxProvider) templateIDForLanguageGroup(language, group string) string {
 	languageMapSetting := fmt.Sprintf("LANGUAGE_MAP_%s", strings.ToUpper(language))
 	if b.cfg.IsSet(languageMapSetting) {
 		language = b.cfg.Get(languageMapSetting)
@@ -130,7 +130,7 @@ func (b *BlueBoxProvider) templateIDForLanguageGroup(language, group string) str
 	return ""
 }
 
-func (b *BlueBoxProvider) latestTemplates() map[string]string {
+func (b *blueBoxProvider) latestTemplates() map[string]string {
 	latest := map[string]goblueboxapi.Template{}
 	latestIDs := map[string]string{}
 
@@ -163,13 +163,13 @@ func (b *BlueBoxProvider) latestTemplates() map[string]string {
 	return latestIDs
 }
 
-type BlueBoxInstance struct {
+type blueBoxInstance struct {
 	client   *goblueboxapi.Client
 	block    *goblueboxapi.Block
 	password string
 }
 
-func (i *BlueBoxInstance) sshClient(ctx gocontext.Context) (*ssh.Client, error) {
+func (i *blueBoxInstance) sshClient(ctx gocontext.Context) (*ssh.Client, error) {
 	if len(i.block.IPs) == 0 {
 		return nil, errNoBlueBoxIP
 	}
@@ -189,7 +189,7 @@ func (i *BlueBoxInstance) sshClient(ctx gocontext.Context) (*ssh.Client, error) 
 	return client, err
 }
 
-func (i *BlueBoxInstance) UploadScript(ctx gocontext.Context, script []byte) error {
+func (i *blueBoxInstance) UploadScript(ctx gocontext.Context, script []byte) error {
 	client, err := i.sshClient(ctx)
 	if err != nil {
 		return err
@@ -220,7 +220,7 @@ func (i *BlueBoxInstance) UploadScript(ctx gocontext.Context, script []byte) err
 	return err
 }
 
-func (i *BlueBoxInstance) RunScript(ctx gocontext.Context, output io.WriteCloser) (*RunResult, error) {
+func (i *blueBoxInstance) RunScript(ctx gocontext.Context, output io.WriteCloser) (*RunResult, error) {
 	client, err := i.sshClient(ctx)
 	if err != nil {
 		return &RunResult{Completed: false}, err
@@ -255,11 +255,10 @@ func (i *BlueBoxInstance) RunScript(ctx gocontext.Context, output io.WriteCloser
 	}
 }
 
-func (i *BlueBoxInstance) Stop(ctx gocontext.Context) error {
+func (i *blueBoxInstance) Stop(ctx gocontext.Context) error {
 	return i.client.Blocks.Destroy(i.block.ID)
 }
 
-// ID is an implementation of Instance.ID.
-func (i *BlueBoxInstance) ID() string {
+func (i *blueBoxInstance) ID() string {
 	return i.block.ID
 }

--- a/src/github.com/travis-ci/worker/backend/bluebox_test.go
+++ b/src/github.com/travis-ci/worker/backend/bluebox_test.go
@@ -15,14 +15,14 @@ import (
 
 var (
 	blueboxMux      *http.ServeMux
-	blueboxProvider *BlueBoxProvider
+	blueboxProvider *blueBoxProvider
 	blueboxServer   *httptest.Server
 )
 
 func blueboxTestSetup(t *testing.T, cfg *config.ProviderConfig) {
 	blueboxMux = http.NewServeMux()
 	blueboxServer = httptest.NewServer(blueboxMux)
-	blueboxProvider, _ = NewBlueBoxProvider(cfg)
+	blueboxProvider, _ = newBlueBoxProvider(cfg)
 	blueboxProvider.client.BaseURL, _ = url.Parse(blueboxServer.URL)
 }
 

--- a/src/github.com/travis-ci/worker/backend/docker.go
+++ b/src/github.com/travis-ci/worker/backend/docker.go
@@ -38,7 +38,7 @@ func init() {
 	config.SetProviderHelp("Docker", dockerHelp)
 }
 
-type DockerProvider struct {
+type dockerProvider struct {
 	client *docker.Client
 
 	runPrivileged bool
@@ -50,15 +50,15 @@ type DockerProvider struct {
 	cpuSets      []bool
 }
 
-type DockerInstance struct {
+type dockerInstance struct {
 	client    *docker.Client
-	provider  *DockerProvider
+	provider  *dockerProvider
 	container *docker.Container
 
 	imageName string
 }
 
-func NewDockerProvider(cfg *config.ProviderConfig) (*DockerProvider, error) {
+func newDockerProvider(cfg *config.ProviderConfig) (*dockerProvider, error) {
 	client, err := buildClient(cfg)
 	if err != nil {
 		return nil, err
@@ -93,7 +93,7 @@ func NewDockerProvider(cfg *config.ProviderConfig) (*DockerProvider, error) {
 		}
 	}
 
-	return &DockerProvider{
+	return &dockerProvider{
 		client: client,
 
 		runPrivileged: privileged,
@@ -128,7 +128,7 @@ func buildClient(cfg *config.ProviderConfig) (*docker.Client, error) {
 	return docker.NewClient(endpoint)
 }
 
-func (p *DockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttributes) (Instance, error) {
+func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttributes) (Instance, error) {
 	logger := context.LoggerFromContext(ctx)
 
 	cpuSets, err := p.checkoutCPUSets()
@@ -208,7 +208,7 @@ func (p *DockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 	select {
 	case container := <-containerReady:
 		metrics.TimeSince("worker.vm.provider.docker.boot", startBooting)
-		return &DockerInstance{
+		return &dockerInstance{
 			client:    p.client,
 			provider:  p,
 			container: container,
@@ -224,7 +224,7 @@ func (p *DockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 	}
 }
 
-func (p *DockerProvider) imageForLanguage(language string) (string, string, error) {
+func (p *dockerProvider) imageForLanguage(language string) (string, string, error) {
 	images, err := p.client.ListImages(docker.ListImagesOptions{All: true})
 	if err != nil {
 		return "", "", err
@@ -248,7 +248,7 @@ func (p *DockerProvider) imageForLanguage(language string) (string, string, erro
 	return "", "", fmt.Errorf("no image found with language %s", language)
 }
 
-func (p *DockerProvider) checkoutCPUSets() (string, error) {
+func (p *dockerProvider) checkoutCPUSets() (string, error) {
 	p.cpuSetsMutex.Lock()
 	defer p.cpuSetsMutex.Unlock()
 
@@ -278,7 +278,7 @@ func (p *DockerProvider) checkoutCPUSets() (string, error) {
 	return strings.Join(cpuSetsString, ","), nil
 }
 
-func (p *DockerProvider) checkinCPUSets(sets string) {
+func (p *dockerProvider) checkinCPUSets(sets string) {
 	p.cpuSetsMutex.Lock()
 	defer p.cpuSetsMutex.Unlock()
 
@@ -291,7 +291,7 @@ func (p *DockerProvider) checkinCPUSets(sets string) {
 	}
 }
 
-func (i *DockerInstance) sshClient() (*ssh.Client, error) {
+func (i *dockerInstance) sshClient() (*ssh.Client, error) {
 	var err error
 	i.container, err = i.client.InspectContainer(i.container.ID)
 	if err != nil {
@@ -308,7 +308,7 @@ func (i *DockerInstance) sshClient() (*ssh.Client, error) {
 	})
 }
 
-func (i *DockerInstance) UploadScript(ctx gocontext.Context, script []byte) error {
+func (i *dockerInstance) UploadScript(ctx gocontext.Context, script []byte) error {
 	client, err := i.sshClient()
 	if err != nil {
 		return err
@@ -338,7 +338,7 @@ func (i *DockerInstance) UploadScript(ctx gocontext.Context, script []byte) erro
 	return nil
 }
 
-func (i *DockerInstance) RunScript(ctx gocontext.Context, output io.WriteCloser) (*RunResult, error) {
+func (i *dockerInstance) RunScript(ctx gocontext.Context, output io.WriteCloser) (*RunResult, error) {
 	client, err := i.sshClient()
 	if err != nil {
 		return &RunResult{Completed: false}, err
@@ -372,7 +372,7 @@ func (i *DockerInstance) RunScript(ctx gocontext.Context, output io.WriteCloser)
 	}
 }
 
-func (i *DockerInstance) Stop(ctx gocontext.Context) error {
+func (i *dockerInstance) Stop(ctx gocontext.Context) error {
 	defer i.provider.checkinCPUSets(i.container.Config.CPUSet)
 
 	err := i.client.StopContainer(i.container.ID, 30)
@@ -387,7 +387,7 @@ func (i *DockerInstance) Stop(ctx gocontext.Context) error {
 	})
 }
 
-func (i *DockerInstance) ID() string {
+func (i *dockerInstance) ID() string {
 	if i.container == nil {
 		return "{unidentified}"
 	}

--- a/src/github.com/travis-ci/worker/backend/fake.go
+++ b/src/github.com/travis-ci/worker/backend/fake.go
@@ -6,27 +6,27 @@ import (
 	"golang.org/x/net/context"
 )
 
-type FakeProvider struct {
+type fakeProvider struct {
 	logOutput []byte
 }
 
-func NewFakeProvider(logOutput []byte) *FakeProvider {
-	return &FakeProvider{logOutput: logOutput}
+func newFakeProvider(logOutput []byte) *fakeProvider {
+	return &fakeProvider{logOutput: logOutput}
 }
 
-func (p *FakeProvider) Start(ctx context.Context, _ *StartAttributes) (Instance, error) {
-	return &FakeInstance{logOutput: p.logOutput}, nil
+func (p *fakeProvider) Start(ctx context.Context, _ *StartAttributes) (Instance, error) {
+	return &fakeInstance{logOutput: p.logOutput}, nil
 }
 
-type FakeInstance struct {
+type fakeInstance struct {
 	logOutput []byte
 }
 
-func (i *FakeInstance) UploadScript(ctx context.Context, script []byte) error {
+func (i *fakeInstance) UploadScript(ctx context.Context, script []byte) error {
 	return nil
 }
 
-func (i *FakeInstance) RunScript(ctx context.Context, writer io.WriteCloser) (*RunResult, error) {
+func (i *fakeInstance) RunScript(ctx context.Context, writer io.WriteCloser) (*RunResult, error) {
 	_, err := writer.Write(i.logOutput)
 	if err != nil {
 		return &RunResult{Completed: false}, err
@@ -40,10 +40,10 @@ func (i *FakeInstance) RunScript(ctx context.Context, writer io.WriteCloser) (*R
 	return &RunResult{Completed: true}, nil
 }
 
-func (i *FakeInstance) Stop(ctx context.Context) error {
+func (i *fakeInstance) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (i *FakeInstance) ID() string {
+func (i *fakeInstance) ID() string {
 	return "fake"
 }

--- a/src/github.com/travis-ci/worker/backend/jupiterbrain.go
+++ b/src/github.com/travis-ci/worker/backend/jupiterbrain.go
@@ -75,7 +75,7 @@ type jupiterBrainInstance struct {
 
 type jupiterBrainInstancePayload struct {
 	ID          string   `json:"id"`
-	IpAddresses []string `json:"ip-addresses"`
+	IPAddresses []string `json:"ip-addresses"`
 	State       string   `json:"state"`
 	BaseImage   string   `json:"base-image,omitempty"`
 	Type        string   `json:"type,omitempty"`
@@ -260,10 +260,10 @@ func (p *jupiterBrainProvider) Start(ctx context.Context, startAttributes *Start
 			_ = resp.Body.Close()
 
 			var ip net.IP
-			for _, ipString := range payload.IpAddresses {
-				curIp := net.ParseIP(ipString)
-				if curIp.To4() != nil {
-					ip = curIp
+			for _, ipString := range payload.IPAddresses {
+				curIP := net.ParseIP(ipString)
+				if curIP.To4() != nil {
+					ip = curIP
 					break
 				}
 
@@ -453,10 +453,10 @@ func (i *jupiterBrainInstance) sshClient() (*ssh.Client, error) {
 	}
 
 	var ip net.IP
-	for _, ipString := range i.payload.IpAddresses {
-		curIp := net.ParseIP(ipString)
-		if curIp.To4() != nil {
-			ip = curIp
+	for _, ipString := range i.payload.IPAddresses {
+		curIP := net.ParseIP(ipString)
+		if curIP.To4() != nil {
+			ip = curIP
 			break
 		}
 

--- a/src/github.com/travis-ci/worker/backend/package.go
+++ b/src/github.com/travis-ci/worker/backend/package.go
@@ -13,7 +13,13 @@ import (
 )
 
 var (
-	ErrStaleVM               = fmt.Errorf("previous build artifacts found on stale vm")
+	// ErrStaleVM is returned from one of the Instance methods if it detects
+	// that the VM had already been used for a repository and was not reverted
+	// afterwards.
+	ErrStaleVM = fmt.Errorf("previous build artifacts found on stale vm")
+
+	// ErrMissingEndpointConfig is returned if the provider config was missing
+	// an 'ENDPOINT' configuration, but one is required.
 	ErrMissingEndpointConfig = fmt.Errorf("expected config key endpoint")
 	punctRegex               = regexp.MustCompile(`[&+/=\\]`)
 )
@@ -54,11 +60,18 @@ type StartAttributes struct {
 	OS       string `json:"os"`
 }
 
+// RunResult represents the result of running a script with Instance.RunScript.
 type RunResult struct {
-	ExitCode  uint8
+	// The exit code of the script. Only valid if Completed is true.
+	ExitCode uint8
+
+	// Whether the script finished running or not. Can be false if there was a
+	// connection error in the middle of the script run.
 	Completed bool
 }
 
+// NewProvider creates a new provider using the given name and provider config.
+// Valid names are 'docker', 'jupiterbrain', 'bluebox' and 'fake'.
 func NewProvider(name string, cfg *config.ProviderConfig) (Provider, error) {
 	switch name {
 	case "docker":

--- a/src/github.com/travis-ci/worker/backend/package.go
+++ b/src/github.com/travis-ci/worker/backend/package.go
@@ -62,13 +62,13 @@ type RunResult struct {
 func NewProvider(name string, cfg *config.ProviderConfig) (Provider, error) {
 	switch name {
 	case "docker":
-		return NewDockerProvider(cfg)
+		return newDockerProvider(cfg)
 	case "jupiterbrain":
-		return NewJupiterBrainProvider(cfg)
+		return newJupiterBrainProvider(cfg)
 	case "bluebox":
-		return NewBlueBoxProvider(cfg)
+		return newBlueBoxProvider(cfg)
 	case "fake":
-		return NewFakeProvider([]byte("Hello to the logs")), nil
+		return newFakeProvider([]byte("Hello to the logs")), nil
 	default:
 		return nil, fmt.Errorf("unknown provider: %s", name)
 	}

--- a/src/github.com/travis-ci/worker/cmd/travis-worker/main.go
+++ b/src/github.com/travis-ci/worker/cmd/travis-worker/main.go
@@ -66,7 +66,7 @@ func runWorker(c *cli.Context) {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
 
-	cfg := config.ConfigFromCLIContext(c)
+	cfg := config.FromCLIContext(c)
 
 	if c.Bool("echo-config") {
 		config.WriteEnvConfig(cfg, os.Stdout)

--- a/src/github.com/travis-ci/worker/config/config.go
+++ b/src/github.com/travis-ci/worker/config/config.go
@@ -49,9 +49,9 @@ type Config struct {
 	BuildCacheS3SecretAccessKey string
 }
 
-// ConfigFromCLIContext creates a Config using a cli.Context by pulling
-// configuration from the flags in the context.
-func ConfigFromCLIContext(c *cli.Context) *Config {
+// FromCLIContext creates a Config using a cli.Context by pulling configuration
+// from the flags in the context.
+func FromCLIContext(c *cli.Context) *Config {
 	cfg := &Config{
 		AmqpURI:       c.String("amqp-uri"),
 		PoolSize:      c.Int("pool-size"),

--- a/src/github.com/travis-ci/worker/config/config.go
+++ b/src/github.com/travis-ci/worker/config/config.go
@@ -126,7 +126,7 @@ func WriteEnvConfig(cfg *Config, out io.Writer) {
 
 	sortedCfgMapKeys := []string{}
 
-	for key, _ := range cfgMap {
+	for key := range cfgMap {
 		sortedCfgMapKeys = append(sortedCfgMapKeys, key)
 	}
 

--- a/src/github.com/travis-ci/worker/config/config.go
+++ b/src/github.com/travis-ci/worker/config/config.go
@@ -10,10 +10,6 @@ import (
 	"github.com/codegangsta/cli"
 )
 
-var (
-	zeroDuration time.Duration
-)
-
 // Config contains all the configuration needed to run the worker.
 type Config struct {
 	AmqpURI        string

--- a/src/github.com/travis-ci/worker/config/config.go
+++ b/src/github.com/travis-ci/worker/config/config.go
@@ -49,6 +49,8 @@ type Config struct {
 	BuildCacheS3SecretAccessKey string
 }
 
+// ConfigFromCLIContext creates a Config using a cli.Context by pulling
+// configuration from the flags in the context.
 func ConfigFromCLIContext(c *cli.Context) *Config {
 	cfg := &Config{
 		AmqpURI:       c.String("amqp-uri"),
@@ -87,6 +89,9 @@ func ConfigFromCLIContext(c *cli.Context) *Config {
 	return cfg
 }
 
+// WriteEnvConfig writes the given configuration to out. The format of the
+// output is a list of environment variables settings suitable to be sourced
+// by a Bourne-like shell.
 func WriteEnvConfig(cfg *Config, out io.Writer) {
 	cfgMap := map[string]interface{}{
 		"amqp-uri":       cfg.AmqpURI,

--- a/src/github.com/travis-ci/worker/config/flags.go
+++ b/src/github.com/travis-ci/worker/config/flags.go
@@ -8,6 +8,7 @@ import (
 )
 
 var (
+	// Flags is the list of all CLI flags accepted by travis-worker
 	Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:   "amqp-uri",

--- a/src/github.com/travis-ci/worker/config/help.go
+++ b/src/github.com/travis-ci/worker/config/help.go
@@ -49,7 +49,7 @@ func helpPrinter(w io.Writer, templ string, data interface{}) {
 	cliHelpPrinter(w, templ, data)
 
 	providerNames := []string{}
-	for providerName, _ := range providerHelps {
+	for providerName := range providerHelps {
 		providerNames = append(providerNames, providerName)
 	}
 

--- a/src/github.com/travis-ci/worker/config/help.go
+++ b/src/github.com/travis-ci/worker/config/help.go
@@ -31,6 +31,9 @@ e.g.:
 `
 )
 
+// SetProviderHelp sets the help for a backend.Provider with the given name.
+// The help text should contain a list of all required and optional
+// configuration options.
 func SetProviderHelp(providerName, help string) {
 	providerHelpsMut.Lock()
 	defer providerHelpsMut.Unlock()

--- a/src/github.com/travis-ci/worker/config/provider_config.go
+++ b/src/github.com/travis-ci/worker/config/provider_config.go
@@ -9,16 +9,22 @@ import (
 	"sync"
 )
 
+// ProviderConfig is the part of a configuration specific to a provider.
 type ProviderConfig struct {
 	sync.Mutex
 
 	cfgMap map[string]string
 }
 
+// GoString formats the ProviderConfig as valid Go syntax. This makes
+// ProviderConfig implement fmt.GoStringer.
 func (pc *ProviderConfig) GoString() string {
 	return fmt.Sprintf("&ProviderConfig{cfgMap: %#v}", pc.cfgMap)
 }
 
+// Map loops over all configuration settings and calls the given function with
+// the key and value. The settings are sorted so f i called with the keys in
+// alphabetical order.
 func (pc *ProviderConfig) Map(f func(string, string)) {
 	keys := []string{}
 	for key, _ := range pc.cfgMap {
@@ -32,6 +38,8 @@ func (pc *ProviderConfig) Map(f func(string, string)) {
 	}
 }
 
+// Get the value of a setting with the given key. The empty string is returned
+// if the setting could not be found.
 func (pc *ProviderConfig) Get(key string) string {
 	pc.Lock()
 	defer pc.Unlock()
@@ -43,6 +51,7 @@ func (pc *ProviderConfig) Get(key string) string {
 	return ""
 }
 
+// Set the value of a setting with the given key.
 func (pc *ProviderConfig) Set(key, value string) {
 	pc.Lock()
 	defer pc.Unlock()
@@ -50,6 +59,8 @@ func (pc *ProviderConfig) Set(key, value string) {
 	pc.cfgMap[key] = value
 }
 
+// IsSet returns true if a setting with the given key exists, or false if it
+// does not.
 func (pc *ProviderConfig) IsSet(key string) bool {
 	pc.Lock()
 	defer pc.Unlock()
@@ -92,6 +103,8 @@ func ProviderConfigFromEnviron(providerName string) *ProviderConfig {
 	return pc
 }
 
+// ProviderConfigFromMap creates a provider configuration backed by the given
+// map. Useful for testing a provider.
 func ProviderConfigFromMap(cfgMap map[string]string) *ProviderConfig {
 	return &ProviderConfig{cfgMap: cfgMap}
 }

--- a/src/github.com/travis-ci/worker/config/provider_config.go
+++ b/src/github.com/travis-ci/worker/config/provider_config.go
@@ -27,7 +27,7 @@ func (pc *ProviderConfig) GoString() string {
 // alphabetical order.
 func (pc *ProviderConfig) Map(f func(string, string)) {
 	keys := []string{}
-	for key, _ := range pc.cfgMap {
+	for key := range pc.cfgMap {
 		keys = append(keys, key)
 	}
 

--- a/src/github.com/travis-ci/worker/context/package.go
+++ b/src/github.com/travis-ci/worker/context/package.go
@@ -17,51 +17,84 @@ const (
 	repositoryKey
 )
 
+// FromUUID generates a new context with the given context as its parent and
+// stores the given UUID with the context. The UUID can be retrieved again using
+// UUIDFromContext.
 func FromUUID(ctx context.Context, uuid string) context.Context {
 	return context.WithValue(ctx, uuidKey, uuid)
 }
 
+// FromProcessor generates a new context with the given context as its parent
+// and stores the given processor ID with the context. The processor ID can be
+// retrieved again using ProcessorFromContext.
 func FromProcessor(ctx context.Context, processor string) context.Context {
 	return context.WithValue(ctx, processorKey, processor)
 }
 
+// FromComponent generates a new context with the given context as its parent
+// and stores the given component name with the context. The component name can
+// be retrieved again using ComponentFromContext.
 func FromComponent(ctx context.Context, component string) context.Context {
 	return context.WithValue(ctx, componentKey, component)
 }
 
+// FromJobID generates a new context with the given context as its parent and
+// stores the given job ID with the context. The job ID can be retrieved again
+// using JobIDFromContext.
 func FromJobID(ctx context.Context, jobID uint64) context.Context {
 	return context.WithValue(ctx, jobIDKey, jobID)
 }
 
+// FromRepository generates a new context with the given context as its parent
+// and stores the given repository name with the context. The repository name
+// can be retrieved again using RepositoryFromContext.
 func FromRepository(ctx context.Context, repository string) context.Context {
 	return context.WithValue(ctx, repositoryKey, repository)
 }
 
+// UUIDFromContext returns the UUID stored in the context with FromUUID. If no
+// UUID was stored in the context, the second argument is false. Otherwise it is
+// true.
 func UUIDFromContext(ctx context.Context) (string, bool) {
 	uuid, ok := ctx.Value(uuidKey).(string)
 	return uuid, ok
 }
 
+// ProcessorFromContext returns the processor name stored in the context with
+// FromProcessor. If no processor name was stored in the context, the second
+// argument is false. Otherwise it is true.
 func ProcessorFromContext(ctx context.Context) (string, bool) {
 	processor, ok := ctx.Value(processorKey).(string)
 	return processor, ok
 }
 
+// ComponentFromContext returns the component name stored in the context with
+// FromComponent. If no component name was stored in the context, the second
+// argument is false. Otherwise it is true.
 func ComponentFromContext(ctx context.Context) (string, bool) {
 	component, ok := ctx.Value(componentKey).(string)
 	return component, ok
 }
 
+// JobIDFromContext returns the job ID stored in the context with FromJobID. If
+// no job ID was stored in the context, the second argument is false. Otherwise
+// it is true.
 func JobIDFromContext(ctx context.Context) (uint64, bool) {
 	jobID, ok := ctx.Value(jobIDKey).(uint64)
 	return jobID, ok
 }
 
+// RepositoryFromContext returns the repository name stored in the context with
+// FromRepository. If no repository name was stored in the context, the second
+// argument is false. Otherwise it is true.
 func RepositoryFromContext(ctx context.Context) (string, bool) {
 	repository, ok := ctx.Value(repositoryKey).(string)
 	return repository, ok
 }
 
+// LoggerFromContext returns a logrus.Entry with the PID of the current process
+// set as a field, and also includes every field set using the From* functions
+// this package.
 func LoggerFromContext(ctx context.Context) *logrus.Entry {
 	entry := logrus.WithField("pid", os.Getpid())
 

--- a/src/github.com/travis-ci/worker/job.go
+++ b/src/github.com/travis-ci/worker/job.go
@@ -20,21 +20,26 @@ type JobPayload struct {
 	Timeouts   TimeoutsPayload        `json:"timeouts,omitempty"`
 }
 
+// JobJobPayload contains information about the job.
 type JobJobPayload struct {
 	ID     uint64 `json:"id"`
 	Number string `json:"number"`
 }
 
+// BuildPayload contains information about the build.
 type BuildPayload struct {
 	ID     uint64 `json:"id"`
 	Number string `json:"number"`
 }
 
+// RepositoryPayload contains information about the repository.
 type RepositoryPayload struct {
 	ID   uint64 `json:"id"`
 	Slug string `json:"slug"`
 }
 
+// TimeoutsPayload contains information about any custom timeouts. The timeouts
+// are given in seconds, and a value of 0 means no custom timeout is set.
 type TimeoutsPayload struct {
 	HardLimit  uint64 `json:"hard_limit"`
 	LogSilence uint64 `json:"log_silence"`
@@ -68,6 +73,10 @@ type Job interface {
 	LogWriter(context.Context) (LogWriter, error)
 }
 
+// A LogWriter is primarily an io.Writer that will send all bytes to travis-logs
+// for processing, and also has some utility methods for timeouts and log length
+// limiting. Each LogWriter is tied to a given job, and can be gotten by calling
+// the LogWriter() method on a Job.
 type LogWriter interface {
 	io.WriteCloser
 	WriteAndClose([]byte) (int, error)

--- a/src/github.com/travis-ci/worker/log_writer.go
+++ b/src/github.com/travis-ci/worker/log_writer.go
@@ -14,6 +14,8 @@ import (
 )
 
 var (
+	// LogWriterTick is how often the buffer should be flushed out and sent to
+	// travis-logs.
 	LogWriterTick = 500 * time.Millisecond
 
 	// LogChunkSize is a bit of a magic number, calculated like this: The
@@ -67,6 +69,8 @@ type logPart struct {
 	Final   bool   `json:"final"`
 }
 
+// NewLogWriter creates a new AMQP-backed log writer for the given job ID. An
+// error can be returned if there was an error declaring the right AMQP queues.
 func NewLogWriter(ctx gocontext.Context, conn *amqp.Connection, jobID uint64) (LogWriter, error) {
 	channel, err := conn.Channel()
 	if err != nil {

--- a/src/github.com/travis-ci/worker/processor_pool.go
+++ b/src/github.com/travis-ci/worker/processor_pool.go
@@ -30,6 +30,7 @@ type ProcessorPool struct {
 	processors     []*Processor
 }
 
+// NewProcessorPool creates a new processor pool using the given arguments.
 func NewProcessorPool(hostname string, ctx gocontext.Context, hardTimeout time.Duration,
 	logTimeout time.Duration, amqpConn *amqp.Connection, provider backend.Provider,
 	generator BuildScriptGenerator, canceller Canceller) *ProcessorPool {
@@ -46,6 +47,9 @@ func NewProcessorPool(hostname string, ctx gocontext.Context, hardTimeout time.D
 	}
 }
 
+// Each loops through all the processors in the pool and calls the given
+// function for each of them, passing in the index and the processor. The order
+// of the processors is the same for the same set of processors.
 func (p *ProcessorPool) Each(f func(int, *Processor)) {
 	procIDs := []string{}
 	procsByID := map[string]*Processor{}


### PR DESCRIPTION
Nothing in this pull request should change any behavior.

The largest change is probably the change in the `backend` package of making all implementations of `backend.Provider` and `backend.Instance` unexported. I did this as I found myself documenting all of the functions on these types as just `Start implements Provider.Start`, or something similar, and realised that the types don't really need to be exported at all, so they probably shouldn't.

My linter still reports some issues, but they are all either "cyclomatic complexity" issues, "duplicated code" issues or "error unchecked issues", all of which could only really be fixed by changing behavior, and not all of them _should_ be fixed, so I'm leaving that for another time.

(Also, this means that every exported type and function now has a documentation comment)