### PR TITLE
metrics: add Memstats runtime metrics

### DIFF
--- a/src/github.com/travis-ci/worker/cmd/travis-worker/main.go
+++ b/src/github.com/travis-ci/worker/cmd/travis-worker/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/travis-ci/worker/backend"
 	"github.com/travis-ci/worker/config"
 	"github.com/travis-ci/worker/context"
+	travismetrics "github.com/travis-ci/worker/metrics"
 	gocontext "golang.org/x/net/context"
 )
 
@@ -81,7 +82,7 @@ func runWorker(c *cli.Context) {
 	defer logger.Info("worker finished")
 
 	setupSentry(logger, cfg)
-	setupLibrato(logger, cfg, c)
+	setupMetrics(logger, cfg, c)
 
 	amqpConn, err := amqp.Dial(cfg.AmqpURI)
 	if err != nil {
@@ -147,7 +148,8 @@ func setupSentry(logger *logrus.Entry, cfg *config.Config) {
 	}
 }
 
-func setupLibrato(logger *logrus.Entry, cfg *config.Config, c *cli.Context) {
+func setupMetrics(logger *logrus.Entry, cfg *config.Config, c *cli.Context) {
+	go travismetrics.ReportMemstatsMetrics()
 	if cfg.LibratoEmail != "" && cfg.LibratoToken != "" && cfg.LibratoSource != "" {
 		logger.Info("starting librato metrics reporter")
 		go librato.Librato(metrics.DefaultRegistry, time.Minute, cfg.LibratoEmail, cfg.LibratoToken, cfg.LibratoSource, []float64{0.95}, time.Millisecond)

--- a/src/github.com/travis-ci/worker/metrics/memstats.go
+++ b/src/github.com/travis-ci/worker/metrics/memstats.go
@@ -1,0 +1,63 @@
+package metrics
+
+import (
+	"runtime"
+	"time"
+
+	"github.com/rcrowley/go-metrics"
+)
+
+// ReportMemstatsMetrics will send runtime Memstats metrics every 10 seconds,
+// and will block forever.
+func ReportMemstatsMetrics() {
+	memStats := &runtime.MemStats{}
+	lastSampleTime := time.Now()
+	var lastPauseNs uint64
+	var lastNumGC uint64
+
+	sleep := 10 * time.Second
+
+	for {
+		runtime.ReadMemStats(memStats)
+
+		now := time.Now()
+
+		metrics.GetOrRegisterGauge("travis.worker.goroutines", metrics.DefaultRegistry).Update(int64(runtime.NumGoroutine()))
+		metrics.GetOrRegisterGauge("travis.worker.memory.allocated", metrics.DefaultRegistry).Update(int64(memStats.Alloc))
+		metrics.GetOrRegisterGauge("travis.worker.memory.mallocs", metrics.DefaultRegistry).Update(int64(memStats.Mallocs))
+		metrics.GetOrRegisterGauge("travis.worker.memory.frees", metrics.DefaultRegistry).Update(int64(memStats.Frees))
+		metrics.GetOrRegisterGauge("travis.worker.memory.gc.total_pause", metrics.DefaultRegistry).Update(int64(memStats.PauseTotalNs))
+		metrics.GetOrRegisterGauge("travis.worker.memory.gc.heap", metrics.DefaultRegistry).Update(int64(memStats.HeapAlloc))
+		metrics.GetOrRegisterGauge("travis.worker.memory.gc.stack", metrics.DefaultRegistry).Update(int64(memStats.StackInuse))
+
+		if lastPauseNs > 0 {
+			pauseSinceLastSample := memStats.PauseTotalNs - lastPauseNs
+			metrics.GetOrRegisterGauge("travis.worker.memory.gc.pause_per_second", metrics.DefaultRegistry).Update(int64(float64(pauseSinceLastSample) / sleep.Seconds()))
+		}
+		lastPauseNs = memStats.PauseTotalNs
+
+		countGC := int(uint64(memStats.NumGC) - lastNumGC)
+		if lastNumGC > 0 {
+			diff := float64(countGC)
+			diffTime := now.Sub(lastSampleTime).Seconds()
+			metrics.GetOrRegisterGauge("travis.worker.memory.gc.gc_per_second", metrics.DefaultRegistry).Update(int64(diff / diffTime))
+		}
+
+		if countGC > 0 {
+			if countGC > 256 {
+				countGC = 256
+			}
+
+			for i := 0; i < countGC; i++ {
+				idx := int((memStats.NumGC-uint32(i))+255) % 256
+				pause := time.Duration(memStats.PauseNs[idx])
+				metrics.GetOrRegisterTimer("travis.worker.memory.gc.pause", metrics.DefaultRegistry).Update(pause)
+			}
+		}
+
+		lastNumGC = uint64(memStats.NumGC)
+		lastSampleTime = now
+
+		time.Sleep(sleep)
+	}
+}


### PR DESCRIPTION
This includes metrics on things like GC pause times. The metric calculation comes from http://pythonic.zoomquiet.io/data/20131112090955/index.html, but I'm not 100% sure I got everything translated correctly.