### PR TITLE
config: use hostname as default value for librato source

### DIFF
--- a/src/github.com/travis-ci/worker/config/flags.go
+++ b/src/github.com/travis-ci/worker/config/flags.go
@@ -50,6 +50,7 @@ var (
 		},
 		cli.StringFlag{
 			Name:   "librato-source",
+			Value:  defaultHostname,
 			Usage:  "Librato metrics source name",
 			EnvVar: twEnvVars("LIBRATO_SOURCE"),
 		},


### PR DESCRIPTION
This makes it easier to set up Librato in places where it's hard to set per-host settings (such as with our current Chef recipe).