### PR TITLE
log-writer: lock the mutex as little as possible

### DIFF
--- a/src/github.com/travis-ci/worker/log_writer.go
+++ b/src/github.com/travis-ci/worker/log_writer.go
@@ -229,9 +229,6 @@ func (w *amqpLogWriter) flushRegularly() {
 }
 
 func (w *amqpLogWriter) flush() {
-	w.bufferMutex.Lock()
-	defer w.bufferMutex.Unlock()
-
 	if w.buffer.Len() <= 0 {
 		return
 	}
@@ -239,7 +236,9 @@ func (w *amqpLogWriter) flush() {
 	buf := make([]byte, LogChunkSize)
 
 	for w.buffer.Len() > 0 {
+		w.bufferMutex.Lock()
 		n, err := w.buffer.Read(buf)
+		w.bufferMutex.Unlock()
 		if err != nil {
 			// According to documentation, err should only be non-nil if
 			// there's no data in the buffer. We've checked for this, so


### PR DESCRIPTION
We've been seeing an issue where it seems like the output from the logs of a job suddenly stop, and eventually triggers the log timeout. This has happened on several platforms, including multiple OS-es (both Linux and OS X), which leads me to believe the issue is in the worker.

While running some tests that sent a lot of output to the log writer, I noticed that it was possible to get it into a locked state where the flushing would take a long time and therefore Write() would stall on attempting to lock the mutex. This change fixes that so even with a very fast writer, nothing would lock (until you hit the maximum log limit).

While I'm not positive that this will fix the issue we're seeing, it does seem like a good idea to keep the mutex locked for as little time as possible.