### PR TITLE
processor: check if we're shutting down before picking up job

### DIFF
--- a/src/github.com/travis-ci/worker/processor.go
+++ b/src/github.com/travis-ci/worker/processor.go
@@ -77,6 +77,16 @@ func (p *Processor) Run() {
 		case <-p.graceful:
 			context.LoggerFromContext(p.ctx).Info("processor is done, terminating")
 			return
+		default:
+		}
+
+		select {
+		case <-p.ctx.Done():
+			context.LoggerFromContext(p.ctx).Info("processor is done, terminating")
+			return
+		case <-p.graceful:
+			context.LoggerFromContext(p.ctx).Info("processor is done, terminating")
+			return
 		case buildJob, ok := <-p.buildJobsChan:
 			if !ok {
 				return


### PR DESCRIPTION
If more than one case branch in a select statement can proceed, one is picked at random, which I think is the cause for graceful and forceful shutdown not to work a lot of times.