### PR TITLE
gce: remove the language tag on instances

### DIFF
--- a/src/github.com/travis-ci/worker/backend/gce.go
+++ b/src/github.com/travis-ci/worker/backend/gce.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -65,7 +64,6 @@ cat > ~travis/.ssh/authorized_keys <<EOF
 {{ .SSHPubKey }}
 EOF
 `))
-	gceIllegalTagChars = regexp.MustCompile(`[^-a-z0-9]`)
 )
 
 func init() {

--- a/src/github.com/travis-ci/worker/backend/gce.go
+++ b/src/github.com/travis-ci/worker/backend/gce.go
@@ -415,7 +415,6 @@ func (p *gceProvider) Start(ctx gocontext.Context, startAttributes *StartAttribu
 		Tags: &compute.Tags{
 			Items: []string{
 				"testing",
-				string(gceIllegalTagChars.ReplaceAll([]byte(startAttributes.Language), []byte("-"))),
 			},
 		},
 	}


### PR DESCRIPTION
The language tag is invalid for some languages (such as "c++"), since a tag can't end with a -. Instead of somehow changing the tags to be valid, I removed the language tag, since I'm not sure why it's useful.