### PR TITLE
processor: assign the right UUID to the processor field in logs

### DIFF
--- a/src/github.com/travis-ci/worker/processor.go
+++ b/src/github.com/travis-ci/worker/processor.go
@@ -40,7 +40,7 @@ func NewProcessor(ctx gocontext.Context, hostname string, buildJobsChan <-chan J
 	provider backend.Provider, generator BuildScriptGenerator, canceller Canceller,
 	hardTimeout time.Duration, logTimeout time.Duration) (*Processor, error) {
 
-	uuidString, _ := context.UUIDFromContext(ctx)
+	uuidString, _ := context.ProcessorFromContext(ctx)
 	processorUUID := uuid.Parse(uuidString)
 
 	ctx, cancel := gocontext.WithCancel(ctx)
@@ -51,7 +51,7 @@ func NewProcessor(ctx gocontext.Context, hostname string, buildJobsChan <-chan J
 		hardTimeout: hardTimeout,
 		logTimeout:  logTimeout,
 
-		ctx:           context.FromProcessor(ctx, processorUUID.String()),
+		ctx:           ctx,
 		buildJobsChan: buildJobsChan,
 		provider:      provider,
 		generator:     generator,


### PR DESCRIPTION
Previously we pulled the _job_ UUID out of the context (it's an empty string) and set that as the processor UUID, blanking out the UUID from the ProcessorPool.