### PR TITLE
Fix graceful shutdown, mark π

### DIFF
--- a/src/github.com/travis-ci/worker/processor.go
+++ b/src/github.com/travis-ci/worker/processor.go
@@ -119,7 +119,7 @@ func (p *Processor) GracefulShutdown() {
 		}
 	}()
 	context.LoggerFromContext(p.ctx).Info("processor initiating graceful shutdown")
-	p.graceful <- struct{}{}
+	tryClose(p.graceful)
 }
 
 // Terminate tells the processor to stop working on the current job as soon as


### PR DESCRIPTION
The `graceful` channel isn't buffered, so sending to it will block until
the processor is shut down. Calling `GracefulShutdown()` again will block
forever. Closing the channel will return immediately.

This should fix the issue with graceful shutdowns, since the processor pool waits for `GracefulShutdown()` to return before moving on to the next processor.