### PR TITLE
jupiterbrain: don't panic if an error is returned on Stop

### DIFF
--- a/src/github.com/travis-ci/worker/backend/jupiterbrain.go
+++ b/src/github.com/travis-ci/worker/backend/jupiterbrain.go
@@ -440,9 +440,12 @@ func (i *jupiterBrainInstance) Stop(ctx context.Context) error {
 	}
 
 	resp, err := i.provider.httpDo(req)
-	io.Copy(ioutil.Discard, resp.Body)
+	if err != nil {
+		return err
+	}
+
 	resp.Body.Close()
-	return err
+	return nil
 }
 
 func (i *jupiterBrainInstance) ID() string {


### PR DESCRIPTION
I noticed a panic due to `resp` being `nil` and `resp.Body` then throwing a "nil pointer error".