### PR TITLE
Attempt to fix cutoff logs

### DIFF
--- a/src/github.com/travis-ci/worker/backend/jupiterbrain.go
+++ b/src/github.com/travis-ci/worker/backend/jupiterbrain.go
@@ -423,18 +423,7 @@ func (i *jupiterBrainInstance) RunScript(ctx context.Context, output io.Writer) 
 		return &RunResult{Completed: false}, err
 	}
 
-	stdoutErrChan := make(chan error, 1)
-	stderrErrChan := make(chan error, 1)
-
-	go func() {
-		_, err := io.Copy(output, stdoutPipe)
-		stdoutErrChan <- err
-	}()
-
-	go func() {
-		_, err := io.Copy(output, stderrPipe)
-		stderrErrChan <- err
-	}()
+	session.Stdout = output
 
 	errChan := make(chan error, 1)
 
@@ -446,8 +435,6 @@ func (i *jupiterBrainInstance) RunScript(ctx context.Context, output io.Writer) 
 	case <-ctx.Done():
 		return &RunResult{Completed: false}, ctx.Err()
 	case err = <-errChan:
-		<-stdoutErrChan
-		<-stderrErrChan
 	}
 
 	if err == nil {

--- a/src/github.com/travis-ci/worker/backend/jupiterbrain.go
+++ b/src/github.com/travis-ci/worker/backend/jupiterbrain.go
@@ -401,8 +401,18 @@ func (i *jupiterBrainInstance) RunScript(ctx context.Context, output io.Writer) 
 		return &RunResult{Completed: false}, err
 	}
 
-	session.Stdout = output
-	session.Stderr = output
+	stdoutPipe, err := session.StdoutPipe()
+	if err != nil {
+		return &RunResult{Completed: false}, err
+	}
+
+	stderrPipe, err := session.StderrPipe()
+	if err != nil {
+		return &RunResult{Completed: false}, err
+	}
+
+	go io.Copy(output, stdoutPipe)
+	go io.Copy(output, stderrPipe)
 
 	errChan := make(chan error, 1)
 

--- a/src/github.com/travis-ci/worker/backend/jupiterbrain.go
+++ b/src/github.com/travis-ci/worker/backend/jupiterbrain.go
@@ -404,7 +404,7 @@ func (i *jupiterBrainInstance) RunScript(ctx context.Context, output io.Writer) 
 	session.Stdout = output
 	session.Stderr = output
 
-	errChan := make(chan error)
+	errChan := make(chan error, 1)
 
 	go func() {
 		errChan <- session.Run("bash ~/wrapper.sh")

--- a/src/github.com/travis-ci/worker/backend/jupiterbrain.go
+++ b/src/github.com/travis-ci/worker/backend/jupiterbrain.go
@@ -413,16 +413,6 @@ func (i *jupiterBrainInstance) RunScript(ctx context.Context, output io.Writer) 
 		return &RunResult{Completed: false}, err
 	}
 
-	stdoutPipe, err := session.StdoutPipe()
-	if err != nil {
-		return &RunResult{Completed: false}, err
-	}
-
-	stderrPipe, err := session.StderrPipe()
-	if err != nil {
-		return &RunResult{Completed: false}, err
-	}
-
 	session.Stdout = output
 
 	errChan := make(chan error, 1)


### PR DESCRIPTION
Included are a few changes to the Jupiter Brain log writer setup to attempt to fix the issue where the end of the logs aren't being sent to travis-logs. I'm not 100% confident that this will fix it, since these bugs would be in the GCE backend too, but the bug doesn't seem to be there from what I can see.