### PR TITLE
Don't send zero timestamps in "finished" event to hub

### DIFF
--- a/amqp_job.go
+++ b/amqp_job.go
@@ -87,11 +87,21 @@ func (j *amqpJob) Started() error {
 }
 
 func (j *amqpJob) Finish(state FinishState) error {
+	finishedAt := time.Now()
+	receivedAt := j.received
+	if receivedAt.IsZero() {
+		receivedAt = finishedAt
+	}
+	startedAt := j.started
+	if startedAt.IsZero() {
+		startedAt = finishedAt
+	}
+
 	err := j.sendStateUpdate("job:test:finish", map[string]interface{}{
 		"id":          j.Payload().Job.ID,
 		"state":       state,
-		"received_at": j.received.UTC().Format(time.RFC3339),
-		"started_at":  j.started.UTC().Format(time.RFC3339),
+		"received_at": receivedAt.UTC().Format(time.RFC3339),
+		"started_at":  startedAt.UTC().Format(time.RFC3339),
 		"finished_at": time.Now().UTC().Format(time.RFC3339),
 	})
 	if err != nil {

--- a/amqp_job.go
+++ b/amqp_job.go
@@ -102,7 +102,7 @@ func (j *amqpJob) Finish(state FinishState) error {
 		"state":       state,
 		"received_at": receivedAt.UTC().Format(time.RFC3339),
 		"started_at":  startedAt.UTC().Format(time.RFC3339),
-		"finished_at": time.Now().UTC().Format(time.RFC3339),
+		"finished_at": finishedAt.UTC().Format(time.RFC3339),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
The finish event can be sent without the received or started event having been sent if something errors in between. In that case, we would send 0001-01-01T00:00:00Z for received_at and/or started_at, causing hub to think the job had ran for roughly 2015 years.