### PR TITLE
image: ignore language for osx_image queries

### DIFF
--- a/image/api_selector.go
+++ b/image/api_selector.go
@@ -173,8 +173,8 @@ func (as *APISelector) buildCandidateTags(params *Params) []*tagSet {
 
 	hasLang := params.Language != ""
 
-	if params.OS == "osx" && params.OsxImage != "" && hasLang {
-		addTags("osx_image:"+params.OsxImage, "language_"+params.Language+":true")
+	if params.OS == "osx" && params.OsxImage != "" {
+		addTags("osx_image:"+params.OsxImage, "os:osx")
 	}
 
 	if params.Dist != "" && params.Group != "" && hasLang {

--- a/image/api_selector_test.go
+++ b/image/api_selector_test.go
@@ -57,7 +57,7 @@ var (
 					Repo:     "corp/frob",
 				},
 				{
-					Infra:    "macstadium6",
+					Infra:    "jupiterbrain",
 					Language: "python",
 					OS:       "osx",
 					OsxImage: "xcode7",
@@ -65,7 +65,7 @@ var (
 					Repo:     "corp/frob",
 				},
 				{
-					Infra:    "macstadium6",
+					Infra:    "jupiterbrain",
 					Language: "objective-c",
 					OS:       "osx",
 					OsxImage: "xcode6.4",
@@ -73,7 +73,7 @@ var (
 					Repo:     "corp/frob",
 				},
 				{
-					Infra:    "macstadium6",
+					Infra:    "jupiterbrain",
 					Language: "node_js",
 					OsxImage: "xcode6.1",
 					Dist:     "yosammity",
@@ -111,7 +111,7 @@ var (
 				},
 				{
 					&tagSet{[]string{"language_python:true", "os:osx", "osx_image:xcode7"}, false, uint64(4), "corp/frob"},
-					&tagSet{[]string{"language_python:true", "osx_image:xcode7"}, false, uint64(4), "corp/frob"},
+					&tagSet{[]string{"os:osx", "osx_image:xcode7"}, false, uint64(4), "corp/frob"},
 					&tagSet{[]string{"language_python:true", "os:osx"}, false, uint64(4), "corp/frob"},
 					&tagSet{[]string{"language_python:true"}, true, uint64(4), "corp/frob"},
 					&tagSet{[]string{"osx_image:xcode7"}, true, uint64(4), "corp/frob"},
@@ -119,7 +119,7 @@ var (
 				},
 				{
 					&tagSet{[]string{"language_objective-c:true", "os:osx", "osx_image:xcode6.4"}, false, uint64(4), "corp/frob"},
-					&tagSet{[]string{"language_objective-c:true", "osx_image:xcode6.4"}, false, uint64(4), "corp/frob"},
+					&tagSet{[]string{"os:osx", "osx_image:xcode6.4"}, false, uint64(4), "corp/frob"},
 					&tagSet{[]string{"language_objective-c:true", "os:osx"}, false, uint64(4), "corp/frob"},
 					&tagSet{[]string{"language_objective-c:true"}, true, uint64(4), "corp/frob"},
 					&tagSet{[]string{"osx_image:xcode6.4"}, true, uint64(4), "corp/frob"},
@@ -127,7 +127,7 @@ var (
 				},
 				{
 					&tagSet{[]string{"dist:yosammity", "group:fancy", "language_node_js:true", "os:osx", "osx_image:xcode6.1"}, false, uint64(4), "corp/frob"},
-					&tagSet{[]string{"language_node_js:true", "osx_image:xcode6.1"}, false, uint64(4), "corp/frob"},
+					&tagSet{[]string{"os:osx", "osx_image:xcode6.1"}, false, uint64(4), "corp/frob"},
 					&tagSet{[]string{"dist:yosammity", "group:fancy", "language_node_js:true"}, false, uint64(4), "corp/frob"},
 					&tagSet{[]string{"dist:yosammity", "language_node_js:true"}, false, uint64(4), "corp/frob"},
 					&tagSet{[]string{"group:fancy", "language_node_js:true"}, false, uint64(4), "corp/frob"},


### PR DESCRIPTION
We're not doing any kind of separation by language for OS X images, so having to list every language can be error-prone due to missing things. Instead, let's just filter by os:osx, which gets us what we need today.