### PR TITLE
gce: add support for a premium instance type

### DIFF
--- a/amqp_job_queue.go
+++ b/amqp_job_queue.go
@@ -105,7 +105,8 @@ func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 			}
 
 			buildJob.startAttributes = startAttrs.Config
-			buildJob.startAttributes.SetDefaults(q.DefaultLanguage, q.DefaultDist, q.DefaultGroup, q.DefaultOS)
+			buildJob.startAttributes.VMType = buildJob.payload.VMType
+			buildJob.startAttributes.SetDefaults(q.DefaultLanguage, q.DefaultDist, q.DefaultGroup, q.DefaultOS, VMTypeDefault)
 			buildJob.conn = q.conn
 			buildJob.delivery = delivery
 

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -57,7 +57,7 @@ var (
 		"SSH_KEY_PATH":          "[REQUIRED] path to ssh key used to access job vms",
 		"SSH_PUB_KEY_PATH":      "[REQUIRED] path to ssh public key used to access job vms",
 		"SSH_KEY_PASSPHRASE":    "[REQUIRED] passphrase for ssh key given as ssh_key_path",
-		"IMAGE_SELECTOR_TYPE":   fmt.Sprintf("image selector type (\"legacy\", \"env\" or \"api\", default %q)", defaultGCEImageSelectorType),
+		"IMAGE_SELECTOR_TYPE":   fmt.Sprintf("image selector type (\"env\" or \"api\", default %q)", defaultGCEImageSelectorType),
 		"IMAGE_SELECTOR_URL":    "URL for image selector API, used only when image selector is \"api\"",
 		"ZONE":                  fmt.Sprintf("zone name (default %q)", defaultGCEZone),
 		"MACHINE_TYPE":          fmt.Sprintf("machine name (default %q)", defaultGCEMachineType),

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -35,6 +35,7 @@ import (
 const (
 	defaultGCEZone               = "us-central1-a"
 	defaultGCEMachineType        = "n1-standard-2"
+	defaultGCEPremiumMachineType = "n1-standard-4"
 	defaultGCENetwork            = "default"
 	defaultGCEDiskSize           = int64(20)
 	defaultGCELanguage           = "minimal"
@@ -59,6 +60,7 @@ var (
 		"IMAGE_SELECTOR_URL":      "URL for image selector API, used only when image selector is \"api\"",
 		"ZONE":                    fmt.Sprintf("zone name (default %q)", defaultGCEZone),
 		"MACHINE_TYPE":            fmt.Sprintf("machine name (default %q)", defaultGCEMachineType),
+		"PREMIUM_MACHINE_TYPE":    fmt.Sprintf("premium machine type (default %q)", defaultGCEPremiumMachineType),
 		"NETWORK":                 fmt.Sprintf("machine name (default %q)", defaultGCENetwork),
 		"DISK_SIZE":               fmt.Sprintf("disk size in GB (default %v)", defaultGCEDiskSize),
 		"LANGUAGE_MAP_{LANGUAGE}": "Map the key specified in the key to the image associated with a different language, used only when image selector type is \"legacy\"",
@@ -129,6 +131,7 @@ type gceProvider struct {
 
 type gceInstanceConfig struct {
 	MachineType        *compute.MachineType
+	PremiumMachineType *compute.MachineType
 	Zone               *compute.Zone
 	Network            *compute.Network
 	DiskType           string
@@ -225,6 +228,13 @@ func newGCEProvider(cfg *config.ProviderConfig) (Provider, error) {
 	}
 
 	cfg.Set("MACHINE_TYPE", mtName)
+
+	premiumMTName := defaultGCEPremiumMachineType
+	if cfg.IsSet("PREMIUM_MACHINE_TYPE") {
+		premiumMTName = cfg.Get("PREMIUM_MACHINE_TYPE")
+	}
+
+	cfg.Set("PREMIUM_MACHINE_TYPE", premiumMTName)
 
 	nwName := defaultGCENetwork
 	if cfg.IsSet("NETWORK") {
@@ -356,6 +366,11 @@ func (p *gceProvider) Setup() error {
 	p.ic.DiskType = fmt.Sprintf("zones/%s/diskTypes/pd-ssd", p.ic.Zone.Name)
 
 	p.ic.MachineType, err = p.client.MachineTypes.Get(p.projectID, p.ic.Zone.Name, p.cfg.Get("MACHINE_TYPE")).Do()
+	if err != nil {
+		return err
+	}
+
+	p.ic.PremiumMachineType, err = p.client.MachineTypes.Get(p.projectID, p.ic.Zone.Name, p.cfg.Get("PREMIUM_MACHINE_TYPE")).Do()
 	if err != nil {
 		return err
 	}
@@ -662,6 +677,14 @@ func buildGCEImageSelector(selectorType string, cfg *config.ProviderConfig) (ima
 }
 
 func (p *gceProvider) buildInstance(startAttributes *StartAttributes, imageLink, startupScript string) *compute.Instance {
+	var machineType *compute.MachineType
+	switch startAttributes.VMType {
+	case "premium":
+		machineType = p.ic.PremiumMachineType
+	default:
+		machineType = p.ic.MachineType
+	}
+
 	return &compute.Instance{
 		Description: fmt.Sprintf("Travis CI %s test VM", startAttributes.Language),
 		Disks: []*compute.AttachedDisk{
@@ -680,7 +703,7 @@ func (p *gceProvider) buildInstance(startAttributes *StartAttributes, imageLink,
 		Scheduling: &compute.Scheduling{
 			Preemptible: true,
 		},
-		MachineType: p.ic.MachineType.SelfLink,
+		MachineType: machineType.SelfLink,
 		Name:        fmt.Sprintf("testing-gce-%s", uuid.NewRandom()),
 		Metadata: &compute.Metadata{
 			Items: []*compute.MetadataItems{

--- a/backend/start_attributes.go
+++ b/backend/start_attributes.go
@@ -8,10 +8,14 @@ type StartAttributes struct {
 	Dist     string `json:"dist"`
 	Group    string `json:"group"`
 	OS       string `json:"os"`
+
+	// The VMType isn't stored in the config directly, but in the top level of
+	// the job payload, see the worker.JobPayload struct.
+	VMType string `json:"-"`
 }
 
 // SetDefaults sets any missing required attributes to the default values provided
-func (sa *StartAttributes) SetDefaults(lang, dist, group, os string) {
+func (sa *StartAttributes) SetDefaults(lang, dist, group, os, vmType string) {
 	if sa.Language == "" {
 		sa.Language = lang
 	}
@@ -26,5 +30,9 @@ func (sa *StartAttributes) SetDefaults(lang, dist, group, os string) {
 
 	if sa.OS == "" {
 		sa.OS = os
+	}
+
+	if sa.VMType == "" {
+		sa.VMType = vmType
 	}
 }

--- a/backend/start_attributes_test.go
+++ b/backend/start_attributes_test.go
@@ -19,14 +19,16 @@ var (
 				{Language: "python", Dist: "trusty", Group: "edge"},
 				{Language: "python", Dist: "frob", Group: "edge", OS: "flob"},
 				{Language: "python", Dist: "frob", OsxImage: "", Group: "edge", OS: "flob"},
+				{Language: "python", Dist: "frob", OsxImage: "", Group: "edge", OS: "flob", VMType: "premium"},
 			},
 			O: []*StartAttributes{
-				{Language: "default", Dist: "precise", Group: "stable", OS: "linux"},
-				{Language: "ruby", Dist: "precise", Group: "stable", OS: "linux"},
-				{Language: "python", Dist: "trusty", Group: "stable", OS: "linux"},
-				{Language: "python", Dist: "trusty", Group: "edge", OS: "linux"},
-				{Language: "python", Dist: "frob", Group: "edge", OS: "flob"},
-				{Language: "python", Dist: "frob", OsxImage: "", Group: "edge", OS: "flob"},
+				{Language: "default", Dist: "precise", Group: "stable", OS: "linux", VMType: "default"},
+				{Language: "ruby", Dist: "precise", Group: "stable", OS: "linux", VMType: "default"},
+				{Language: "python", Dist: "trusty", Group: "stable", OS: "linux", VMType: "default"},
+				{Language: "python", Dist: "trusty", Group: "edge", OS: "linux", VMType: "default"},
+				{Language: "python", Dist: "frob", Group: "edge", OS: "flob", VMType: "default"},
+				{Language: "python", Dist: "frob", OsxImage: "", Group: "edge", OS: "flob", VMType: "default"},
+				{Language: "python", Dist: "frob", OsxImage: "", Group: "edge", OS: "flob", VMType: "premium"},
 			},
 		},
 	}
@@ -39,13 +41,14 @@ func TestStartAttributes(t *testing.T) {
 	assert.Equal(t, "", sa.Language)
 	assert.Equal(t, "", sa.OS)
 	assert.Equal(t, "", sa.OsxImage)
+	assert.Equal(t, "", sa.VMType)
 }
 
 func TestStartAttributes_SetDefaults(t *testing.T) {
 	for _, tc := range testStartAttributesTestCases {
 		for i, sa := range tc.A {
 			expected := tc.O[i]
-			sa.SetDefaults("default", "precise", "stable", "linux")
+			sa.SetDefaults("default", "precise", "stable", "linux", "default")
 			assert.Equal(t, expected, sa)
 		}
 	}

--- a/file_job_queue.go
+++ b/file_job_queue.go
@@ -139,7 +139,8 @@ func (f *FileJobQueue) pollInDirTick(ctx gocontext.Context) {
 		}
 
 		buildJob.startAttributes = startAttrs.Config
-		buildJob.startAttributes.SetDefaults(f.DefaultLanguage, f.DefaultDist, f.DefaultGroup, f.DefaultOS)
+		buildJob.startAttributes.VMType = buildJob.payload.VMType
+		buildJob.startAttributes.SetDefaults(f.DefaultLanguage, f.DefaultDist, f.DefaultGroup, f.DefaultOS, VMTypeDefault)
 		buildJob.receivedFile = filepath.Join(f.receivedDir, entry.Name())
 		buildJob.startedFile = filepath.Join(f.startedDir, entry.Name())
 		buildJob.finishedFile = filepath.Join(f.finishedDir, entry.Name())

--- a/job.go
+++ b/job.go
@@ -6,6 +6,11 @@ import (
 	gocontext "golang.org/x/net/context"
 )
 
+const (
+	VMTypeDefault = "default"
+	VMTypePremium = "premium"
+)
+
 type jobPayloadStartAttrs struct {
 	Config *backend.StartAttributes `json:"config"`
 }
@@ -19,6 +24,7 @@ type JobPayload struct {
 	UUID       string                 `json:"uuid"`
 	Config     map[string]interface{} `json:"config"`
 	Timeouts   TimeoutsPayload        `json:"timeouts,omitempty"`
+	VMType     string                 `json:"vm_type"`
 }
 
 // JobJobPayload contains information about the job.


### PR DESCRIPTION
With this, the `vm_type` field on the payload we get from AMQP can be set to `premium` to get an `n1-standard-4` instead of `n1-standard-2`.