### PR TITLE
docker: pass resource limitations in HostConfig

### DIFF
--- a/backend/docker.go
+++ b/backend/docker.go
@@ -149,10 +149,12 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 
 	dockerHostConfig := &docker.HostConfig{
 		Privileged: p.runPrivileged,
+		Memory:     int64(p.runMemory),
 	}
 
 	if cpuSets != "" {
 		dockerConfig.CPUSet = cpuSets
+		dockerHostConfig.CPUSet = cpuSets
 	}
 
 	logger.WithFields(logrus.Fields{


### PR DESCRIPTION
While not documented anywhere, in Docker 1.6.0 the resource limits were
moved to HostConfig instead of Config.

BREAKING CHANGES:

  - Drops support for Docker versions before 1.6.0 (1.6.0+ is supported) (maybe?)