### PR TITLE
gce: Add rate limiting

### DIFF
--- a/amqp_job.go
+++ b/amqp_job.go
@@ -78,6 +78,9 @@ func (j *amqpJob) Received() error {
 
 func (j *amqpJob) Started() error {
 	j.started = time.Now()
+
+	metrics.TimeSince("travis.worker.job.start_time", j.received)
+
 	return j.sendStateUpdate("job:test:start", map[string]interface{}{
 		"id":          j.Payload().Job.ID,
 		"state":       "started",

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -447,10 +447,10 @@ func newGCEProvider(cfg *config.ProviderConfig) (Provider, error) {
 
 func (p *gceProvider) apiRateLimit() {
 	atomic.AddUint64(&p.rateLimitQueueDepth, 1)
-	metrics.Gauge("worker.vm.provider.gce.rate-limit.queue", int64(p.rateLimitQueueDepth))
+	metrics.Gauge("travis.worker.vm.provider.gce.rate-limit.queue", int64(p.rateLimitQueueDepth))
 	startWait := time.Now()
 	<-p.rateLimiter.C
-	metrics.TimeSince("worker.vm.provider.gce.rate-limit", startWait)
+	metrics.TimeSince("travis.worker.vm.provider.gce.rate-limit", startWait)
 	// This decrements the counter, see the docs for atomic.AddUint64
 	atomic.AddUint64(&p.rateLimitQueueDepth, ^uint64(0))
 }

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -49,7 +49,7 @@ const (
 	defaultGCEHardTimeoutMinutes = int64(130)
 	defaultGCEImageSelectorType  = "env"
 	defaultGCEImage              = "travis-ci-mega.+"
-	defaultGCERateLimitTick      = 5 * time.Second
+	defaultGCERateLimitTick      = 1 * time.Second
 	gceImageTravisCIPrefixFilter = "name eq ^travis-ci-%s.+"
 )
 

--- a/metrics/package.go
+++ b/metrics/package.go
@@ -21,3 +21,8 @@ func TimeSince(name string, since time.Time) {
 func TimeDuration(name string, duration time.Duration) {
 	metrics.GetOrRegisterTimer(name, metrics.DefaultRegistry).Update(duration)
 }
+
+// Gauge sets a gauge metric to a given value
+func Gauge(name string, value int64) {
+	metrics.GetOrRegisterGauge(name, metrics.DefaultRegistry).Update(value)
+}


### PR DESCRIPTION
This rate limiter makes sure that we self-throttle on the number of API calls we make to the GCE API.