### PR TITLE
Metrics update

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -200,7 +200,7 @@ func (i *CLI) setupMetrics() {
 
 		go librato.Librato(metrics.DefaultRegistry, time.Minute,
 			i.Config.LibratoEmail, i.Config.LibratoToken, i.Config.LibratoSource,
-			[]float64{0.95}, time.Millisecond)
+			[]float64{0.50, 0.75, 0.90, 0.95, 0.99, 0.999, 1.0}, time.Millisecond)
 	} else if !i.c.Bool("silence-metrics") {
 		i.logger.Info("starting logger metrics reporter")
 

--- a/cli.go
+++ b/cli.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
+	"github.com/mihasya/go-metrics-librato"
 	"github.com/rcrowley/go-metrics"
-	"github.com/rcrowley/go-metrics/librato"
 	"github.com/streadway/amqp"
 	"github.com/travis-ci/worker/backend"
 	"github.com/travis-ci/worker/config"

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -68,6 +68,12 @@
 			"branch": "master"
 		},
 		{
+			"importpath": "github.com/mihasya/go-metrics-librato",
+			"repository": "https://github.com/mihasya/go-metrics-librato",
+			"revision": "742811266180500ea5934ea6ed3313f90d806a20",
+			"branch": "master"
+		},
+		{
 			"importpath": "github.com/mitchellh/multistep",
 			"repository": "https://github.com/mitchellh/multistep",
 			"revision": "162146fc57112954184d90266f4733e900ed05a5",


### PR DESCRIPTION
Updates to github.com/mihasya/go-metrics-librato since the librato provider in rcrowley/go-metrics has been deprecated for a while, and also sends more percentiles to Librato. More specifically, it sends these:

- 50th %ile (median)
- 75th %ile
- 90th %ile
- 95th %ile
- 99th %ile
- 99.9th %ile
- 100th %ile (maximum)