### PR TITLE
Added the feature to support amqp to use custom TLS cert

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"log"
 	"net/http"
@@ -275,7 +276,13 @@ func (i *CLI) setupJobQueueAndCanceller() error {
 	case "amqp":
 		var amqpConn *amqp.Connection
 		var err error
-		if i.Config.AmqpInsecure {
+
+		if i.Config.AmqpTlsCert != "" {
+			cfg := new(tls.Config)
+			cfg.RootCAs = x509.NewCertPool()
+			cfg.RootCAs.AppendCertsFromPEM([]byte(i.Config.AmqpTlsCert))
+			amqpConn, err = amqp.DialTLS(i.Config.AmqpURI, cfg)
+		} else if i.Config.AmqpInsecure {
 			amqpConn, err = amqp.DialTLS(
 				i.Config.AmqpURI,
 				&tls.Config{InsecureSkipVerify: true},

--- a/config/config.go
+++ b/config/config.go
@@ -58,6 +58,9 @@ var (
 		NewConfigDef("AmqpInsecure", &cli.BoolFlag{
 			Usage: `Whether to connect to the AMQP server without verifying TLS certificates (only valid for "amqp" queue type)`,
 		}),
+		NewConfigDef("AmqpTlsCert", &cli.StringFlag{
+			Usage: `The TLS certificate used to connet to the AMQP server`,
+		}),
 		NewConfigDef("BaseDir", &cli.StringFlag{
 			Value: defaultBaseDir,
 			Usage: `The base directory for file-based queues (only valid for "file" queue type)`,
@@ -262,6 +265,7 @@ type Config struct {
 	QueueType       string `config:"queue-type"`
 	AmqpURI         string `config:"amqp-uri"`
 	AmqpInsecure    bool   `config:"amqp-insecure"`
+	AmqpTlsCert     string `config:"amqp-tls-cert"`
 	BaseDir         string `config:"base-dir"`
 	PoolSize        int    `config:"pool-size"`
 	BuildAPIURI     string `config:"build-api-uri"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -49,6 +49,7 @@ func TestFromCLIContext_SetsBoolFlags(t *testing.T) {
 func TestFromCLIContext_SetsStringFlags(t *testing.T) {
 	runAppTest(t, []string{
 		"--amqp-uri=amqp://",
+		"--amqp-tls-cert=cert",
 		"--base-dir=dir",
 		"--build-api-uri=http://build/api",
 		"--build-apt-cache=cache",
@@ -75,6 +76,7 @@ func TestFromCLIContext_SetsStringFlags(t *testing.T) {
 		cfg := FromCLIContext(c)
 
 		assert.Equal(t, "amqp://", cfg.AmqpURI, "AmqpURI")
+		assert.Equal(t, "cert", cfg.AmqpTlsCert, "AmqpTlsCert")
 		assert.Equal(t, "dir", cfg.BaseDir, "BaseDir")
 		assert.Equal(t, "http://build/api", cfg.BuildAPIURI, "BuildAPIURI")
 		assert.Equal(t, "cache", cfg.BuildAptCache, "BuildAptCache")


### PR DESCRIPTION
Adding the feature of adding a TLS cert. The cert should be configured as a PEM formatted string in the AmqpTlsCert config value.

Here are some documentation about this:
* https://godoc.org/github.com/streadway/amqp#hdr-Use_Case
* https://www.compose.io/articles/making-secure-connections-with-compose-rabbitmq/#finallygo