### PR TITLE
Add a Redis-backed rate limiter for GCE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ group: edge
 services:
 - rabbitmq
 - docker
+- redis
 
 env:
   global:
@@ -17,6 +18,7 @@ env:
   - PATH="bin:$HOME/gopath/bin:$HOME/bin:$PATH"
   - CHECKOUT_ROOT="$HOME/gopath/src/github.com/travis-ci/worker"
   - GO15VENDOREXPERIMENT='1'
+  - REDIS_URL="redis://"
 
 addons:
   artifacts:

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -225,7 +225,7 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 	}
 }
 
-func (p *dockerProvider) Setup() error { return nil }
+func (p *dockerProvider) Setup(ctx gocontext.Context) error { return nil }
 
 func (p *dockerProvider) imageForLanguage(language string) (string, string, error) {
 	images, err := p.client.ListImages(docker.ListImagesOptions{All: true})

--- a/backend/fake.go
+++ b/backend/fake.go
@@ -39,7 +39,7 @@ func (p *fakeProvider) Start(ctx context.Context, _ *StartAttributes) (Instance,
 	return &fakeInstance{p: p, startupDuration: dur}, nil
 }
 
-func (p *fakeProvider) Setup() error { return nil }
+func (p *fakeProvider) Setup(ctx context.Context) error { return nil }
 
 type fakeInstance struct {
 	p *fakeProvider

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -473,6 +473,7 @@ func (p *gceProvider) apiRateLimit(ctx gocontext.Context) error {
 		if err != nil {
 			errCount++
 			if errCount >= 5 {
+				context.CaptureError(ctx, err)
 				context.LoggerFromContext(ctx).WithField("err", err).Info("rate limiter errored 5 times")
 				return err
 			}

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/cenkalti/backoff"
-	"github.com/garyburd/redigo/redis"
 	"github.com/mitchellh/multistep"
 	"github.com/pborman/uuid"
 	"github.com/pkg/sftp"
@@ -382,12 +381,7 @@ func newGCEProvider(cfg *config.ProviderConfig) (Provider, error) {
 
 	var rateLimiter ratelimit.RateLimiter
 	if cfg.IsSet("RATE_LIMIT_REDIS_URL") {
-		redisConn, err := redis.DialURL(cfg.Get("RATE_LIMIT_REDIS_URL"))
-		if err != nil {
-			return nil, err
-		}
-
-		rateLimiter = ratelimit.NewRateLimiter(redisConn, cfg.Get("RATE_LIMIT_PREFIX"))
+		rateLimiter = ratelimit.NewRateLimiter(cfg.Get("RATE_LIMIT_REDIS_URL"), cfg.Get("RATE_LIMIT_PREFIX"))
 	} else {
 		rateLimiter = ratelimit.NewNullRateLimiter()
 	}

--- a/backend/gce_test.go
+++ b/backend/gce_test.go
@@ -134,7 +134,7 @@ func TestNewGCEProvider_RequiresProjectID(t *testing.T) {
 
 func TestGCEProvider_SetupMakesRequests(t *testing.T) {
 	p, _, rl := gceTestSetup(t, nil, nil)
-	err := p.Setup()
+	err := p.Setup(nil)
 
 	assert.NotNil(t, err)
 	assert.Len(t, rl.Reqs, 1)

--- a/backend/jupiterbrain.go
+++ b/backend/jupiterbrain.go
@@ -340,7 +340,7 @@ func (p *jupiterBrainProvider) Start(ctx gocontext.Context, startAttributes *Sta
 	}
 }
 
-func (p *jupiterBrainProvider) Setup() error {
+func (p *jupiterBrainProvider) Setup(ctx gocontext.Context) error {
 	return nil
 }
 

--- a/backend/local.go
+++ b/backend/local.go
@@ -47,7 +47,7 @@ func (p *localProvider) Start(ctx gocontext.Context, startAttributes *StartAttri
 	return newLocalInstance(p)
 }
 
-func (p *localProvider) Setup() error { return nil }
+func (p *localProvider) Setup(ctx gocontext.Context) error { return nil }
 
 type localInstance struct {
 	p *localProvider

--- a/backend/package.go
+++ b/backend/package.go
@@ -30,7 +30,7 @@ var (
 type Provider interface {
 	// Setup performs whatever is necessary in order to be ready to start
 	// instances.
-	Setup() error
+	Setup(context.Context) error
 
 	// Start starts an instance. It shouldn't return until the instance is
 	// ready to call UploadScript on (this may, for example, mean that it

--- a/cli.go
+++ b/cli.go
@@ -198,6 +198,11 @@ func (i *CLI) setupSentry() {
 	}
 
 	logrus.AddHook(sentryHook)
+
+	err = raven.SetDSN(i.Config.SentryDSN)
+	if err != nil {
+		i.logger.WithField("err", err).Error("couldn't set DSN in raven")
+	}
 }
 
 func (i *CLI) setupMetrics() {

--- a/cli.go
+++ b/cli.go
@@ -115,7 +115,7 @@ func (i *CLI) Setup() (bool, error) {
 		return false, err
 	}
 
-	err = provider.Setup()
+	err = provider.Setup(ctx)
 	if err != nil {
 		logger.WithField("err", err).Error("couldn't setup backend provider")
 		return false, err

--- a/cli.go
+++ b/cli.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
+	"github.com/getsentry/raven-go"
 	"github.com/mihasya/go-metrics-librato"
 	"github.com/rcrowley/go-metrics"
 	"github.com/streadway/amqp"

--- a/context/package.go
+++ b/context/package.go
@@ -2,8 +2,10 @@ package context
 
 import (
 	"os"
+	"strconv"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/getsentry/raven-go"
 	"golang.org/x/net/context"
 )
 
@@ -119,4 +121,34 @@ func LoggerFromContext(ctx context.Context) *logrus.Entry {
 	}
 
 	return entry
+}
+
+// CaptureError takes an error and captures the details about it and sends it
+// off to Sentry, if Sentry has been set up.
+func CaptureError(ctx context.Context, err error) {
+	if raven.DefaultClient == nil {
+		// No client, so we can short-circuit to make things faster
+		return
+	}
+
+	interfaces := []raven.Interface{
+		raven.NewException(err, raven.NewStacktrace(1, 3, []string{"github.com/travis-ci/worker"})),
+	}
+
+	tags := make(map[string]string)
+	if processor, ok := ProcessorFromContext(ctx); ok {
+		tags["processor"] = processor
+	}
+	if jobID, ok := JobIDFromContext(ctx); ok {
+		tags["job-id"] = strconv.FormatUint(jobID, 10)
+	}
+	if repository, ok := RepositoryFromContext(ctx); ok {
+		tags["repository"] = repository
+	}
+
+	packet := raven.NewPacket(
+		err.Error(),
+		interfaces...,
+	)
+	raven.DefaultClient.Capture(packet, tags)
 }

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -1,0 +1,73 @@
+package ratelimit
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/garyburd/redigo/redis"
+)
+
+type RateLimiter interface {
+	RateLimit(name string, maxCalls uint64, per time.Duration) (bool, error)
+}
+
+type redisRateLimiter struct {
+	c      redis.Conn
+	prefix string
+
+	mutex sync.Mutex
+}
+
+type nullRateLimiter struct{}
+
+func NewRateLimiter(c redis.Conn, prefix string) RateLimiter {
+	return &redisRateLimiter{
+		c:      c,
+		prefix: prefix,
+	}
+}
+
+func NewNullRateLimiter() RateLimiter {
+	return nullRateLimiter{}
+}
+
+func (rl *redisRateLimiter) RateLimit(name string, maxCalls uint64, per time.Duration) (bool, error) {
+	rl.mutex.Lock()
+	defer rl.mutex.Unlock()
+
+	fmt.Printf("Rate limit %s, %d/%v\n", name, maxCalls, per)
+
+	now := time.Now()
+	timestamp := now.Unix() - (now.Unix() % int64(per.Seconds()))
+
+	key := fmt.Sprintf("%s:%s:%d", rl.prefix, name, timestamp)
+
+	_, err := rl.c.Do("WATCH", key)
+
+	cur, err := redis.Int64(rl.c.Do("GET", key))
+	if err != nil && err != redis.ErrNil {
+		return false, err
+	}
+
+	if err != redis.ErrNil && uint64(cur) >= maxCalls {
+		return false, nil
+	}
+
+	rl.c.Send("MULTI")
+	rl.c.Send("INCR", key)
+	rl.c.Send("EXPIRE", key, int64(per.Seconds()))
+	reply, err := rl.c.Do("EXEC")
+	if err != nil {
+		return false, err
+	}
+	if reply == nil {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (rl nullRateLimiter) RateLimit(name string, maxCalls uint64, per time.Duration) (bool, error) {
+	return true, nil
+}

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -36,8 +36,6 @@ func (rl *redisRateLimiter) RateLimit(name string, maxCalls uint64, per time.Dur
 	rl.mutex.Lock()
 	defer rl.mutex.Unlock()
 
-	fmt.Printf("Rate limit %s, %d/%v\n", name, maxCalls, per)
-
 	now := time.Now()
 	timestamp := now.Unix() - (now.Unix() % int64(per.Seconds()))
 

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -56,11 +56,6 @@ func (rl *redisRateLimiter) RateLimit(name string, maxCalls uint64, per time.Dur
 
 	key := fmt.Sprintf("%s:%s:%d", rl.prefix, name, timestamp)
 
-	_, err := conn.Do("WATCH", key)
-	if err != nil {
-		return false, err
-	}
-
 	cur, err := redis.Int64(conn.Do("GET", key))
 	if err != nil && err != redis.ErrNil {
 		return false, err
@@ -68,6 +63,11 @@ func (rl *redisRateLimiter) RateLimit(name string, maxCalls uint64, per time.Dur
 
 	if err != redis.ErrNil && uint64(cur) >= maxCalls {
 		return false, nil
+	}
+
+	_, err = conn.Do("WATCH", key)
+	if err != nil {
+		return false, err
 	}
 
 	connSend := func(commandName string, args ...interface{}) {

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -1,0 +1,51 @@
+package ratelimit
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/garyburd/redigo/redis"
+)
+
+func TestRateLimit(t *testing.T) {
+	if os.Getenv("REDIS_URL") == "" {
+		t.Skip("skipping redis test since there is no REDIS_URL")
+	}
+
+	if time.Now().Minute() > 58 {
+		t.Log("Note: The TestRateLimit test is known to have a bug if run near the top of the hour. Since the rate limiter isn't a moving window, it could end up checking against two different buckets on either side of the top of the hour, so if you see that just re-run it after you've passed the top of the hour.")
+	}
+
+	conn, err := redis.DialURL(os.Getenv("REDIS_URL"))
+	if err != nil {
+		t.Fatalf("unable to connect to Redis: %v", err)
+	}
+
+	rateLimiter := NewRateLimiter(conn, fmt.Sprintf("worker-test-rl-%d", os.Getpid()))
+
+	ok, err := rateLimiter.RateLimit("slow", 2, time.Hour)
+	if err != nil {
+		t.Fatalf("rate limiter error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected to not get rate limited, but was limited")
+	}
+
+	ok, err = rateLimiter.RateLimit("slow", 2, time.Hour)
+	if err != nil {
+		t.Fatalf("rate limiter error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected to not get rate limited, but was limited")
+	}
+
+	ok, err = rateLimiter.RateLimit("slow", 2, time.Hour)
+	if err != nil {
+		t.Fatalf("rate limiter error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected to get rate limited, but was not limited")
+	}
+}

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"testing"
 	"time"
-
-	"github.com/garyburd/redigo/redis"
 )
 
 func TestRateLimit(t *testing.T) {
@@ -18,12 +16,7 @@ func TestRateLimit(t *testing.T) {
 		t.Log("Note: The TestRateLimit test is known to have a bug if run near the top of the hour. Since the rate limiter isn't a moving window, it could end up checking against two different buckets on either side of the top of the hour, so if you see that just re-run it after you've passed the top of the hour.")
 	}
 
-	conn, err := redis.DialURL(os.Getenv("REDIS_URL"))
-	if err != nil {
-		t.Fatalf("unable to connect to Redis: %v", err)
-	}
-
-	rateLimiter := NewRateLimiter(conn, fmt.Sprintf("worker-test-rl-%d", os.Getpid()))
+	rateLimiter := NewRateLimiter(os.Getenv("REDIS_URL"), fmt.Sprintf("worker-test-rl-%d", os.Getpid()))
 
 	ok, err := rateLimiter.RateLimit("slow", 2, time.Hour)
 	if err != nil {

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -56,6 +56,12 @@
 			"branch": "master"
 		},
 		{
+			"importpath": "github.com/garyburd/redigo",
+			"repository": "https://github.com/garyburd/redigo",
+			"revision": "836b6e58b3358112c8291565d01c35b8764070d7",
+			"branch": "master"
+		},
+		{
 			"importpath": "github.com/getsentry/raven-go",
 			"repository": "https://github.com/getsentry/raven-go",
 			"revision": "74c334d7b8aaa4fd1b4fc6aa428c36fed1699e28",


### PR DESCRIPTION
This allows the rate limiter to share state across all workers, instead of just being local to a single worker process.

I tested this using a load testing script that ran three parallel processes, each spawning 50 goroutines that shared a rate limiter instance set to maximum 40 requests per second, and each goroutine continuously sending requests to a HTTP endpoint which tracked the maximum number of requests it got in a second. I let them run for about 15 minutes, and never did it go over 40 requests in a single second.

I also checked Redis to make sure the keys were actually cleaned up, and all of them expired and got removed correctly.

This could probably be improved in the future by using an implementation that allows you to spike over n req/s for a limited amount of time, as long as the average doesn't go over what you've set. That's probably a lot more complicated, and I don't think we need it to begin with.