### PR TITLE
Only build packages when the API TOKEN is present as an environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,7 @@ script:
 - make test-race
 - make crossbuild
 - make smoke
-- if [[ $PACKAGECLOUD_TOKEN ]]; then make package; fi
-- make smoke-package
+- if [[ $PACKAGECLOUD_TOKEN ]]; then make package && make smoke-package; fi
 
 after_success:
 - utils/atlas-push

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
 - make test-race
 - make crossbuild
 - make smoke
-- make package
+- if [[ $PACKAGECLOUD_TOKEN ]]; then make package fi
 - make smoke-package
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
 - make test-race
 - make crossbuild
 - make smoke
-- if [[ $PACKAGECLOUD_TOKEN ]]; then make package fi
+- if [[ $PACKAGECLOUD_TOKEN ]]; then make package; fi
 - make smoke-package
 
 after_success:


### PR DESCRIPTION
Only build packages when the API TOKEN is present as an environment variable. This helps with external PRs building.