### PR TITLE
backend/gce: add a metric for each GCE API call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ addons:
 
 install:
 - go get github.com/FiloSottile/gvt
-- go get github.com/alecthomas/gometalinter
+- go get -u github.com/alecthomas/gometalinter
 - go get github.com/laher/goxc
 - gometalinter --install --update
 - gem install package_cloud --no-ri --no-rdoc

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -697,6 +697,10 @@ func (p *gceProvider) stepWaitForInstanceIP(c *gceStartContext) multistep.StepAc
 
 		if newOp.Status == "RUNNING" || newOp.Status == "DONE" {
 			if newOp.Error != nil {
+				logger.WithFields(logrus.Fields{
+					"error": newOp.Error,
+				}).Debug("Error with instance state")
+
 				c.errChan <- &gceOpError{Err: newOp.Error}
 				return multistep.ActionHalt
 			}

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -471,6 +471,8 @@ func (p *gceProvider) apiRateLimit(ctx gocontext.Context) error {
 	for {
 		ok, err := p.rateLimiter.RateLimit("gce-api", p.rateLimitMaxCalls, p.rateLimitDuration)
 		if err != nil {
+			context.CaptureError(ctx, err)
+			context.LoggerFromContext(ctx).WithField("err", err).Info("Received an error when trying to get rate limiter")
 			errCount++
 			if errCount >= 5 {
 				context.CaptureError(ctx, err)
@@ -485,7 +487,9 @@ func (p *gceProvider) apiRateLimit(ctx gocontext.Context) error {
 		}
 
 		// Sleep for up to 1 second
-		time.Sleep(time.Millisecond * time.Duration(mathrand.Intn(1000)))
+		delay := time.Millisecond * time.Duration(mathrand.Intn(1000))
+		context.LoggerFromContext(ctx).WithField("sleep", delay).Info("Sleeping before trying to get rate limiter again")
+		time.Sleep(delay)
 	}
 }
 

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -558,7 +558,7 @@ func (rt *gceAPIFakeRateLimitRoundTripper) RoundTrip(req *http.Request) (*http.R
 		ProtoMajor:    1,
 		ProtoMinor:    1,
 		Header:        headers,
-		Body:          body,
+		Body:          ioutil.NopCloser(body),
 		ContentLength: int64(body.Len()),
 		Request:       req,
 	}


### PR DESCRIPTION
**DO NOT MERGE - CONTAINS DEBUG LOGIC**

This way we can see how long they take, and more interestingly right now, exactly how many are being made.