### PR TITLE
Prevent race condition when pushing to master and creating a tag shotly after

### DIFF
--- a/utils/package
+++ b/utils/package
@@ -61,7 +61,7 @@ __build_all_platforms() {
 
     export PC_REPO='worker'
 
-    if [[ $VERSION =~ dev ]] ; then
+    if [[ -z $TRAVIS_TAG ]] ; then
       export PC_REPO='worker-testing'
     fi
 


### PR DESCRIPTION
Instead of trying to detect if we are building a tag, just use the `$TRAVIS_TAG` var, which should only be set in that case.