### PR TITLE
backend/gce: use hard timeout for the job instead of a global setting

### DIFF
--- a/backend/start_attributes.go
+++ b/backend/start_attributes.go
@@ -1,5 +1,7 @@
 package backend
 
+import "time"
+
 // StartAttributes contains some parts of the config which can be used to
 // determine the type of instance to boot up (for example, what image to use)
 type StartAttributes struct {
@@ -12,6 +14,10 @@ type StartAttributes struct {
 	// The VMType isn't stored in the config directly, but in the top level of
 	// the job payload, see the worker.JobPayload struct.
 	VMType string `json:"-"`
+
+	// HardTimeout isn't stored in the config directly, but is injected
+	// from the processor
+	HardTimeout time.Duration `json:"-"`
 }
 
 // SetDefaults sets any missing required attributes to the default values provided

--- a/processor.go
+++ b/processor.go
@@ -109,6 +109,7 @@ func (p *Processor) Run() {
 			if buildJob.Payload().Timeouts.HardLimit != 0 {
 				hardTimeout = time.Duration(buildJob.Payload().Timeouts.HardLimit) * time.Second
 			}
+			buildJob.StartAttributes().HardTimeout = hardTimeout
 
 			ctx := context.FromJobID(context.FromRepository(p.ctx, buildJob.Payload().Repository.Slug), buildJob.Payload().Job.ID)
 			if buildJob.Payload().UUID != "" {

--- a/processor_test.go
+++ b/processor_test.go
@@ -152,6 +152,7 @@ func TestProcessor(t *testing.T) {
 			Config:   map[string]interface{}{},
 			Timeouts: TimeoutsPayload{},
 		},
+		startAttributes: &backend.StartAttributes{},
 	}
 	jobChan <- job
 


### PR DESCRIPTION
It's possible that the job has an extended timeout, and if we are still using the global default for when the worker shuts down, it'll cause an infinite loop until the job is cancelled.