### PR TITLE
Fix systemd service file

### DIFF
--- a/utils/package-overlay.d/rpm/lib/systemd/system/travis-worker.service
+++ b/utils/package-overlay.d/rpm/lib/systemd/system/travis-worker.service
@@ -1,17 +1,14 @@
 [Unit]
-Description=no description given
+Description=Travis Worker
 
 [Service]
 Type=simple
-EnvironmentFile=/etc/default/travis-enterprise
-EnvironmentFile=/etc/default/travis-worker
-EnvironmentFile=/etc/default/travis-worker-local
 User=travis
 Group=travis
-ExecStartPre=mkdir -p /var/tmp/travis-run.d
-ExecStartPre=cp /usr/local/bin/travis-worker /var/tmp/travis-run.d/travis-worker
-ExecStart=/var/tmp/travis-run.d/travis-worker
-ExecStopPost=sleep 5
+ExecStartPre=/bin/mkdir -p /var/tmp/travis-run.d
+ExecStartPre=/bin/cp /usr/local/bin/travis-worker /var/tmp/travis-run.d/%n
+ExecStart=/bin/sh -c 'for config_file in travis-enterprise %n %n-local; do if [ -f /etc/default/$config_file ]; then source /etc/default/$config_file; fi; done; export GOMAXPROCS=$(nproc); exec /var/tmp/travis-run.d/%n'
+ExecStopPost=/bin/sleep 5
 Restart=always
 
 [Install]


### PR DESCRIPTION
`EnvironmentFile`s aren't "executed", and since we depend on that in order to have certain variables be defined by using others, we can't use them. Changed to a `/bin/sh -c ''` style command instead in `ExecStart`, similar to the upstart file.

In addition, the binary name in `Exec*` needs to be a full path, so `/bin/mkdir` instead of just `mkdir`, for example.