### PR TITLE
systemd service file: switch %n to travis-worker

### DIFF
--- a/utils/package-overlay.d/rpm/lib/systemd/system/travis-worker.service
+++ b/utils/package-overlay.d/rpm/lib/systemd/system/travis-worker.service
@@ -6,8 +6,8 @@ Type=simple
 User=travis
 Group=travis
 ExecStartPre=/bin/mkdir -p /var/tmp/travis-run.d
-ExecStartPre=/bin/cp /usr/local/bin/travis-worker /var/tmp/travis-run.d/%n
-ExecStart=/bin/sh -c 'for config_file in travis-enterprise %n %n-local; do if [ -f /etc/default/$config_file ]; then source /etc/default/$config_file; fi; done; export GOMAXPROCS=$(nproc); exec /var/tmp/travis-run.d/%n'
+ExecStartPre=/bin/cp /usr/local/bin/travis-worker /var/tmp/travis-run.d/travis-worker
+ExecStart=/bin/sh -c 'for config_file in travis-enterprise travis-worker travis-worker-local; do if [ -f /etc/default/$config_file ]; then source /etc/default/$config_file; fi; done; export GOMAXPROCS=$(nproc); exec /var/tmp/travis-run.d/travis-worker'
 ExecStopPost=/bin/sleep 5
 Restart=always
 


### PR DESCRIPTION
`%n` expands to `travis-worker.service`, not `travis-worker`. There's probably something else that expands to  `travis-worker`, but it's easier to just hardcode it for now.