### PR TITLE
add link to docs when there's a log timeout error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.3.2 (July 8, 2016)
+
+IMPROVEMENTS:
+
+  * step/run-script: Add a new line with a link to the docs explaining
+    `travis_wait` when there's a log timeout error.
+
 ## 2.3.1 (May 30, 2016)
 
 IMPROVEMENTS:

--- a/step_run_script.go
+++ b/step_run_script.go
@@ -89,7 +89,7 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 
 		return multistep.ActionHalt
 	case <-logWriter.Timeout():
-		s.writeLogAndFinishWithState(ctx, logWriter, buildJob, FinishStateErrored, fmt.Sprintf("\n\nNo output has been received in the last %v, this potentially indicates a stalled build or something wrong with the build itself.\n\nThe build has been terminated\n\n", s.logTimeout))
+		s.writeLogAndFinishWithState(ctx, logWriter, buildJob, FinishStateErrored, fmt.Sprintf("\n\nNo output has been received in the last %v, this potentially indicates a stalled build or something wrong with the build itself.\nCheck the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received\n\nThe build has been terminated\n\n", s.logTimeout))
 
 		if s.skipShutdownOnLogTimeout {
 			state.Put("skipShutdown", true)


### PR DESCRIPTION
This PR adds a new line with a link to the docs explaining travis_wait when there's a log timeout error :)