### PR TITLE
amqp-job-queue: don't log the channel when close fails

### DIFF
--- a/amqp_job_queue.go
+++ b/amqp_job_queue.go
@@ -115,7 +115,7 @@ func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 
 		err := channel.Close()
 		if err != nil {
-			context.LoggerFromContext(ctx).WithField("err", err).WithField("channel", channel).Error("couldn't close channel")
+			context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't close channel")
 		}
 	}()
 


### PR DESCRIPTION
The channel object is very long and doesn't contain any exported information that has helped in debugging in the past, so let's remove it to make the log messages easier to read.