### PR TITLE
Bump GCE backend image default

### DIFF
--- a/backend/gce.go
+++ b/backend/gce.go
@@ -51,7 +51,7 @@ const (
 	defaultGCEUploadRetries      = uint64(120)
 	defaultGCEUploadRetrySleep   = 1 * time.Second
 	defaultGCEImageSelectorType  = "env"
-	defaultGCEImage              = "travis-ci-sugilite-trusty.+"
+	defaultGCEImage              = "travis-ci.+"
 	defaultGCERateLimitMaxCalls  = uint64(10)
 	defaultGCERateLimitDuration  = time.Second
 )

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -51,7 +51,7 @@ const (
 	defaultGCEUploadRetries      = uint64(120)
 	defaultGCEUploadRetrySleep   = 1 * time.Second
 	defaultGCEImageSelectorType  = "env"
-	defaultGCEImage              = "travis-ci-mega.+"
+	defaultGCEImage              = "travis-ci-sugilite-trusty.+"
 	defaultGCERateLimitMaxCalls  = uint64(10)
 	defaultGCERateLimitDuration  = time.Second
 )


### PR DESCRIPTION
to point to sugilite instead of mega