### PR TITLE
Expect Docker 1.12.0 instead of 1.9.1 to be preinstalled

### DIFF
--- a/utils/smoke-package
+++ b/utils/smoke-package
@@ -20,7 +20,7 @@ main() {
   ${sudo_exe} ./bin/travis-worker-install --trace --skip-docker-populate --edge
 
   /usr/local/bin/travis-worker --version
-  docker version | if ! grep -q '1.9.1' ; then
+  docker version | if ! grep -q '1.12.0' ; then
     echo '     ERROR: unexpected docker version' >&2
     docker version
     exit 1


### PR DESCRIPTION
The build is currently failing (I think) because the preinstalled Docker version is now 1.12.0 instead of 1.9.1. This PR just updates what version it expects, I'm hoping that's all that's needed.

@meatballhat or @solarce Do you know if this is correct, or if we specifically want to test against 1.9.1?