### PR TITLE
Revert "attempt to log upstream error on start failure"

### DIFF
--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -28,7 +28,7 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 
 	instance, err := s.provider.Start(ctx, buildJob.StartAttributes())
 	if err != nil {
-		context.LoggerFromContext(ctx).WithField("err", err).Errorf("couldn't start instance: %v", err)
+		context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't start instance")
 		err := buildJob.Requeue()
 		if err != nil {
 			context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't requeue job")


### PR DESCRIPTION
The previous change caused the error to be logged twice, and breaks the
"constant" msg field.

This reverts commit 4ce7d2cfc42e536043277e8257823dd2c7cd32b6.