### PR TITLE
backend/jupiterbrain: parse SSH key on backend init

### DIFF
--- a/backend/docker.go
+++ b/backend/docker.go
@@ -15,11 +15,11 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/fsouza/go-dockerclient"
 	"github.com/pborman/uuid"
-	"github.com/pkg/sftp"
+	"github.com/pkg/errors"
 	"github.com/travis-ci/worker/config"
 	"github.com/travis-ci/worker/context"
 	"github.com/travis-ci/worker/metrics"
-	"golang.org/x/crypto/ssh"
+	"github.com/travis-ci/worker/ssh"
 	gocontext "golang.org/x/net/context"
 )
 
@@ -52,7 +52,8 @@ func (nc *stdlibNumCPUer) NumCPU() int {
 }
 
 type dockerProvider struct {
-	client *docker.Client
+	client    *docker.Client
+	sshDialer ssh.Dialer
 
 	runPrivileged bool
 	runCmd        []string
@@ -136,8 +137,14 @@ func newDockerProvider(cfg *config.ProviderConfig) (Provider, error) {
 		}
 	}
 
+	sshDialer, err := ssh.NewDialerWithPassword("travis")
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't create SSH dialer")
+	}
+
 	return &dockerProvider{
-		client: client,
+		client:    client,
+		sshDialer: sshDialer,
 
 		runPrivileged: privileged,
 		runCmd:        cmd,
@@ -341,7 +348,7 @@ func (p *dockerProvider) checkinCPUSets(sets string) {
 	}
 }
 
-func (i *dockerInstance) sshClient() (*ssh.Client, error) {
+func (i *dockerInstance) sshConnection() (ssh.Connection, error) {
 	var err error
 	i.container, err = i.client.InspectContainer(i.container.ID)
 	if err != nil {
@@ -350,12 +357,7 @@ func (i *dockerInstance) sshClient() (*ssh.Client, error) {
 
 	time.Sleep(2 * time.Second)
 
-	return ssh.Dial("tcp", fmt.Sprintf("%s:22", i.container.NetworkSettings.IPAddress), &ssh.ClientConfig{
-		User: "travis",
-		Auth: []ssh.AuthMethod{
-			ssh.Password("travis"),
-		},
-	})
+	return i.provider.sshDialer.Dial(fmt.Sprintf("%s:22", i.container.NetworkSettings.IPAddress), "travis")
 }
 
 func (i *dockerInstance) UploadScript(ctx gocontext.Context, script []byte) error {
@@ -394,30 +396,21 @@ func (i *dockerInstance) uploadScriptNative(ctx gocontext.Context, script []byte
 }
 
 func (i *dockerInstance) uploadScriptSCP(ctx gocontext.Context, script []byte) error {
-	client, err := i.sshClient()
+	conn, err := i.sshConnection()
 	if err != nil {
 		return err
 	}
-	defer client.Close()
+	defer conn.Close()
 
-	sftp, err := sftp.NewClient(client)
-	if err != nil {
-		return err
-	}
-	defer sftp.Close()
-
-	_, err = sftp.Lstat("build.sh")
-	if err == nil {
+	existed, err := conn.UploadFile("build.sh", script)
+	if existed {
 		return ErrStaleVM
 	}
-
-	f, err := sftp.Create("build.sh")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "couldn't upload build script")
 	}
 
-	_, err = f.Write(script)
-	return err
+	return nil
 }
 
 func (i *dockerInstance) RunScript(ctx gocontext.Context, output io.Writer) (*RunResult, error) {
@@ -485,37 +478,15 @@ func (i *dockerInstance) runScriptExec(ctx gocontext.Context, output io.Writer) 
 }
 
 func (i *dockerInstance) runScriptSSH(ctx gocontext.Context, output io.Writer) (*RunResult, error) {
-	client, err := i.sshClient()
+	conn, err := i.sshConnection()
 	if err != nil {
-		return &RunResult{Completed: false}, err
+		return &RunResult{Completed: false}, errors.Wrap(err, "couldn't connect to SSH server")
 	}
-	defer client.Close()
+	defer conn.Close()
 
-	session, err := client.NewSession()
-	if err != nil {
-		return &RunResult{Completed: false}, err
-	}
-	defer session.Close()
+	exitStatus, err := conn.RunCommand("bash ~/build.sh", output)
 
-	err = session.RequestPty("xterm", 80, 40, ssh.TerminalModes{})
-	if err != nil {
-		return &RunResult{Completed: false}, err
-	}
-
-	session.Stdout = output
-	session.Stderr = output
-
-	err = session.Run("bash ~/build.sh")
-	if err == nil {
-		return &RunResult{Completed: true, ExitCode: 0}, nil
-	}
-
-	switch err := err.(type) {
-	case *ssh.ExitError:
-		return &RunResult{Completed: true, ExitCode: uint8(err.ExitStatus())}, nil
-	default:
-		return &RunResult{Completed: false}, err
-	}
+	return &RunResult{Completed: err != nil, ExitCode: exitStatus}, errors.Wrap(err, "error running script")
 }
 
 func (i *dockerInstance) Stop(ctx gocontext.Context) error {

--- a/ssh/package.go
+++ b/ssh/package.go
@@ -46,6 +46,12 @@ func NewDialerWithKey(key crypto.Signer) (*SSHDialer, error) {
 	}, nil
 }
 
+func NewDialerWithPassword(password string) (*SSHDialer, error) {
+	return &SSHDialer{
+		authMethods: []ssh.AuthMethod{ssh.Password(password)},
+	}, nil
+}
+
 func NewDialer(keyPath, keyPassphrase string) (*SSHDialer, error) {
 	file, err := ioutil.ReadFile(keyPath)
 	if err != nil {

--- a/ssh/package.go
+++ b/ssh/package.go
@@ -1,0 +1,145 @@
+package ssh
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"io/ioutil"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/pkg/errors"
+	"github.com/pkg/sftp"
+)
+
+type Dialer interface {
+	Dial(address, username string) (Connection, error)
+}
+type Connection interface {
+	UploadFile(path string, data []byte) (bool, error)
+	RunCommand(command string, output io.Writer) (uint8, error)
+	Close() error
+}
+
+func FormatPublicKey(key interface{}) ([]byte, error) {
+	pubKey, err := ssh.NewPublicKey(key)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't use public key")
+	}
+
+	return ssh.MarshalAuthorizedKey(pubKey), nil
+}
+
+type SSHDialer struct {
+	authMethods []ssh.AuthMethod
+}
+
+func NewDialerWithKey(key crypto.Signer) (*SSHDialer, error) {
+	signer, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't create signer from SSH key")
+	}
+
+	return &SSHDialer{
+		authMethods: []ssh.AuthMethod{ssh.PublicKeys(signer)},
+	}, nil
+}
+
+func NewDialer(keyPath, keyPassphrase string) (*SSHDialer, error) {
+	file, err := ioutil.ReadFile(keyPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't read SSH key")
+	}
+
+	block, _ := pem.Decode(file)
+	if block == nil {
+		return nil, errors.Errorf("ssh key does not contain a valid PEM block")
+	}
+
+	der, err := x509.DecryptPEMBlock(block, []byte(keyPassphrase))
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't decrypt SSH key")
+	}
+
+	key, err := x509.ParsePKCS1PrivateKey(der)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't parse SSH key")
+	}
+
+	return NewDialerWithKey(key)
+}
+
+func (d *SSHDialer) Dial(address, username string) (Connection, error) {
+	client, err := ssh.Dial("tcp", address, &ssh.ClientConfig{
+		User: username,
+		Auth: d.authMethods,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't connect to SSH server")
+	}
+
+	return &sshConnection{client: client}, nil
+}
+
+type sshConnection struct {
+	client *ssh.Client
+}
+
+func (c *sshConnection) UploadFile(path string, data []byte) (bool, error) {
+	sftp, err := sftp.NewClient(c.client)
+	if err != nil {
+		return false, errors.Wrap(err, "couldn't create SFTP client")
+	}
+	defer sftp.Close()
+
+	_, err = sftp.Lstat(path)
+	if err == nil {
+		return true, errors.New("file already existed")
+	}
+
+	f, err := sftp.Create(path)
+	if err != nil {
+		return false, errors.Wrap(err, "couldn't create file")
+	}
+
+	_, err = f.Write(data)
+	if err != nil {
+		return false, errors.Wrap(err, "couldn't write contents to file")
+	}
+
+	return false, nil
+}
+
+func (c *sshConnection) RunCommand(command string, output io.Writer) (uint8, error) {
+	session, err := c.client.NewSession()
+	if err != nil {
+		return 0, errors.Wrap(err, "error creating SSH session")
+	}
+	defer session.Close()
+
+	err = session.RequestPty("xterm", 80, 40, ssh.TerminalModes{})
+	if err != nil {
+		return 0, errors.Wrap(err, "error requesting PTY")
+	}
+
+	session.Stdout = output
+	session.Stderr = output
+
+	err = session.Run(command)
+
+	if err == nil {
+		return 0, nil
+	}
+
+	switch err := err.(type) {
+	case *ssh.ExitError:
+		return uint8(err.ExitStatus()), nil
+	default:
+		return 0, errors.Wrap(err, "error running script")
+	}
+}
+
+func (c *sshConnection) Close() error {
+	return c.client.Close()
+}


### PR DESCRIPTION
Instead of loading, parsing and decrypting the key on every SSH connect, this does it only once when the worker is first set up.

Gonna test this in staging once the build passes and I have a binary to test with.

Fixes #206.