### PR TITLE
Use errors.Cause when checking error values

### DIFF
--- a/step_run_script.go
+++ b/step_run_script.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/mitchellh/multistep"
+	"github.com/pkg/errors"
 	"github.com/travis-ci/worker/backend"
 	"github.com/travis-ci/worker/context"
 	gocontext "golang.org/x/net/context"
@@ -42,7 +43,7 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 
 	select {
 	case r := <-resultChan:
-		if r.err == ErrWrotePastMaxLogLength {
+		if errors.Cause(r.err) == ErrWrotePastMaxLogLength {
 			context.LoggerFromContext(ctx).Info("wrote past maximum log length")
 			s.writeLogAndFinishWithState(ctx, logWriter, buildJob, FinishStateErrored, "\n\nThe job exceeded the maximum log length, and has been terminated.\n\n")
 			return multistep.ActionHalt
@@ -51,7 +52,7 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 		// We need to check for this since it's possible that the RunScript
 		// implementation returns with the error too quickly for the ctx.Done()
 		// case branch below to catch it.
-		if r.err == gocontext.DeadlineExceeded {
+		if errors.Cause(r.err) == gocontext.DeadlineExceeded {
 			context.LoggerFromContext(ctx).Info("hard timeout exceeded, terminating")
 			s.writeLogAndFinishWithState(ctx, logWriter, buildJob, FinishStateErrored, "\n\nThe job exceeded the maximum time limit for jobs, and has been terminated.\n\n")
 			return multistep.ActionHalt

--- a/step_upload_script.go
+++ b/step_upload_script.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/mitchellh/multistep"
+	"github.com/pkg/errors"
 	"github.com/travis-ci/worker/backend"
 	"github.com/travis-ci/worker/context"
 	"github.com/travis-ci/worker/metrics"
@@ -27,7 +28,7 @@ func (s *stepUploadScript) Run(state multistep.StateBag) multistep.StepAction {
 	err := instance.UploadScript(ctx, script)
 	if err != nil {
 		errMetric := "worker.job.upload.error"
-		if err == backend.ErrStaleVM {
+		if errors.Cause(err) == backend.ErrStaleVM {
 			errMetric += ".stalevm"
 		}
 		metrics.Mark(errMetric)


### PR DESCRIPTION
Since we've started to wrap the errors using `errors.Wrap` the error returned is no longer the value we expect, which means things like handling max log length overruns don't work right and now requeue the job instead. `errors.Cause` returns the original error, which we can then
compare against.