### PR TITLE
processor: always mark as done when Run finishes

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -102,6 +102,7 @@ func NewProcessor(ctx gocontext.Context, hostname string, queue JobQueue,
 func (p *Processor) Run() {
 	context.LoggerFromContext(p.ctx).Info("starting processor")
 	defer context.LoggerFromContext(p.ctx).Info("processor done")
+	defer func() { p.CurrentStatus = "done" }()
 
 	for {
 		select {
@@ -118,16 +119,13 @@ func (p *Processor) Run() {
 		select {
 		case <-p.ctx.Done():
 			context.LoggerFromContext(p.ctx).Info("processor is done, terminating")
-			p.CurrentStatus = "done"
 			return
 		case <-p.graceful:
 			context.LoggerFromContext(p.ctx).Info("processor is done, terminating")
 			p.terminate()
-			p.CurrentStatus = "done"
 			return
 		case buildJob, ok := <-p.buildJobsChan:
 			if !ok {
-				p.CurrentStatus = "done"
 				p.terminate()
 				return
 			}


### PR DESCRIPTION
There are many different exit paths out of the Run function, and not all of them marked the "current status" as done as they should. Moving the set to a deferred function should ensure that the processor is always marked as done.