### PR TITLE
Add step to transform build json using an external filter script

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -171,6 +171,7 @@ func (i *CLI) Setup() (bool, error) {
 		MaxLogLength:        i.Config.MaxLogLength,
 		ScriptUploadTimeout: i.Config.ScriptUploadTimeout,
 		StartupTimeout:      i.Config.StartupTimeout,
+		PayloadFilterScript: i.Config.FilterJobJsonScript,
 	}
 
 	pool := NewProcessorPool(ppc, i.BackendProvider, i.BuildScriptGenerator, i.CancellationBroadcaster)

--- a/cli.go
+++ b/cli.go
@@ -165,13 +165,13 @@ func (i *CLI) Setup() (bool, error) {
 		Hostname: i.Config.Hostname,
 		Context:  ctx,
 
-		HardTimeout:         i.Config.HardTimeout,
-		InitialSleep:        i.Config.InitialSleep,
-		LogTimeout:          i.Config.LogTimeout,
-		MaxLogLength:        i.Config.MaxLogLength,
-		ScriptUploadTimeout: i.Config.ScriptUploadTimeout,
-		StartupTimeout:      i.Config.StartupTimeout,
-		PayloadFilterScript: i.Config.FilterJobJsonScript,
+		HardTimeout:             i.Config.HardTimeout,
+		InitialSleep:            i.Config.InitialSleep,
+		LogTimeout:              i.Config.LogTimeout,
+		MaxLogLength:            i.Config.MaxLogLength,
+		ScriptUploadTimeout:     i.Config.ScriptUploadTimeout,
+		StartupTimeout:          i.Config.StartupTimeout,
+		PayloadFilterExecutable: i.Config.PayloadFilterExecutable,
 	}
 
 	pool := NewProcessorPool(ppc, i.BackendProvider, i.BuildScriptGenerator, i.CancellationBroadcaster)

--- a/config/config.go
+++ b/config/config.go
@@ -166,6 +166,9 @@ var (
 		NewConfigDef("BuildCacheS3SecretAccessKey", &cli.StringFlag{}),
 
 		// non-config and special case flags
+		NewConfigDef("FilterJobJsonScript", &cli.StringFlag{
+			Usage: "External script which will be called to filter the json to be sent to the build script generator",
+		}),
 		NewConfigDef("SkipShutdownOnLogTimeout", &cli.BoolFlag{
 			Usage: "Special-case mode to aid with debugging timed out jobs",
 		}),
@@ -343,6 +346,8 @@ type Config struct {
 	BuildCacheS3Bucket          string `config:"build-cache-s3-bucket"`
 	BuildCacheS3AccessKeyID     string `config:"build-cache-s3-access-key-id"`
 	BuildCacheS3SecretAccessKey string `config:"build-cache-s3-secret-access-key"`
+
+	FilterJobJsonScript string `config:"filter-job-json-script"`
 
 	ProviderConfig *ProviderConfig
 }

--- a/config/config.go
+++ b/config/config.go
@@ -166,8 +166,8 @@ var (
 		NewConfigDef("BuildCacheS3SecretAccessKey", &cli.StringFlag{}),
 
 		// non-config and special case flags
-		NewConfigDef("FilterJobJsonScript", &cli.StringFlag{
-			Usage: "External script which will be called to filter the json to be sent to the build script generator",
+		NewConfigDef("PayloadFilterExecutable", &cli.StringFlag{
+			Usage: "External executable which will be called to filter the json to be sent to the build script generator",
 		}),
 		NewConfigDef("SkipShutdownOnLogTimeout", &cli.BoolFlag{
 			Usage: "Special-case mode to aid with debugging timed out jobs",
@@ -347,7 +347,7 @@ type Config struct {
 	BuildCacheS3AccessKeyID     string `config:"build-cache-s3-access-key-id"`
 	BuildCacheS3SecretAccessKey string `config:"build-cache-s3-secret-access-key"`
 
-	FilterJobJsonScript string `config:"filter-job-json-script"`
+	PayloadFilterExecutable string `config:"payload-filter-executable"`
 
 	ProviderConfig *ProviderConfig
 }

--- a/processor.go
+++ b/processor.go
@@ -18,13 +18,13 @@ type Processor struct {
 	ID       uuid.UUID
 	hostname string
 
-	hardTimeout         time.Duration
-	initialSleep        time.Duration
-	logTimeout          time.Duration
-	maxLogLength        int
-	scriptUploadTimeout time.Duration
-	startupTimeout      time.Duration
-	payloadFilterScript string
+	hardTimeout             time.Duration
+	initialSleep            time.Duration
+	logTimeout              time.Duration
+	maxLogLength            int
+	scriptUploadTimeout     time.Duration
+	startupTimeout          time.Duration
+	payloadFilterExecutable string
 
 	ctx                     gocontext.Context
 	buildJobsChan           <-chan Job
@@ -51,13 +51,13 @@ type Processor struct {
 }
 
 type ProcessorConfig struct {
-	HardTimeout         time.Duration
-	InitialSleep        time.Duration
-	LogTimeout          time.Duration
-	MaxLogLength        int
-	ScriptUploadTimeout time.Duration
-	StartupTimeout      time.Duration
-	PayloadFilterScript string
+	HardTimeout             time.Duration
+	InitialSleep            time.Duration
+	LogTimeout              time.Duration
+	MaxLogLength            int
+	ScriptUploadTimeout     time.Duration
+	StartupTimeout          time.Duration
+	PayloadFilterExecutable string
 }
 
 // NewProcessor creates a new processor that will run the build jobs on the
@@ -83,13 +83,13 @@ func NewProcessor(ctx gocontext.Context, hostname string, queue JobQueue,
 		ID:       processorUUID,
 		hostname: hostname,
 
-		initialSleep:        config.InitialSleep,
-		hardTimeout:         config.HardTimeout,
-		logTimeout:          config.LogTimeout,
-		scriptUploadTimeout: config.ScriptUploadTimeout,
-		startupTimeout:      config.StartupTimeout,
-		maxLogLength:        config.MaxLogLength,
-		payloadFilterScript: config.PayloadFilterScript,
+		initialSleep:            config.InitialSleep,
+		hardTimeout:             config.HardTimeout,
+		logTimeout:              config.LogTimeout,
+		scriptUploadTimeout:     config.ScriptUploadTimeout,
+		startupTimeout:          config.StartupTimeout,
+		maxLogLength:            config.MaxLogLength,
+		payloadFilterExecutable: config.PayloadFilterExecutable,
 
 		ctx:                     ctx,
 		buildJobsChan:           buildJobsChan,
@@ -198,7 +198,7 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 			cancellationBroadcaster: p.cancellationBroadcaster,
 		},
 		&stepTransformBuildJSON{
-			payloadFilterScript: p.payloadFilterScript,
+			payloadFilterExecutable: p.payloadFilterExecutable,
 		},
 		&stepGenerateScript{
 			generator: p.generator,

--- a/processor_pool.go
+++ b/processor_pool.go
@@ -25,6 +25,8 @@ type ProcessorPool struct {
 	HardTimeout, InitialSleep, LogTimeout, ScriptUploadTimeout, StartupTimeout time.Duration
 	MaxLogLength                                                               int
 
+	PayloadFilterScript string
+
 	SkipShutdownOnLogTimeout bool
 
 	queue          JobQueue
@@ -41,6 +43,8 @@ type ProcessorPoolConfig struct {
 
 	HardTimeout, InitialSleep, LogTimeout, ScriptUploadTimeout, StartupTimeout time.Duration
 	MaxLogLength                                                               int
+
+	PayloadFilterScript string
 }
 
 // NewProcessorPool creates a new processor pool using the given arguments.
@@ -62,6 +66,7 @@ func NewProcessorPool(ppc *ProcessorPoolConfig,
 		Provider:                provider,
 		Generator:               generator,
 		CancellationBroadcaster: cancellationBroadcaster,
+		PayloadFilterScript:     ppc.PayloadFilterScript,
 	}
 }
 
@@ -185,6 +190,7 @@ func (p *ProcessorPool) runProcessor(queue JobQueue) error {
 			MaxLogLength:        p.MaxLogLength,
 			ScriptUploadTimeout: p.ScriptUploadTimeout,
 			StartupTimeout:      p.StartupTimeout,
+			PayloadFilterScript: p.PayloadFilterScript,
 		})
 
 	if err != nil {

--- a/processor_pool.go
+++ b/processor_pool.go
@@ -25,7 +25,7 @@ type ProcessorPool struct {
 	HardTimeout, InitialSleep, LogTimeout, ScriptUploadTimeout, StartupTimeout time.Duration
 	MaxLogLength                                                               int
 
-	PayloadFilterScript string
+	PayloadFilterExecutable string
 
 	SkipShutdownOnLogTimeout bool
 
@@ -44,7 +44,7 @@ type ProcessorPoolConfig struct {
 	HardTimeout, InitialSleep, LogTimeout, ScriptUploadTimeout, StartupTimeout time.Duration
 	MaxLogLength                                                               int
 
-	PayloadFilterScript string
+	PayloadFilterExecutable string
 }
 
 // NewProcessorPool creates a new processor pool using the given arguments.
@@ -66,7 +66,7 @@ func NewProcessorPool(ppc *ProcessorPoolConfig,
 		Provider:                provider,
 		Generator:               generator,
 		CancellationBroadcaster: cancellationBroadcaster,
-		PayloadFilterScript:     ppc.PayloadFilterScript,
+		PayloadFilterExecutable: ppc.PayloadFilterExecutable,
 	}
 }
 
@@ -184,13 +184,13 @@ func (p *ProcessorPool) runProcessor(queue JobQueue) error {
 	proc, err := NewProcessor(ctx, p.Hostname,
 		queue, p.Provider, p.Generator, p.CancellationBroadcaster,
 		ProcessorConfig{
-			HardTimeout:         p.HardTimeout,
-			InitialSleep:        p.InitialSleep,
-			LogTimeout:          p.LogTimeout,
-			MaxLogLength:        p.MaxLogLength,
-			ScriptUploadTimeout: p.ScriptUploadTimeout,
-			StartupTimeout:      p.StartupTimeout,
-			PayloadFilterScript: p.PayloadFilterScript,
+			HardTimeout:             p.HardTimeout,
+			InitialSleep:            p.InitialSleep,
+			LogTimeout:              p.LogTimeout,
+			MaxLogLength:            p.MaxLogLength,
+			ScriptUploadTimeout:     p.ScriptUploadTimeout,
+			StartupTimeout:          p.StartupTimeout,
+			PayloadFilterExecutable: p.PayloadFilterExecutable,
 		})
 
 	if err != nil {

--- a/processor_test.go
+++ b/processor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	simplejson "github.com/bitly/go-simplejson"
 	"github.com/pborman/uuid"
 	"github.com/travis-ci/worker/backend"
 	"github.com/travis-ci/worker/config"
@@ -43,6 +44,7 @@ func TestProcessor(t *testing.T) {
 		ScriptUploadTimeout: 3 * time.Second,
 		StartupTimeout:      4 * time.Second,
 		MaxLogLength:        4500000,
+		PayloadFilterScript: "filter.py",
 	})
 	if err != nil {
 		t.Error(err)
@@ -54,7 +56,10 @@ func TestProcessor(t *testing.T) {
 		doneChan <- struct{}{}
 	}()
 
+	rawPayload, _ := simplejson.NewJson([]byte("{}"))
+
 	job := &fakeJob{
+		rawPayload: rawPayload,
 		payload: &JobPayload{
 			Type: "job:test",
 			Job: JobJobPayload{

--- a/processor_test.go
+++ b/processor_test.go
@@ -39,12 +39,12 @@ func TestProcessor(t *testing.T) {
 	cancellationBroadcaster := NewCancellationBroadcaster()
 
 	processor, err := NewProcessor(ctx, "test-hostname", jobQueue, provider, generator, cancellationBroadcaster, ProcessorConfig{
-		HardTimeout:         2 * time.Second,
-		LogTimeout:          time.Second,
-		ScriptUploadTimeout: 3 * time.Second,
-		StartupTimeout:      4 * time.Second,
-		MaxLogLength:        4500000,
-		PayloadFilterScript: "filter.py",
+		HardTimeout:             2 * time.Second,
+		LogTimeout:              time.Second,
+		ScriptUploadTimeout:     3 * time.Second,
+		StartupTimeout:          4 * time.Second,
+		MaxLogLength:            4500000,
+		PayloadFilterExecutable: "filter.py",
 	})
 	if err != nil {
 		t.Error(err)

--- a/step_transform_build_json.go
+++ b/step_transform_build_json.go
@@ -1,0 +1,68 @@
+package worker
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/mitchellh/multistep"
+	"github.com/travis-ci/worker/context"
+	gocontext "golang.org/x/net/context"
+)
+
+type stepTransformBuildJSON struct {
+	payloadFilterScript string
+}
+
+type EnvVar struct {
+	Name   string
+	Public bool
+	Value  string
+}
+
+func (s *stepTransformBuildJSON) Run(state multistep.StateBag) multistep.StepAction {
+	buildJob := state.Get("buildJob").(Job)
+	ctx := state.Get("ctx").(gocontext.Context)
+
+	if s.payloadFilterScript == "" {
+		context.LoggerFromContext(ctx).Info("skipping json transformation, no filter script defined")
+		return multistep.ActionContinue
+	}
+
+	context.LoggerFromContext(ctx).Info(fmt.Sprintf("calling filter script: %s", s.payloadFilterScript))
+
+	payload := buildJob.RawPayload()
+
+	cmd := exec.Command(s.payloadFilterScript)
+	rawJson, err := payload.MarshalJSON()
+	if err != nil {
+		context.LoggerFromContext(ctx).Info(fmt.Sprintf("failed to marshal json: %v", err))
+		return multistep.ActionContinue
+	}
+
+	cmd.Stdin = strings.NewReader(string(rawJson))
+
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	err = cmd.Run()
+	if err != nil {
+		context.LoggerFromContext(ctx).Info(fmt.Sprintf("failed to execute filter script: %v", err))
+		return multistep.ActionContinue
+	}
+
+	err = payload.UnmarshalJSON(out.Bytes())
+	if err != nil {
+		context.LoggerFromContext(ctx).Info(fmt.Sprintf("failed to unmarshal json: %v", err))
+		return multistep.ActionContinue
+	}
+
+	context.LoggerFromContext(ctx).Info("replaced the build json")
+
+	return multistep.ActionContinue
+}
+
+func (s *stepTransformBuildJSON) Cleanup(multistep.StateBag) {
+	// Nothing to clean up
+}

--- a/step_transform_build_json.go
+++ b/step_transform_build_json.go
@@ -12,7 +12,7 @@ import (
 )
 
 type stepTransformBuildJSON struct {
-	payloadFilterScript string
+	payloadFilterExecutable string
 }
 
 type EnvVar struct {
@@ -25,16 +25,16 @@ func (s *stepTransformBuildJSON) Run(state multistep.StateBag) multistep.StepAct
 	buildJob := state.Get("buildJob").(Job)
 	ctx := state.Get("ctx").(gocontext.Context)
 
-	if s.payloadFilterScript == "" {
-		context.LoggerFromContext(ctx).Info("skipping json transformation, no filter script defined")
+	if s.payloadFilterExecutable == "" {
+		context.LoggerFromContext(ctx).Info("skipping json transformation, no filter executable defined")
 		return multistep.ActionContinue
 	}
 
-	context.LoggerFromContext(ctx).Info(fmt.Sprintf("calling filter script: %s", s.payloadFilterScript))
+	context.LoggerFromContext(ctx).Info(fmt.Sprintf("calling filter executable: %s", s.payloadFilterExecutable))
 
 	payload := buildJob.RawPayload()
 
-	cmd := exec.Command(s.payloadFilterScript)
+	cmd := exec.Command(s.payloadFilterExecutable)
 	rawJson, err := payload.MarshalJSON()
 	if err != nil {
 		context.LoggerFromContext(ctx).Info(fmt.Sprintf("failed to marshal json: %v", err))
@@ -48,7 +48,7 @@ func (s *stepTransformBuildJSON) Run(state multistep.StateBag) multistep.StepAct
 
 	err = cmd.Run()
 	if err != nil {
-		context.LoggerFromContext(ctx).Info(fmt.Sprintf("failed to execute filter script: %v", err))
+		context.LoggerFromContext(ctx).Info(fmt.Sprintf("failed to run filter executable: %v", err))
 		return multistep.ActionContinue
 	}
 

--- a/step_transform_build_json_test.go
+++ b/step_transform_build_json_test.go
@@ -1,0 +1,57 @@
+package worker
+
+import (
+	"testing"
+
+	gocontext "golang.org/x/net/context"
+
+	"github.com/bitly/go-simplejson"
+	"github.com/mitchellh/multistep"
+	"github.com/stretchr/testify/assert"
+	"github.com/travis-ci/worker/backend"
+	"github.com/travis-ci/worker/config"
+)
+
+func setupStepTransformBuildJSON(cfg *config.ProviderConfig) (*stepTransformBuildJSON, multistep.StateBag) {
+	s := &stepTransformBuildJSON{}
+
+	bp, _ := backend.NewBackendProvider("fake", cfg)
+
+	ctx := gocontext.TODO()
+	instance, _ := bp.Start(ctx, nil)
+
+	rawPayload, _ := simplejson.NewJson([]byte("{}"))
+
+	job := &fakeJob{
+		rawPayload: rawPayload,
+	}
+
+	state := &multistep.BasicStateBag{}
+	state.Put("ctx", ctx)
+	state.Put("buildJob", job)
+	state.Put("instance", instance)
+
+	return s, state
+}
+
+func TestStepTransformBuildJSON_Run(t *testing.T) {
+
+	cfg := config.ProviderConfigFromMap(map[string]string{
+		"FILTER_JOB_JSON_SCRIPT": "",
+	})
+
+	s, state := setupStepTransformBuildJSON(cfg)
+	action := s.Run(state)
+	assert.Equal(t, multistep.ActionContinue, action)
+}
+
+func TestStepTransformBuildJSON_RunWithScriptConfigured(t *testing.T) {
+
+	cfg := config.ProviderConfigFromMap(map[string]string{
+		"FILTER_JOB_JSON_SCRIPT": "/usr/local/bin/filter.py",
+	})
+
+	s, state := setupStepTransformBuildJSON(cfg)
+	action := s.Run(state)
+	assert.Equal(t, multistep.ActionContinue, action)
+}

--- a/step_transform_build_json_test.go
+++ b/step_transform_build_json_test.go
@@ -37,7 +37,7 @@ func setupStepTransformBuildJSON(cfg *config.ProviderConfig) (*stepTransformBuil
 func TestStepTransformBuildJSON_Run(t *testing.T) {
 
 	cfg := config.ProviderConfigFromMap(map[string]string{
-		"FILTER_JOB_JSON_SCRIPT": "",
+		"PAYLOAD_FILTER_EXECUTABLE": "",
 	})
 
 	s, state := setupStepTransformBuildJSON(cfg)
@@ -45,10 +45,10 @@ func TestStepTransformBuildJSON_Run(t *testing.T) {
 	assert.Equal(t, multistep.ActionContinue, action)
 }
 
-func TestStepTransformBuildJSON_RunWithScriptConfigured(t *testing.T) {
+func TestStepTransformBuildJSON_RunWithExecutableConfigured(t *testing.T) {
 
 	cfg := config.ProviderConfigFromMap(map[string]string{
-		"FILTER_JOB_JSON_SCRIPT": "/usr/local/bin/filter.py",
+		"PAYLOAD_FILTER_EXECUTABLE": "/usr/local/bin/filter.py",
 	})
 
 	s, state := setupStepTransformBuildJSON(cfg)


### PR DESCRIPTION
At our company (Schibsted) we are using this feature to inject variables into the Travis build environment:

![image](https://cloud.githubusercontent.com/assets/4490611/19617868/3a7e371c-983c-11e6-9c61-1283bfd37299.png)

This way we can have environment variables (i.e secrets) that are common to the whole company.

To do so, we have an external script that once configured in the worker config parameter `FILTER_JOB_JSON_SCRIPT`, will receive via stdin for each job started, the build json. In this json we inject the variables in the `env_vars` section of the json and return the json via stdout. This way the injected variables will appear in the log (and the build environment) as if they was defined in the settings ui.

We developed this feature due to a requirement of our workflow, feel free to close it if you think that is out of scope of your plans for the worker.
