### PR TITLE
Revert "Increase the log writer tick to 2 seconds (#156)"

### DIFF
--- a/log_writer.go
+++ b/log_writer.go
@@ -9,7 +9,7 @@ import (
 var (
 	// LogWriterTick is how often the buffer should be flushed out and sent to
 	// travis-logs.
-	LogWriterTick = 2 * time.Second
+	LogWriterTick = 500 * time.Millisecond
 
 	// LogChunkSize is a bit of a magic number, calculated like this: The
 	// maximum Pusher payload is 10 kB (or 10 KiB, who knows, but let's go with


### PR DESCRIPTION
After more discussion, we've decided to leave it at half a second.

This reverts commit 0805aaacce44ac58a3843f3320e4ec98b8c1a67a.

/cc @joshk @solarce
