### PR TITLE
amqp-job: implement state message counter

### DIFF
--- a/amqp_job.go
+++ b/amqp_job.go
@@ -22,6 +22,7 @@ type amqpJob struct {
 	startAttributes *backend.StartAttributes
 	received        time.Time
 	started         time.Time
+	stateCount      uint
 }
 
 func (j *amqpJob) GoString() string {
@@ -126,9 +127,13 @@ func (j *amqpJob) sendStateUpdate(event, state string) error {
 	}
 	defer amqpChan.Close()
 
+	j.stateCount++
 	body := map[string]interface{}{
 		"id":    j.Payload().Job.ID,
 		"state": state,
+		"meta": map[string]interface{}{
+			"state_update_count": j.stateCount,
+		},
 	}
 
 	if j.Payload().Job.QueuedAt != nil {

--- a/amqp_job_queue.go
+++ b/amqp_job_queue.go
@@ -128,6 +128,7 @@ func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 				buildJob.startAttributes.SetDefaults(q.DefaultLanguage, q.DefaultDist, q.DefaultGroup, q.DefaultOS, VMTypeDefault)
 				buildJob.conn = q.conn
 				buildJob.delivery = delivery
+				buildJob.stateCount = buildJob.payload.Meta.StateUpdateCount
 
 				select {
 				case buildJobChan <- buildJob:

--- a/job.go
+++ b/job.go
@@ -32,6 +32,12 @@ type JobPayload struct {
 	Config     map[string]interface{} `json:"config"`
 	Timeouts   TimeoutsPayload        `json:"timeouts,omitempty"`
 	VMType     string                 `json:"vm_type"`
+	Meta       JobMetaPayload         `json:"meta"`
+}
+
+// JobMetaPayload contains meta information about the job.
+type JobMetaPayload struct {
+	StateUpdateCount uint `json:"state_update_count"`
 }
 
 // JobJobPayload contains information about the job.


### PR DESCRIPTION
This counter helps Hub reorder the messages if they arrive in a different order than Worker sent them in, which sometimes causes a "requeue" immediately after "received" to be interpreted as "requeue" and _then_ "receive", causing the job to get stuck.

/cc @svenfuchs, is this roughly what you thought in terms of JSON payloads? I.e. `state_update_count` in the top-level of both the payload from Scheduler and the payload to Hub?

/cc @solarce