### PR TITLE
Lost AMQP delivery fixes

### DIFF
--- a/amqp_job_queue.go
+++ b/amqp_job_queue.go
@@ -122,7 +122,12 @@ func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 				buildJob.conn = q.conn
 				buildJob.delivery = delivery
 
-				buildJobChan <- buildJob
+				select {
+				case buildJobChan <- buildJob:
+				case <-ctx.Done():
+					delivery.Nack(false, true)
+					return
+				}
 			}
 		}
 	}()

--- a/amqp_job_queue.go
+++ b/amqp_job_queue.go
@@ -94,6 +94,8 @@ func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 					continue
 				}
 
+				context.LoggerFromContext(ctx).WithField("job", buildJob.payload.Job.ID).Info("received amqp delivery")
+
 				err = json.Unmarshal(delivery.Body, &startAttrs)
 				if err != nil {
 					context.LoggerFromContext(ctx).WithField("err", err).Error("start attributes JSON parse error, attempting to nack delivery")


### PR DESCRIPTION
This adds a log message immediately after JSON decode in order to help detect when a worker receives a job (this is the earliest possible point we have the job ID).

It also changes the way the `buildJob` struct is passed to the processor to interrupt that blocking call if the context is cancelled. I suspect this is where some jobs might be getting stuck right now.