### PR TITLE
Some Jupiter Brain backend refactoring

### DIFF
--- a/backend/jupiterbrain.go
+++ b/backend/jupiterbrain.go
@@ -222,6 +222,9 @@ func (p *jupiterBrainProvider) Start(ctx gocontext.Context, startAttributes *Sta
 		return nil, errors.Wrap(err, "error creating instance in Jupiter Brain")
 	}
 
+	// Sleep to allow the new instance to be fully visible
+	time.Sleep(p.bootPollSleep)
+
 	// Wait for instance to get IP address
 	ip, payload, err := p.waitForIP(ctx, instancePayload.ID)
 	if err != nil {


### PR DESCRIPTION
Mainly:

- Split the "wait for SSH to come up" loop into two separate functions"
- Move HTTP API things to a separate type

The general goal here was to make the functions smaller and easier to read (they used to be bigger than what could fit on my screen, which I think is too big for it to be easy to keep track of what's going on).