### PR TITLE
Capture every requeue and send the error to sentry

### DIFF
--- a/context/package.go
+++ b/context/package.go
@@ -158,4 +158,6 @@ func CaptureError(ctx context.Context, err error) {
 		interfaces...,
 	)
 	raven.DefaultClient.Capture(packet, tags)
+
+	// TODO: check if send to sentry succeeded
 }

--- a/step_open_log_writer.go
+++ b/step_open_log_writer.go
@@ -25,6 +25,8 @@ func (s *stepOpenLogWriter) Run(state multistep.StateBag) multistep.StepAction {
 	logWriter, err := buildJob.LogWriter(ctx)
 	if err != nil {
 		context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't open a log writer")
+		context.CaptureError(ctx, err)
+
 		err := buildJob.Requeue()
 		if err != nil {
 			context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't requeue job")

--- a/step_run_script.go
+++ b/step_run_script.go
@@ -61,6 +61,8 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 		if r.err != nil {
 			if !r.result.Completed {
 				context.LoggerFromContext(ctx).WithField("err", r.err).WithField("completed", r.result.Completed).Error("couldn't run script, attempting requeue")
+				context.CaptureError(ctx, r.err)
+
 				err := buildJob.Requeue()
 				if err != nil {
 					context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't requeue job")

--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -29,6 +29,8 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 	instance, err := s.provider.Start(ctx, buildJob.StartAttributes())
 	if err != nil {
 		context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't start instance")
+		context.CaptureError(ctx, err)
+
 		err := buildJob.Requeue()
 		if err != nil {
 			context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't requeue job")

--- a/step_subscribe_cancellation.go
+++ b/step_subscribe_cancellation.go
@@ -19,6 +19,7 @@ func (s *stepSubscribeCancellation) Run(state multistep.StateBag) multistep.Step
 	err := s.canceller.Subscribe(buildJob.Payload().Job.ID, ch)
 	if err != nil {
 		context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't subscribe to canceller, attempting requeue")
+		context.CaptureError(ctx, err)
 
 		err := buildJob.Requeue()
 		if err != nil {

--- a/step_upload_script.go
+++ b/step_upload_script.go
@@ -34,6 +34,7 @@ func (s *stepUploadScript) Run(state multistep.StateBag) multistep.StepAction {
 		metrics.Mark(errMetric)
 
 		context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't upload script, attemping requeue")
+		context.CaptureError(ctx, err)
 
 		err := buildJob.Requeue()
 		if err != nil {


### PR DESCRIPTION
Currently we are only tracking very few errors in sentry. This change will give us a 1:1 mapping between requeues and errors in sentry. Allowing us to see diagnostic information like stack traces, error aggregation, error counts, which should help us in keeping track of which errors cause requeues.