### PR TITLE
check tagsets for trailing commas before querying job-board

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,27 @@
+package errors
+
+type JobAbortError interface {
+	UserFacingErrorMessage() string
+}
+
+type wrappedJobAbortError struct {
+	err     error
+	message string
+}
+
+func NewWrappedJobAbortError(err error) *wrappedJobAbortError {
+	return &wrappedJobAbortError{
+		err: err,
+	}
+}
+
+// we do not implement Cause(), because we want
+// errors.Cause() to bottom out here
+
+func (abortErr wrappedJobAbortError) Error() string {
+	return abortErr.err.Error()
+}
+
+func (abortErr wrappedJobAbortError) UserFacingErrorMessage() string {
+	return abortErr.err.Error()
+}

--- a/image/api_selector.go
+++ b/image/api_selector.go
@@ -239,7 +239,7 @@ func (as *APISelector) buildCandidateTags(params *Params) ([]*tagSet, error) {
 	for _, ts := range result {
 		for _, tag := range ts.Tags {
 			if strings.Contains(tag, ",") {
-				return result, workererrors.NewWrappedJobAbortError(errors.Errorf("job was aborted because tag %v contained \",\", this can happen when .travis.yml has a trailing comma", tag))
+				return result, workererrors.NewWrappedJobAbortError(errors.Errorf("job was aborted because tag \"%v\" contained \",\", this can happen when .travis.yml has a trailing comma", tag))
 			}
 		}
 	}

--- a/image/api_selector.go
+++ b/image/api_selector.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/cenk/backoff"
 	"github.com/pkg/errors"
-	workerErrors "github.com/travis-ci/worker/errors"
+	workererrors "github.com/travis-ci/worker/errors"
 )
 
 const (
@@ -239,7 +239,7 @@ func (as *APISelector) buildCandidateTags(params *Params) ([]*tagSet, error) {
 	for _, ts := range result {
 		for _, tag := range ts.Tags {
 			if strings.Contains(tag, ",") {
-				return result, workerErrors.NewWrappedJobAbortError(errors.Errorf("tag %v contained \",\", which is not supported by job-board -- check .travis.yml for trailing comma", tag))
+				return result, workererrors.NewWrappedJobAbortError(errors.Errorf("tag %v contained \",\", which is not supported by job-board -- check .travis.yml for trailing comma", tag))
 			}
 		}
 	}

--- a/image/api_selector.go
+++ b/image/api_selector.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cenk/backoff"
 	"github.com/pkg/errors"
+	workerErrors "github.com/travis-ci/worker/errors"
 )
 
 const (
@@ -35,7 +36,12 @@ func NewAPISelector(u *url.URL) *APISelector {
 }
 
 func (as *APISelector) Select(params *Params) (string, error) {
-	imageName, err := as.queryWithTags(params.Infra, as.buildCandidateTags(params))
+	tagSets, err := as.buildCandidateTags(params)
+	if err != nil {
+		return "default", err
+	}
+
+	imageName, err := as.queryWithTags(params.Infra, tagSets)
 	if err != nil {
 		return "default", err
 	}
@@ -154,7 +160,7 @@ func (ts *tagSet) GoString() string {
 	return fmt.Sprintf("&image.tagSet{IsDefault: %v, Tags: %#v}", ts.IsDefault, ts.Tags)
 }
 
-func (as *APISelector) buildCandidateTags(params *Params) []*tagSet {
+func (as *APISelector) buildCandidateTags(params *Params) ([]*tagSet, error) {
 	fullTagSet := &tagSet{
 		Tags:  []string{},
 		JobID: params.JobID,
@@ -230,7 +236,15 @@ func (as *APISelector) buildCandidateTags(params *Params) []*tagSet {
 		sort.Strings(ts.Tags)
 	}
 
-	return result
+	for _, ts := range result {
+		for _, tag := range ts.Tags {
+			if strings.Contains(tag, ",") {
+				return result, workerErrors.NewWrappedJobAbortError(errors.Errorf("tag %v contained \",\", which is not supported by job-board -- check .travis.yml for trailing comma", tag))
+			}
+		}
+	}
+
+	return result, nil
 }
 
 type apiSelectorImageResponse struct {

--- a/image/api_selector.go
+++ b/image/api_selector.go
@@ -239,7 +239,7 @@ func (as *APISelector) buildCandidateTags(params *Params) ([]*tagSet, error) {
 	for _, ts := range result {
 		for _, tag := range ts.Tags {
 			if strings.Contains(tag, ",") {
-				return result, workererrors.NewWrappedJobAbortError(errors.Errorf("tag %v contained \",\", which is not supported by job-board -- check .travis.yml for trailing comma", tag))
+				return result, workererrors.NewWrappedJobAbortError(errors.Errorf("job was aborted because tag %v contained \",\", this can happen when .travis.yml has a trailing comma", tag))
 			}
 		}
 	}

--- a/image/api_selector_test.go
+++ b/image/api_selector_test.go
@@ -189,7 +189,7 @@ func TestAPISelector_SelectDefaultWhenBadResponse(t *testing.T) {
 	u, _ := url.Parse(ts.URL)
 	actual, err := NewAPISelector(u).Select(&Params{})
 	assert.Equal(t, actual, "default")
-	assert.EqualError(t, err, "expected 200 status code from job-board, received status=500")
+	assert.EqualError(t, err, "expected 200 status code from job-board, received status=500 body=\"\"")
 }
 
 func TestAPISelector_SelectDefaultWhenBadJSON(t *testing.T) {

--- a/image/api_selector_test.go
+++ b/image/api_selector_test.go
@@ -189,8 +189,7 @@ func TestAPISelector_SelectDefaultWhenBadResponse(t *testing.T) {
 	u, _ := url.Parse(ts.URL)
 	actual, err := NewAPISelector(u).Select(&Params{})
 	assert.Equal(t, actual, "default")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "expected 200 status code from job-board, received status=500")
+	assert.EqualError(t, err, "expected 200 status code from job-board, received status=500")
 }
 
 func TestAPISelector_SelectDefaultWhenBadJSON(t *testing.T) {
@@ -201,7 +200,7 @@ func TestAPISelector_SelectDefaultWhenBadJSON(t *testing.T) {
 	u, _ := url.Parse(ts.URL)
 	actual, err := NewAPISelector(u).Select(&Params{})
 	assert.Equal(t, actual, "default")
-	assert.Error(t, err, "unexpected end of JSON input")
+	assert.EqualError(t, err, "unexpected end of JSON input")
 }
 
 func TestAPISelector_SelectTrailingComma(t *testing.T) {
@@ -223,7 +222,7 @@ func TestAPISelector_SelectTrailingComma(t *testing.T) {
 		OS:       "osx,",
 	})
 	assert.Equal(t, actual, "default")
-	assert.Error(t, err, "tag \"a\" contained \",\", which is not supported by job-board -- check .travis.yml for trailing comma")
+	assert.EqualError(t, err, "tag \"a\" contained \",\", which is not supported by job-board -- check .travis.yml for trailing comma")
 }
 
 func TestAPISelector_buildCandidateTags(t *testing.T) {

--- a/image/api_selector_test.go
+++ b/image/api_selector_test.go
@@ -222,7 +222,7 @@ func TestAPISelector_SelectTrailingComma(t *testing.T) {
 		OS:       "osx,",
 	})
 	assert.Equal(t, actual, "default")
-	assert.EqualError(t, err, "tag \"a\" contained \",\", which is not supported by job-board -- check .travis.yml for trailing comma")
+	assert.EqualError(t, err, "job was aborted because tag \"dist:yosamitty,\" contained \",\", this can happen when .travis.yml has a trailing comma")
 }
 
 func TestAPISelector_buildCandidateTags(t *testing.T) {

--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -38,6 +38,11 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 			logWriter := state.Get("logWriter").(LogWriter)
 			logWriter.WriteAndClose([]byte(jobAbortErr.UserFacingErrorMessage()))
 
+			err = buildJob.Finish(FinishStateErrored)
+			if err != nil {
+				context.LoggerFromContext(ctx).WithField("err", err).WithField("state", FinishStateErrored).Error("couldn't mark job as finished")
+			}
+
 			return multistep.ActionHalt
 		}
 

--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/travis-ci/worker/backend"
 	"github.com/travis-ci/worker/context"
-	workerErrors "github.com/travis-ci/worker/errors"
+	workererrors "github.com/travis-ci/worker/errors"
 	gocontext "golang.org/x/net/context"
 )
 
@@ -33,7 +33,7 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 		context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't start instance")
 		context.CaptureError(ctx, err)
 
-		jobAbortErr, ok := errors.Cause(err).(workerErrors.JobAbortError)
+		jobAbortErr, ok := errors.Cause(err).(workererrors.JobAbortError)
 		if ok {
 			logWriter := state.Get("logWriter").(LogWriter)
 			logWriter.WriteAndClose([]byte(jobAbortErr.UserFacingErrorMessage()))


### PR DESCRIPTION
When .travis.yml contains trailing commas, those commas propagate all
the way through to to worker, which builds them into tags and passes
those tags on to job-board.

job-board does not like tags with commas and returns a 500, which then
causes a retry loop.

This patch adds a clearer error message for when that happens, displays
this error message to the user, and also makes sure we do not requeue.