### PR TITLE
Change verbosity of canceller missing job id to debug, make logs less spammy

### DIFF
--- a/amqp_canceller.go
+++ b/amqp_canceller.go
@@ -132,7 +132,7 @@ func (d *AMQPCanceller) processCommand(delivery amqp.Delivery) error {
 
 	cancelChan, ok := d.cancelMap[command.JobID]
 	if !ok {
-		context.LoggerFromContext(d.ctx).WithField("command", command.Type).WithField("job", command.JobID).Info("no job with this ID found on this worker")
+		context.LoggerFromContext(d.ctx).WithField("command", command.Type).WithField("job", command.JobID).Debug("no job with this ID found on this worker")
 		return nil
 	}
 


### PR DESCRIPTION
Currently most of the lines in the log look like this:

```
time="2017-01-11T13:53:59Z" level=info msg="no job with this ID found on this worker" command="cancel_job" component=canceller job=123456789 pid=12345
```

This is very noisy makes it difficult to see actual signal in the logs. By changing the log level to `debug` it should no longer show up all the time.