### PR TITLE
processor: open log writer before startInstance step, so it can write logs to the user

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -189,10 +189,7 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 			generator: p.generator,
 		},
 		&stepSendReceived{},
-		&stepOpenLogWriter{
-			logTimeout:   logTimeout,
-			maxLogLength: p.maxLogLength,
-		},
+		&stepOpenLogWriter{},
 		&stepStartInstance{
 			provider:     p.provider,
 			startTimeout: p.startupTimeout,
@@ -202,6 +199,10 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 		},
 		&stepUpdateState{},
 		&stepWriteWorkerInfo{},
+		&stepStartLogTimer{
+			logTimeout:   logTimeout,
+			maxLogLength: p.maxLogLength,
+		},
 		&stepRunScript{
 			logTimeout:               logTimeout,
 			hardTimeout:              p.hardTimeout,

--- a/processor.go
+++ b/processor.go
@@ -189,6 +189,10 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 			generator: p.generator,
 		},
 		&stepSendReceived{},
+		&stepOpenLogWriter{
+			logTimeout:   logTimeout,
+			maxLogLength: p.maxLogLength,
+		},
 		&stepStartInstance{
 			provider:     p.provider,
 			startTimeout: p.startupTimeout,
@@ -197,10 +201,6 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 			uploadTimeout: p.scriptUploadTimeout,
 		},
 		&stepUpdateState{},
-		&stepOpenLogWriter{
-			logTimeout:   logTimeout,
-			maxLogLength: p.maxLogLength,
-		},
 		&stepRunScript{
 			logTimeout:               logTimeout,
 			hardTimeout:              p.hardTimeout,

--- a/processor.go
+++ b/processor.go
@@ -201,6 +201,7 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 			uploadTimeout: p.scriptUploadTimeout,
 		},
 		&stepUpdateState{},
+		&stepWriteWorkerInfo{},
 		&stepRunScript{
 			logTimeout:               logTimeout,
 			hardTimeout:              p.hardTimeout,

--- a/step_open_log_writer.go
+++ b/step_open_log_writer.go
@@ -1,8 +1,6 @@
 package worker
 
 import (
-	"time"
-
 	gocontext "golang.org/x/net/context"
 
 	"github.com/mitchellh/multistep"
@@ -10,8 +8,6 @@ import (
 )
 
 type stepOpenLogWriter struct {
-	logTimeout   time.Duration
-	maxLogLength int
 }
 
 func (s *stepOpenLogWriter) Run(state multistep.StateBag) multistep.StepAction {
@@ -29,9 +25,6 @@ func (s *stepOpenLogWriter) Run(state multistep.StateBag) multistep.StepAction {
 		}
 		return multistep.ActionHalt
 	}
-
-	logWriter.SetTimeout(s.logTimeout)
-	logWriter.SetMaxLogLength(s.maxLogLength)
 
 	state.Put("logWriter", logWriter)
 

--- a/step_open_log_writer.go
+++ b/step_open_log_writer.go
@@ -1,15 +1,11 @@
 package worker
 
 import (
-	"fmt"
-	"io"
-	"strings"
 	"time"
 
 	gocontext "golang.org/x/net/context"
 
 	"github.com/mitchellh/multistep"
-	"github.com/travis-ci/worker/backend"
 	"github.com/travis-ci/worker/context"
 )
 
@@ -37,25 +33,9 @@ func (s *stepOpenLogWriter) Run(state multistep.StateBag) multistep.StepAction {
 	logWriter.SetTimeout(s.logTimeout)
 	logWriter.SetMaxLogLength(s.maxLogLength)
 
-	s.writeUsingWorker(state, logWriter)
-
 	state.Put("logWriter", logWriter)
 
 	return multistep.ActionContinue
-}
-
-func (s *stepOpenLogWriter) writeUsingWorker(state multistep.StateBag, w io.Writer) {
-	instance := state.Get("instance").(backend.Instance)
-
-	if hostname, ok := state.Get("hostname").(string); ok && hostname != "" {
-		_, _ = writeFold(w, "worker_info", []byte(strings.Join([]string{
-			"\033[33;1mWorker information\033[0m",
-			fmt.Sprintf("hostname: %s", hostname),
-			fmt.Sprintf("version: %s %s", VersionString, RevisionURLString),
-			fmt.Sprintf("instance: %s", instance.ID()),
-			fmt.Sprintf("startup: %v", instance.StartupDuration()),
-		}, "\n")))
-	}
 }
 
 func (s *stepOpenLogWriter) Cleanup(state multistep.StateBag) {

--- a/step_open_log_writer_test.go
+++ b/step_open_log_writer_test.go
@@ -8,20 +8,12 @@ import (
 
 	"github.com/mitchellh/multistep"
 	"github.com/stretchr/testify/assert"
-	"github.com/travis-ci/worker/backend"
-	"github.com/travis-ci/worker/config"
 )
 
 func setupStepOpenLogWriter() (*stepOpenLogWriter, multistep.StateBag) {
 	s := &stepOpenLogWriter{logTimeout: time.Second, maxLogLength: 4}
 
-	bp, _ := backend.NewBackendProvider("fake",
-		config.ProviderConfigFromMap(map[string]string{
-			"STARTUP_DURATION": "42.17s",
-		}))
-
 	ctx := gocontext.TODO()
-	instance, _ := bp.Start(ctx, nil)
 
 	job := &fakeJob{
 		payload: &JobPayload{

--- a/step_open_log_writer_test.go
+++ b/step_open_log_writer_test.go
@@ -2,7 +2,6 @@ package worker
 
 import (
 	"testing"
-	"time"
 
 	gocontext "golang.org/x/net/context"
 
@@ -11,7 +10,7 @@ import (
 )
 
 func setupStepOpenLogWriter() (*stepOpenLogWriter, multistep.StateBag) {
-	s := &stepOpenLogWriter{logTimeout: time.Second, maxLogLength: 4}
+	s := &stepOpenLogWriter{}
 
 	ctx := gocontext.TODO()
 

--- a/step_open_log_writer_test.go
+++ b/step_open_log_writer_test.go
@@ -1,7 +1,6 @@
 package worker
 
 import (
-	"bytes"
 	"testing"
 	"time"
 
@@ -48,7 +47,6 @@ func setupStepOpenLogWriter() (*stepOpenLogWriter, multistep.StateBag) {
 	state := &multistep.BasicStateBag{}
 	state.Put("ctx", ctx)
 	state.Put("buildJob", job)
-	state.Put("instance", instance)
 
 	return s, state
 }
@@ -57,26 +55,5 @@ func TestStepOpenLogWriter_Run(t *testing.T) {
 	s, state := setupStepOpenLogWriter()
 	action := s.Run(state)
 	assert.Equal(t, multistep.ActionContinue, action)
-}
-
-func TestStepOpenLogWriter_writeUsingWorker(t *testing.T) {
-	s, state := setupStepOpenLogWriter()
-
-	w := bytes.NewBufferString("")
-	s.writeUsingWorker(state, w)
-	assert.Equal(t, "", w.String())
-
-	state.Put("hostname", "frizzlefry.example.local")
-
-	w = bytes.NewBufferString("")
-	s.writeUsingWorker(state, w)
-	out := w.String()
-
-	assert.Contains(t, out, "travis_fold:start:worker_info\r\033[0K")
-	assert.Contains(t, out, "\033[33;1mWorker information\033[0m\n")
-	assert.Contains(t, out, "\nhostname: frizzlefry.example.local\n")
-	assert.Contains(t, out, "\nversion: "+VersionString+" "+RevisionURLString+"\n")
-	assert.Contains(t, out, "\ninstance: fake\n")
-	assert.Contains(t, out, "\nstartup: 42.17s\n")
-	assert.Contains(t, out, "\ntravis_fold:end:worker_info\r\033[0K")
+	assert.NotNil(t, state.Get("logWriter"))
 }

--- a/step_start_log_timer.go
+++ b/step_start_log_timer.go
@@ -1,0 +1,23 @@
+package worker
+
+import (
+	"time"
+
+	"github.com/mitchellh/multistep"
+)
+
+type stepStartLogTimer struct {
+	logTimeout   time.Duration
+	maxLogLength int
+}
+
+func (s *stepStartLogTimer) Run(state multistep.StateBag) multistep.StepAction {
+	logWriter := state.Get("logWriter").(LogWriter)
+	logWriter.SetTimeout(s.logTimeout)
+	logWriter.SetMaxLogLength(s.maxLogLength)
+
+	return multistep.ActionContinue
+}
+
+func (s *stepStartLogTimer) Cleanup(state multistep.StateBag) {
+}

--- a/step_write_worker_info.go
+++ b/step_write_worker_info.go
@@ -1,0 +1,32 @@
+package worker
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/multistep"
+	"github.com/travis-ci/worker/backend"
+)
+
+type stepWriteWorkerInfo struct {
+}
+
+func (s *stepWriteWorkerInfo) Run(state multistep.StateBag) multistep.StepAction {
+	logWriter := state.Get("logWriter").(LogWriter)
+	instance := state.Get("instance").(backend.Instance)
+
+	if hostname, ok := state.Get("hostname").(string); ok && hostname != "" {
+		_, _ = writeFold(logWriter, "worker_info", []byte(strings.Join([]string{
+			"\033[33;1mWorker information\033[0m",
+			fmt.Sprintf("hostname: %s", hostname),
+			fmt.Sprintf("version: %s %s", VersionString, RevisionURLString),
+			fmt.Sprintf("instance: %s", instance.ID()),
+			fmt.Sprintf("startup: %v", instance.StartupDuration()),
+		}, "\n")))
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *stepWriteWorkerInfo) Cleanup(state multistep.StateBag) {
+}

--- a/step_write_worker_info_test.go
+++ b/step_write_worker_info_test.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"bytes"
 	"testing"
-	"time"
 
 	gocontext "golang.org/x/net/context"
 
@@ -13,8 +12,8 @@ import (
 	"github.com/travis-ci/worker/config"
 )
 
-func setupStepWriteWorkerInfo() (*stepOpenLogWriter, *bytes.Buffer, multistep.StateBag) {
-	s := &stepOpenLogWriter{logTimeout: time.Second, maxLogLength: 4}
+func setupStepWriteWorkerInfo() (*stepWriteWorkerInfo, *bytes.Buffer, multistep.StateBag) {
+	s := &stepWriteWorkerInfo{}
 
 	bp, _ := backend.NewBackendProvider("fake",
 		config.ProviderConfigFromMap(map[string]string{

--- a/step_write_worker_info_test.go
+++ b/step_write_worker_info_test.go
@@ -1,0 +1,49 @@
+package worker
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	gocontext "golang.org/x/net/context"
+
+	"github.com/mitchellh/multistep"
+	"github.com/stretchr/testify/assert"
+	"github.com/travis-ci/worker/backend"
+	"github.com/travis-ci/worker/config"
+)
+
+func setupStepWriteWorkerInfo() (*stepOpenLogWriter, *bytes.Buffer, multistep.StateBag) {
+	s := &stepOpenLogWriter{logTimeout: time.Second, maxLogLength: 4}
+
+	bp, _ := backend.NewBackendProvider("fake",
+		config.ProviderConfigFromMap(map[string]string{
+			"STARTUP_DURATION": "42.17s",
+		}))
+
+	ctx := gocontext.TODO()
+	instance, _ := bp.Start(ctx, nil)
+
+	logWriter := bytes.NewBufferString("")
+
+	state := &multistep.BasicStateBag{}
+	state.Put("logWriter", logWriter)
+	state.Put("instance", instance)
+	state.Put("hostname", "frizzlefry.example.local")
+
+	return s, logWriter, state
+}
+
+func TestStepWriteWorkerInfo_Run(t *testing.T) {
+	s, out, state := setupStepWriteWorkerInfo()
+
+	s.Run(state)
+
+	assert.Contains(t, out, "travis_fold:start:worker_info\r\033[0K")
+	assert.Contains(t, out, "\033[33;1mWorker information\033[0m\n")
+	assert.Contains(t, out, "\nhostname: frizzlefry.example.local\n")
+	assert.Contains(t, out, "\nversion: "+VersionString+" "+RevisionURLString+"\n")
+	assert.Contains(t, out, "\ninstance: fake\n")
+	assert.Contains(t, out, "\nstartup: 42.17s\n")
+	assert.Contains(t, out, "\ntravis_fold:end:worker_info\r\033[0K")
+}


### PR DESCRIPTION
We are currently experiencing panic()s because stepStartInstance may try to
write a message out to the user, but the log writer has not been initialized
yet.

This patch moves the opening of the log writer further back in time.