### PR TITLE
Increase tab width to 4 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,3 @@
 [*.go]
 indent_style = tab
-indent_size = 2
+indent_size = 4


### PR DESCRIPTION
I find the 2-space width makes it hard to see what level of indentation are in in the diff views on GitHub Pull Requests, especially since the first level of indentation ends up being just one space due to some bug(?) in how GitHub renders tabs in diffs.