### PR TITLE
backend/docker: change SHM default to 64 MiB

### DIFF
--- a/backend/docker.go
+++ b/backend/docker.go
@@ -34,7 +34,7 @@ var (
 		"CMD":              "command (CMD) to run when creating containers (default \"/sbin/init\")",
 		"EXEC_CMD":         fmt.Sprintf("command to run via exec/ssh (default %q)", defaultExecCmd),
 		"MEMORY":           "memory to allocate to each container (0 disables allocation, default \"4G\")",
-		"SHM":              "/dev/shm to allocate to each container (0 disables allocation, default \"64MB\")",
+		"SHM":              "/dev/shm to allocate to each container (0 disables allocation, default \"64MiB\")",
 		"CPUS":             "cpu count to allocate to each container (0 disables allocation, default 2)",
 		"CPU_SET_SIZE":     "size of available cpu set (default detected locally via runtime.NumCPU)",
 		"NATIVE":           "upload and run build script via docker API instead of over ssh (default false)",


### PR DESCRIPTION
The actual default is defined later to be 64 * 1024 * 1024 bytes:

``` Go
shm := uint64(1024 * 1024 * 64)
```

If it's overriden with SHM, say by saying `SHM=64MB` (which previously was indicated to be the default in the help text, it would go through `humanize.ParseBytes`:

``` Go
if cfg.IsSet("SHM") {
    if parsedShm, err := humanize.ParseBytes(cfg.Get("SHM")); err == nil {
      shm = parsedShm
    }
}
````

`humanize.ParseBytes("64MB")` returns 64 * 1000 * 1000, not 64 * 1024 * 1024, so if you specify `SHM=64MB` you get something other than the default of "64MB". By changing the default in the docs text to "64MiB", the docs default reflects the actual default, as you could pass `SHM=64MiB` and get the same value as the default.

Note that Docker parses numbers differently, so if you pass `--shm=64MB` on the Docker command line, you end up with 64 * 1024 * 1024 bytes.