### PR TITLE
Send the version string to Sentry

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -314,6 +314,8 @@ func (i *CLI) setupSentry() {
 	if err != nil {
 		i.logger.WithField("err", err).Error("couldn't set DSN in raven")
 	}
+
+	raven.SetRelease(VersionString)
 }
 
 func (i *CLI) setupMetrics() {


### PR DESCRIPTION
Sentry includes the version number on the website if its set, so with this we can see what version of worker is generating which errors.