### PR TITLE
Minor changelog fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## [Unreleased]
 
 ## [2.7.0] - 2017-02-08
 ### Added
@@ -412,7 +412,8 @@
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/travis-ci/worker/compare/v2.6.2...HEAD
+[Unreleased]: https://github.com/travis-ci/worker/compare/v2.7.0...HEAD
+[2.7.0]: https://github.com/travis-ci/worker/compare/v2.6.2...v2.7.0
 [2.6.2]: https://github.com/travis-ci/worker/compare/v2.6.1...v2.6.2
 [2.6.1]: https://github.com/travis-ci/worker/compare/v2.6.0...v2.6.1
 [2.6.0]: https://github.com/travis-ci/worker/compare/v2.5.0...v2.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Change Log
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/).
+
 ## [Unreleased]
 ### Added
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## [Unreleased]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+### Security
 
 ## [2.7.0] - 2017-02-08
 ### Added


### PR DESCRIPTION
This adds back the links that I messed up in the 2.7.0 release (I only just learned that the brackets in the headers were meant to be links, I always thought it looked a bit weird).

Also adds a link to [Keep a Changelog](http://keepachangelog.com/), since that's the format we've based the changelog on, and adds the "standard" sub-sections to the unreleased header.