### PR TITLE
Speed up Travis CI builds & re-fetch deps when manifest updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ script:
 - travis_retry make deps
 - make lintall
 - make test
-- make test-race
 - make crossbuild
 - make smoke
 - if [[ $TRAVIS_PULL_REQUEST = 'false' && $DOCKER_LOGIN_PASSWORD && $DOCKER_LOGIN_USERNAME ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ services:
 - docker
 - redis
 
+cache:
+  directories:
+  - vendor
+
 env:
   global:
   - AMQP_URI="amqp://"

--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,6 @@ test: deps lintall build fmtpolice test-no-cover coverage.html
 
 .PHONY: test-no-cover
 test-no-cover:
-	$(GO) test -v -x -ldflags "$(GOBUILD_LDFLAGS)" $(ALL_PACKAGES)
-
-.PHONY: test-race
-test-race: deps
 	$(GO) test -v -race -x -ldflags "$(GOBUILD_LDFLAGS)" $(ALL_PACKAGES)
 
 coverage.html: coverage.coverprofile

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ distclean: clean
 .PHONY: deps
 deps: vendor/.deps-fetched
 
-vendor/.deps-fetched:
+vendor/.deps-fetched: vendor/manifest
 	$(GVT) rebuild
 	touch $@
 


### PR DESCRIPTION
Disables tests without race detection, and changes the Makefile a bit to make sure that `gvt rebuild` is re-run if the manifest has updated since  the last time it was run.