### PR TITLE
amqp-job: add metric for job finishing without state

### DIFF
--- a/amqp_job.go
+++ b/amqp_job.go
@@ -112,6 +112,7 @@ func (j *amqpJob) Finish(ctx gocontext.Context, state FinishState) error {
 	}
 
 	metrics.Mark(fmt.Sprintf("travis.worker.job.finish.%s", state))
+	metrics.Mark("travis.worker.job.finish")
 
 	err := j.sendStateUpdate("job:test:finish", map[string]interface{}{
 		"id":          j.Payload().Job.ID,


### PR DESCRIPTION
This allows us to more easily track how many jobs are finishing on each worker, instead of having to sum the different state metrics.