### PR TITLE
picks up fixes of golang/go#18861

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ addons:
 install:
 - go get github.com/FiloSottile/gvt
 - go get -u github.com/alecthomas/gometalinter
+- go get -u golang.org/x/crypto/ssh
 - gometalinter --install
 - gem install package_cloud --no-ri --no-rdoc
 


### PR DESCRIPTION
## Problem

We've seen lots of errors from Travis worker like this:

```
textPayload: "time="2017-03-14T19:10:57Z" level=error msg="couldn't run script, attempting requeue" completed=false err="couldn't connect to SSH server: couldn't connect to SSH server: ssh: handshake failed: ssh: unexpected message type 3 (expected one of [6])"
```

the build will finally work after requeue build request several times.

I found a fix from https://github.com/golang/go/issues/18861 and that fix stays on master since Feb 8.