### PR TITLE
build: update golang.org/x/crypto/ssh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ services:
 - docker
 - redis
 
-cache:
-  directories:
-  - vendor
-
 env:
   global:
   - AMQP_URI="amqp://"

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -628,7 +628,7 @@
 			"importpath": "golang.org/x/crypto/ssh",
 			"repository": "https://go.googlesource.com/crypto",
 			"vcs": "git",
-			"revision": "bed12803fa9663d7aa2c2346b0c634ad2dcd43b7",
+			"revision": "728b753d0135da6801d45a38e6f43ff55779c5c2",
 			"branch": "master",
 			"path": "/ssh",
 			"notests": true


### PR DESCRIPTION
This pulls in a fix for golang/go#18861.

Fixes #290.