### PR TITLE
Fix panic occuring when AMQP delivery channel is closed

### DIFF
--- a/amqp_job_queue.go
+++ b/amqp_job_queue.go
@@ -69,6 +69,7 @@ func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 
 	go func() {
 		defer channel.Close()
+		defer close(buildJobChan)
 
 		for {
 			if ctx.Err() != nil {

--- a/amqp_job_queue.go
+++ b/amqp_job_queue.go
@@ -78,7 +78,12 @@ func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 			select {
 			case <-ctx.Done():
 				return
-			case delivery := <-deliveries:
+			case delivery, ok := <-deliveries:
+				if !ok {
+					context.LoggerFromContext(ctx).Info("job queue channel closed")
+					return
+				}
+
 				buildJob := &amqpJob{
 					payload:         &JobPayload{},
 					startAttributes: &backend.StartAttributes{},


### PR DESCRIPTION
When the channel is closed, `delivery` would have the zero value, which would fail JSON parsing (since the body is empty), and then panic on `Nack`.