### PR TITLE
/run mounted in container as exec

### DIFF
--- a/backend/docker.go
+++ b/backend/docker.go
@@ -236,7 +236,7 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 		Privileged: p.runPrivileged,
 		Memory:     int64(p.runMemory),
 		ShmSize:    int64(p.runShm),
-		TmpFS:		map[string]string{"/run": "rw,nosuid,nodev,exec,noatime,size=65536k"},
+		Tmpfs:		map[string]string{"/run": "rw,nosuid,nodev,exec,noatime,size=65536k"},
 	}
 
 	if cpuSets != "" {

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -236,6 +236,7 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 		Privileged: p.runPrivileged,
 		Memory:     int64(p.runMemory),
 		ShmSize:    int64(p.runShm),
+		TmpFS:		map[string]string{"/run": "rw,nosuid,nodev,exec,noatime,size=65536k"},
 	}
 
 	if cpuSets != "" {

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -236,7 +236,7 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 		Privileged: p.runPrivileged,
 		Memory:     int64(p.runMemory),
 		ShmSize:    int64(p.runShm),
-		Tmpfs:		map[string]string{"/run": "rw,nosuid,nodev,exec,noatime,size=65536k"},
+		Tmpfs:      map[string]string{"/run": "rw,nosuid,nodev,exec,noatime,size=65536k"},
 	}
 
 	if cpuSets != "" {


### PR DESCRIPTION
Attempts to fix travis-ci/travis-ci/issues/7062 to enable build systems that generate executable contents and data on shm to be able to execute it.

The go-dockerclient supports this https://github.com/fsouza/go-dockerclient/commit/be34fed0d2cfd8c02f8ecb2bebbc7ce1cd3b9c03