### PR TITLE
Ensure str2map does not populate empty keys

### DIFF
--- a/backend/package.go
+++ b/backend/package.go
@@ -106,10 +106,14 @@ func str2map(s string) map[string]string {
 
 	for _, kv := range strings.Split(s, " ") {
 		kvParts := strings.SplitN(kv, ":", 2)
+		key := strings.TrimSpace(kvParts[0])
+		if key == "" {
+			continue
+		}
 		if len(kvParts) == 1 {
-			ret[strings.TrimSpace(kvParts[0])] = ""
+			ret[key] = ""
 		} else {
-			ret[strings.TrimSpace(kvParts[0])] = strings.TrimSpace(kvParts[1])
+			ret[key] = strings.TrimSpace(kvParts[1])
 		}
 	}
 


### PR DESCRIPTION
This fixes an issue with the docker backend, which is currently unusable due to every container start request returning a 500 from the docker API.