### PR TITLE
Batch together HTTP log parts writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ gin-bin
 *.log
 
 *.coverprofile
-coverage.html
+*coverage.html
 
 .*env
 .build/

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ export GO15VENDOREXPERIMENT
 export DOCKER_DEST
 
 COVERPROFILES := \
+	root-coverage.coverprofile \
 	backend-coverage.coverprofile \
 	config-coverage.coverprofile \
 	image-coverage.coverprofile
@@ -41,7 +42,7 @@ CROSSBUILD_BINARIES := \
 %-coverage.coverprofile:
 	$(GO) test -v -covermode=count -coverprofile=$@ \
 		-x -ldflags "$(GOBUILD_LDFLAGS)" \
-		$(PACKAGE)/$(subst -,/,$(subst -coverage.coverprofile,,$@))
+		$(PACKAGE)/$(subst -,/,$(subst root,,$(subst -coverage.coverprofile,,$@)))
 
 .PHONY: %
 %:

--- a/http_log_part_sink.go
+++ b/http_log_part_sink.go
@@ -1,0 +1,145 @@
+package worker
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	gocontext "context"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
+	"github.com/travis-ci/worker/context"
+)
+
+var (
+	defaultHTTPLogPartSink      *httpLogPartSink
+	defaultHTTPLogPartSinkMutex = &sync.Mutex{}
+
+	maxHTTPLogPartSinkBufferSizeErr = fmt.Errorf("log sink buffer size maximum reached")
+)
+
+const (
+	// defaultHTTPLogPartSinkMaxBufferSize of 150 should be roughly 250MB of
+	// buffer on the high end of possible LogChunkSize, which is somewhat
+	// arbitrary, but is an amount of memory per worker process that we can
+	// tolerate on all hosted infrastructures and should allow for enough wiggle
+	// room that we don't hit log sink buffer backpressure unless something is
+	// seriously broken with log parts publishing. ~@meatballhat
+	defaultHTTPLogPartSinkMaxBufferSize = 150
+)
+
+type httpLogPartSink struct {
+	httpClient *http.Client
+	baseURL    string
+	authToken  string
+
+	partsBuffer      []*httpLogPart
+	partsBufferMutex *sync.Mutex
+
+	maxBufferSize uint64
+}
+
+func newHTTPLogPartSink(ctx gocontext.Context, url, authToken string, maxBufferSize uint64) *httpLogPartSink {
+	lps := &httpLogPartSink{
+		httpClient:       &http.Client{},
+		baseURL:          url,
+		authToken:        authToken,
+		partsBuffer:      []*httpLogPart{},
+		partsBufferMutex: &sync.Mutex{},
+		maxBufferSize:    maxBufferSize,
+	}
+
+	go lps.flushRegularly(ctx)
+
+	return lps
+}
+
+func (lps *httpLogPartSink) Add(part *httpLogPart) error {
+	if len(lps.partsBuffer) >= int(lps.maxBufferSize) {
+		return maxHTTPLogPartSinkBufferSizeErr
+	}
+
+	lps.partsBufferMutex.Lock()
+	defer lps.partsBufferMutex.Unlock()
+
+	lps.partsBuffer = append(lps.partsBuffer, part)
+	return nil
+}
+
+func (lps *httpLogPartSink) flushRegularly(ctx gocontext.Context) {
+	ticker := time.NewTicker(LogWriterTick)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			lps.flush(ctx)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (lps *httpLogPartSink) flush(ctx gocontext.Context) {
+	lps.partsBufferMutex.Lock()
+	defer lps.partsBufferMutex.Unlock()
+
+	payload := []*httpLogPartPayload{}
+
+	for _, part := range lps.partsBuffer {
+		payload = append(payload, &httpLogPartPayload{
+			Type:     "log_part",
+			JobID:    part.JobID,
+			Final:    part.Final,
+			Content:  base64.StdEncoding.EncodeToString([]byte(part.Content)),
+			Encoding: "base64",
+		})
+	}
+
+	err := lps.publishLogParts(payload)
+	if err != nil {
+		context.LoggerFromContext(ctx).WithFields(logrus.Fields{
+			"self": "http_log_part_sink",
+			"err":  err,
+		}).Error("failed to publish buffered parts")
+		return
+	}
+
+	lps.partsBuffer = []*httpLogPart{}
+}
+
+func (lps *httpLogPartSink) publishLogParts(payload []*httpLogPartPayload) error {
+	publishURL, err := url.Parse(lps.baseURL)
+	if err != nil {
+		return errors.Wrap(err, "couldn't parse base URL")
+	}
+	publishURL.Path = "/log-parts/multi"
+
+	payloadBody, err := json.Marshal(payload)
+	if err != nil {
+		return errors.Wrap(err, "couldn't marshal JSON")
+	}
+
+	req, err := http.NewRequest("POST", publishURL.String(), bytes.NewReader(payloadBody))
+	if err != nil {
+		return errors.Wrap(err, "couldn't create request")
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", lps.authToken))
+
+	resp, err := lps.httpClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "error making request")
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		return errors.Errorf("expected %d but got %d", http.StatusNoContent, resp.StatusCode)
+	}
+
+	return nil
+}

--- a/http_log_part_sink.go
+++ b/http_log_part_sink.go
@@ -13,7 +13,7 @@ import (
 	gocontext "context"
 
 	"github.com/Sirupsen/logrus"
-	"github.com/cenkalti/backoff"
+	"github.com/cenk/backoff"
 	"github.com/pkg/errors"
 	"github.com/travis-ci/worker/context"
 )

--- a/http_log_part_sink.go
+++ b/http_log_part_sink.go
@@ -69,6 +69,9 @@ func newHTTPLogPartSink(ctx gocontext.Context, url, authToken string, maxBufferS
 }
 
 func (lps *httpLogPartSink) Add(part *httpLogPart) error {
+	lps.partsBufferMutex.Lock()
+	defer lps.partsBufferMutex.Unlock()
+
 	if len(lps.partsBuffer) >= int(lps.maxBufferSize) {
 		// NOTE: This error may deserve special handling at a higher level to do
 		// something like canceling and resetting the job.  The implementation here
@@ -76,9 +79,6 @@ func (lps *httpLogPartSink) Add(part *httpLogPart) error {
 		// assuming the necessary config bits are set.
 		return maxHTTPLogPartSinkBufferSizeErr
 	}
-
-	lps.partsBufferMutex.Lock()
-	defer lps.partsBufferMutex.Unlock()
 
 	lps.partsBuffer = append(lps.partsBuffer, part)
 	return nil

--- a/http_log_part_sink_test.go
+++ b/http_log_part_sink_test.go
@@ -1,0 +1,36 @@
+package worker
+
+import (
+	"testing"
+
+	gocontext "context"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewHTTPLogPartSink(t *testing.T) {
+	ctx, cancel := gocontext.WithCancel(gocontext.TODO())
+	cancel()
+	lps := newHTTPLogPartSink(
+		ctx,
+		"http://example.org/log-parts/multi",
+		"fafafaf",
+		uint64(1000))
+
+	assert.NotNil(t, lps)
+}
+
+func TestHTTPLogPartSink_flush(t *testing.T) {
+	lps := defaultHTTPLogPartSink
+	lps.flush(gocontext.TODO())
+	lps.Add(&httpLogPart{
+		JobID:   uint64(4),
+		Content: "wat",
+		Number:  3,
+		Final:   false,
+	})
+
+	assert.Len(t, lps.partsBuffer, 1)
+	lps.flush(gocontext.TODO())
+	assert.Len(t, lps.partsBuffer, 0)
+}

--- a/http_log_writer.go
+++ b/http_log_writer.go
@@ -114,6 +114,10 @@ func (w *httpLogWriter) Close() error {
 	})
 
 	if err != nil {
+		context.LoggerFromContext(w.ctx).WithFields(logrus.Fields{
+			"err":  err,
+			"self": "http_log_writer",
+		}).Error("could not add log part to sink")
 		return err
 	}
 
@@ -156,6 +160,10 @@ func (w *httpLogWriter) WriteAndClose(p []byte) (int, error) {
 	err = w.lps.Add(part)
 
 	if err != nil {
+		context.LoggerFromContext(w.ctx).WithFields(logrus.Fields{
+			"err":  err,
+			"self": "http_log_writer",
+		}).Error("could not add log part to sink")
 		return n, err
 	}
 	w.logPartNumber++

--- a/http_log_writer_test.go
+++ b/http_log_writer_test.go
@@ -1,0 +1,88 @@
+package worker
+
+import (
+	"testing"
+	"time"
+
+	gocontext "context"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func buildTestHTTPLogWriter() (gocontext.CancelFunc, *httpLogWriter, error) {
+	ctx, cancel := gocontext.WithCancel(gocontext.TODO())
+	hlw, err := newHTTPLogWriter(
+		ctx,
+		"https://jobs.example.org/foo",
+		"fafafaf",
+		1337,
+		time.Second)
+
+	hlw.SetMaxLogLength(100)
+
+	return cancel, hlw, err
+}
+
+func TestNewHTTPLogWriter(t *testing.T) {
+	cancel, hlw, err := buildTestHTTPLogWriter()
+	defer cancel()
+
+	assert.Nil(t, err)
+	assert.NotNil(t, hlw)
+	assert.Implements(t, (*LogWriter)(nil), hlw)
+}
+
+func TestHTTPLogWriter_Write(t *testing.T) {
+	cancel, hlw, err := buildTestHTTPLogWriter()
+	defer cancel()
+
+	assert.NotNil(t, hlw)
+	n, err := hlw.Write([]byte("it's a hot one out there"))
+	assert.Nil(t, err)
+	assert.True(t, hlw.buffer.Len() > 0)
+	assert.True(t, n > 0)
+}
+
+func TestHTTPLogWriter_Write_HitsMaxLogLength(t *testing.T) {
+	cancel, hlw, err := buildTestHTTPLogWriter()
+	defer cancel()
+
+	assert.NotNil(t, hlw)
+
+	hlw.bytesWritten = 1000
+
+	n, err := hlw.Write([]byte("there's a strong wind blowing"))
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestHTTPLogWriter_Write_HitsMaxLogLength_CannotWriteAndClose(t *testing.T) {
+	cancel, hlw, err := buildTestHTTPLogWriter()
+	defer cancel()
+
+	assert.NotNil(t, hlw)
+
+	hlw.bytesWritten = 1000
+	mbs := hlw.lps.maxBufferSize
+	hlw.lps.maxBufferSize = 0
+	defer func() { hlw.lps.maxBufferSize = mbs }()
+
+	n, err := hlw.Write([]byte("looks like rain mmm hmm"))
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestHTTPLogWriter_Write_HitsMaxLogLength_CannotWriteAndClose_LogClosed(t *testing.T) {
+	cancel, hlw, err := buildTestHTTPLogWriter()
+	defer cancel()
+
+	assert.NotNil(t, hlw)
+
+	hlw.bytesWritten = 1000
+	err = hlw.Close()
+	assert.Nil(t, err)
+
+	n, err := hlw.Write([]byte("a storm is a comin"))
+	assert.NotNil(t, err)
+	assert.Equal(t, 0, n)
+}

--- a/package_test.go
+++ b/package_test.go
@@ -2,7 +2,11 @@ package worker
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"time"
+
+	gocontext "context"
 
 	"github.com/Sirupsen/logrus"
 	simplejson "github.com/bitly/go-simplejson"
@@ -11,6 +15,7 @@ import (
 
 func init() {
 	logrus.SetLevel(logrus.FatalLevel)
+	defaultHTTPLogPartSink = buildTestHTTPLogPartSink()
 }
 
 type fakeJobQueue struct {
@@ -95,3 +100,21 @@ func (flw *fakeLogWriter) Timeout() <-chan time.Time {
 }
 
 func (flw *fakeLogWriter) SetMaxLogLength(l int) {}
+
+func buildTestHTTPLogPartSink() *httpLogPartSink {
+	return newHTTPLogPartSink(
+		gocontext.TODO(),
+		buildTestHTTPLogPartSinkServer().URL,
+		"fafafaf",
+		uint64(1000))
+}
+
+func buildTestHTTPLogPartSinkServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && r.URL.Path == "/log-parts/multi" {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.WriteHeader(http.StatusNotImplemented)
+	}))
+}


### PR DESCRIPTION
mostly to cut down a bit on the bulk number of HTTP requests.  I'm guessing that we may want the max batch size to be configurable (?).  **NOTE**: I couldn't find where or how the http log part `UUID` was being used, which is why I dropped it.

- [x] https://github.com/travis-ci/travis-logs/pull/131 is merged
- [x] is this a good idea?
- [x] does it work?
- [x] more tests!

**Update**: This solution explicitly _does not_ increase the size of a given log part because there is a max size restriction imposed by Pusher.  Further explanation is available [here](https://github.com/travis-ci/worker/blob/51222dac0393503fc5a28657e2997273e56d6ca1/log_writer.go#L14-L32)! :heart: