### PR TITLE
Check for context cancellation every loop in http-job-queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 ### Changed
+- http-job-queue: fetch full jobs in series for smoother HTTP traffic
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+- http-job-queue: check for context cancellation every loop
 
 ### Security
 


### PR DESCRIPTION
and fetch the full jobs in series rather than async goroutine parallel
to help with smoothing out HTTP traffic and avoid goroutine leakage
issues.