### PR TITLE
Sort version tags properly

### DIFF
--- a/package/functions.bash
+++ b/package/functions.bash
@@ -66,7 +66,7 @@ __define_with_file_cache() {
 }
 
 __define_version() {
-  __define_with_file_cache VERSION_TAG "git tag | tail -1"
+  __define_with_file_cache VERSION_TAG "git tag -l --sort=v:refname | tail -1"
   __define_with_file_cache VERSION "echo \${VERSION_TAG##v}"
   __define_with_file_cache VERSION_SHA1 \
     "git rev-parse --short --no-abbrev-ref \"\${VERSION_TAG}\""


### PR DESCRIPTION
This patch is for fixing a bug in version handling that happens since version `v2.10.0`. Before the patch the output of `git tag -l` is:

```
[...]
v2.1.0
v2.10.0
v2.2.0
v2.3.0
v2.3.1
[...]
v2.9.1
v2.9.2
v2.9.3
```

So it always takes version `v2.9.3` as the last version.