### PR TITLE
Remove redundant buffering layer in HTTP log handling

### DIFF
--- a/http_log_part_sink.go
+++ b/http_log_part_sink.go
@@ -41,7 +41,7 @@ type httpLogPartEncodedPayload struct {
 	Encoding string `json:"encoding"`
 	Final    bool   `json:"final"`
 	JobID    uint64 `json:"job_id"`
-	Number   int    `json:"number"`
+	Number   uint64 `json:"number"`
 	Token    string `json:"tok"`
 	Type     string `json:"@type"`
 }

--- a/http_log_writer_test.go
+++ b/http_log_writer_test.go
@@ -39,7 +39,6 @@ func TestHTTPLogWriter_Write(t *testing.T) {
 	assert.NotNil(t, hlw)
 	n, err := hlw.Write([]byte("it's a hot one out there"))
 	assert.Nil(t, err)
-	assert.True(t, hlw.buffer.Len() > 0)
 	assert.True(t, n > 0)
 }
 


### PR DESCRIPTION
now that log parts from all processors are buffered together in the log
part sink.