### PR TITLE
Ensure HTTP response bodies are closed in more places

### DIFF
--- a/http_job.go
+++ b/http_job.go
@@ -170,6 +170,9 @@ func (j *httpJob) Finish(ctx gocontext.Context, state FinishState) error {
 				"actual_status":   resp.StatusCode,
 			}).Debug("delete failed")
 
+			if resp.Body != nil {
+				resp.Body.Close()
+			}
 			return errors.Errorf("expected %d but got %d", http.StatusNoContent, resp.StatusCode)
 		}
 
@@ -273,6 +276,8 @@ func (j *httpJob) sendStateUpdate(curState, newState string) error {
 	if err != nil {
 		return errors.Wrap(err, "error making state update request")
 	}
+
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return errors.Errorf("expected %d, but got %d", http.StatusOK, resp.StatusCode)

--- a/http_job_queue.go
+++ b/http_job_queue.go
@@ -244,6 +244,10 @@ func (q *HTTPJobQueue) fetchJob(ctx gocontext.Context, id uint64) (Job, error) {
 				"actual_status":   resp.StatusCode,
 			}).Debug("job fetch failed")
 
+			if resp.Body != nil {
+				resp.Body.Close()
+			}
+
 			return errors.Errorf("expected %d but got %d", http.StatusOK, resp.StatusCode)
 		}
 		return

--- a/http_log_part_sink.go
+++ b/http_log_part_sink.go
@@ -231,6 +231,10 @@ func (lps *httpLogPartSink) publishLogParts(ctx gocontext.Context, payload []*ht
 				"actual_status":   resp.StatusCode,
 			}).Debug("publish failed")
 
+			if resp.Body != nil {
+				resp.Body.Close()
+			}
+
 			return errors.Errorf("expected %d but got %d", http.StatusNoContent, resp.StatusCode)
 		}
 		return


### PR DESCRIPTION
to prevent file descriptor leakage.