### PR TITLE
Send to job queue only when ready

### DIFF
--- a/amqp_canceller.go
+++ b/amqp_canceller.go
@@ -2,9 +2,11 @@ package worker
 
 import (
 	"encoding/json"
+	"fmt"
 
 	gocontext "context"
 
+	"github.com/sirupsen/logrus"
 	"github.com/streadway/amqp"
 	"github.com/travis-ci/worker/context"
 )
@@ -41,7 +43,10 @@ func NewAMQPCanceller(ctx gocontext.Context, conn *amqp.Connection, cancellation
 // start dispatching any incoming commands.
 func (d *AMQPCanceller) Run() {
 	amqpChan, err := d.conn.Channel()
-	logger := context.LoggerFromContext(d.ctx).WithField("self", "amqp_canceller")
+	logger := context.LoggerFromContext(d.ctx).WithFields(logrus.Fields{
+		"self": "amqp_canceller",
+		"inst": fmt.Sprintf("%p", d),
+	})
 	if err != nil {
 		logger.WithField("err", err).Error("couldn't open channel")
 		return
@@ -93,7 +98,10 @@ func (d *AMQPCanceller) Run() {
 
 func (d *AMQPCanceller) processCommand(delivery amqp.Delivery) error {
 	command := &cancelCommand{}
-	logger := context.LoggerFromContext(d.ctx).WithField("self", "amqp_canceller")
+	logger := context.LoggerFromContext(d.ctx).WithFields(logrus.Fields{
+		"self": "amqp_canceller",
+		"inst": fmt.Sprintf("%p", d),
+	})
 	err := json.Unmarshal(delivery.Body, command)
 	if err != nil {
 		logger.WithField("err", err).Error("unable to parse JSON")

--- a/amqp_job.go
+++ b/amqp_job.go
@@ -188,7 +188,7 @@ func (j *amqpJob) sendStateUpdate(ctx gocontext.Context, event, state string) er
 	case err = <-done:
 		return err
 	case <-time.After(timeout):
-		return fmt.Errorf("%v timeout waiting for state update", timeout)
+		return fmt.Errorf("timeout waiting for state update (%v)", timeout)
 	}
 }
 

--- a/amqp_job.go
+++ b/amqp_job.go
@@ -169,6 +169,7 @@ func (j *amqpJob) sendStateUpdate(ctx gocontext.Context, event, state string) er
 		_, err = amqpChan.QueueDeclare("reporting.jobs.builds", true, false, false, false, nil)
 		if err != nil {
 			done <- err
+			return
 		}
 
 		done <- amqpChan.Publish("", "reporting.jobs.builds", false, false, amqp.Publishing{

--- a/amqp_job.go
+++ b/amqp_job.go
@@ -63,7 +63,7 @@ func (j *amqpJob) Requeue(ctx gocontext.Context) error {
 
 	metrics.Mark("worker.job.requeue")
 
-	err := j.sendStateUpdate("job:test:reset", "reset")
+	err := j.sendStateUpdate(ctx, "job:test:reset", "reset")
 	if err != nil {
 		return err
 	}
@@ -71,22 +71,22 @@ func (j *amqpJob) Requeue(ctx gocontext.Context) error {
 	return j.delivery.Ack(false)
 }
 
-func (j *amqpJob) Received() error {
+func (j *amqpJob) Received(ctx gocontext.Context) error {
 	j.received = time.Now()
 
 	if j.payload.Job.QueuedAt != nil {
 		metrics.TimeSince("travis.worker.job.queue_time", *j.payload.Job.QueuedAt)
 	}
 
-	return j.sendStateUpdate("job:test:receive", "received")
+	return j.sendStateUpdate(ctx, "job:test:receive", "received")
 }
 
-func (j *amqpJob) Started() error {
+func (j *amqpJob) Started(ctx gocontext.Context) error {
 	j.started = time.Now()
 
 	metrics.TimeSince("travis.worker.job.start_time", j.received)
 
-	return j.sendStateUpdate("job:test:start", "started")
+	return j.sendStateUpdate(ctx, "job:test:start", "started")
 }
 
 func (j *amqpJob) Finish(ctx gocontext.Context, state FinishState) error {
@@ -107,7 +107,7 @@ func (j *amqpJob) Finish(ctx gocontext.Context, state FinishState) error {
 	metrics.Mark(fmt.Sprintf("travis.worker.job.finish.%s", state))
 	metrics.Mark("travis.worker.job.finish")
 
-	err := j.sendStateUpdate("job:test:finish", string(state))
+	err := j.sendStateUpdate(ctx, "job:test:finish", string(state))
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func (j *amqpJob) createStateUpdateBody(state string) map[string]interface{} {
 	return body
 }
 
-func (j *amqpJob) sendStateUpdate(event, state string) error {
+func (j *amqpJob) sendStateUpdate(ctx gocontext.Context, event, state string) error {
 	amqpChan, err := j.conn.Channel()
 	if err != nil {
 		return err
@@ -164,18 +164,31 @@ func (j *amqpJob) sendStateUpdate(event, state string) error {
 		return err
 	}
 
-	_, err = amqpChan.QueueDeclare("reporting.jobs.builds", true, false, false, false, nil)
-	if err != nil {
-		return err
-	}
+	done := make(chan error)
+	go func() {
+		_, err = amqpChan.QueueDeclare("reporting.jobs.builds", true, false, false, false, nil)
+		if err != nil {
+			done <- err
+		}
 
-	return amqpChan.Publish("", "reporting.jobs.builds", false, false, amqp.Publishing{
-		ContentType:  "application/json",
-		DeliveryMode: amqp.Persistent,
-		Timestamp:    time.Now().UTC(),
-		Type:         event,
-		Body:         bodyBytes,
-	})
+		done <- amqpChan.Publish("", "reporting.jobs.builds", false, false, amqp.Publishing{
+			ContentType:  "application/json",
+			DeliveryMode: amqp.Persistent,
+			Timestamp:    time.Now().UTC(),
+			Type:         event,
+			Body:         bodyBytes,
+		})
+	}()
+
+	timeout := 10 * time.Second
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case err = <-done:
+		return err
+	case <-time.After(timeout):
+		return fmt.Errorf("%v timeout waiting for state update", timeout)
+	}
 }
 
 func (j *amqpJob) Name() string {

--- a/amqp_job_queue.go
+++ b/amqp_job_queue.go
@@ -89,7 +89,6 @@ func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 			case <-ctx.Done():
 				return
 			case <-time.After(time.Second):
-				logger.Debug("timeout waiting for delivery")
 				continue
 			case delivery, ok := <-deliveries:
 				if !ok {

--- a/amqp_job_queue.go
+++ b/amqp_job_queue.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	gocontext "context"
@@ -74,7 +75,10 @@ func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 		defer channel.Close()
 		defer close(buildJobChan)
 
-		logger := context.LoggerFromContext(ctx).WithField("self", "amqp_job_queue")
+		logger := context.LoggerFromContext(ctx).WithFields(logrus.Fields{
+			"self": "amqp_job_queue",
+			"inst": fmt.Sprintf("%p", q),
+		})
 
 		for {
 			if ctx.Err() != nil {

--- a/amqp_job_queue.go
+++ b/amqp_job_queue.go
@@ -85,8 +85,7 @@ func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 			case <-ctx.Done():
 				return
 			case <-time.After(100 * time.Millisecond):
-				logger.Info("timeout waiting for delivery, sending nil job")
-				buildJobChan <- nil
+				logger.Info("timeout waiting for delivery")
 				continue
 			case delivery, ok := <-deliveries:
 				if !ok {

--- a/amqp_job_queue.go
+++ b/amqp_job_queue.go
@@ -84,7 +84,7 @@ func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(100 * time.Millisecond):
+			case <-time.After(time.Second):
 				logger.Debug("timeout waiting for delivery")
 				continue
 			case delivery, ok := <-deliveries:

--- a/amqp_job_queue.go
+++ b/amqp_job_queue.go
@@ -85,7 +85,7 @@ func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 			case <-ctx.Done():
 				return
 			case <-time.After(100 * time.Millisecond):
-				logger.Info("timeout waiting for delivery")
+				logger.Debug("timeout waiting for delivery")
 				continue
 			case delivery, ok := <-deliveries:
 				if !ok {

--- a/amqp_job_test.go
+++ b/amqp_job_test.go
@@ -152,7 +152,7 @@ func TestAMQPJob_Requeue(t *testing.T) {
 func TestAMQPJob_Received(t *testing.T) {
 	job := newTestAMQPJob(t)
 
-	err := job.Received()
+	err := job.Received(gocontext.TODO())
 	if err != nil {
 		t.Error(err)
 	}
@@ -161,7 +161,7 @@ func TestAMQPJob_Received(t *testing.T) {
 func TestAMQPJob_Started(t *testing.T) {
 	job := newTestAMQPJob(t)
 
-	err := job.Started()
+	err := job.Started(gocontext.TODO())
 	if err != nil {
 		t.Error(err)
 	}

--- a/amqp_log_writer.go
+++ b/amqp_log_writer.go
@@ -90,7 +90,10 @@ func (w *amqpLogWriter) Write(p []byte) (int, error) {
 		return 0, fmt.Errorf("attempted write to closed log")
 	}
 
-	logger := context.LoggerFromContext(w.ctx).WithField("self", "amqp_log_writer")
+	logger := context.LoggerFromContext(w.ctx).WithFields(logrus.Fields{
+		"self": "amqp_log_writer",
+		"inst": fmt.Sprintf("%p", w),
+	})
 
 	logger.WithFields(logrus.Fields{
 		"length": len(p),
@@ -205,7 +208,10 @@ func (w *amqpLogWriter) flush() {
 	}
 
 	buf := make([]byte, LogChunkSize)
-	logger := context.LoggerFromContext(w.ctx).WithField("self", "amqp_log_writer")
+	logger := context.LoggerFromContext(w.ctx).WithFields(logrus.Fields{
+		"self": "amqp_log_writer",
+		"inst": fmt.Sprintf("%p", w),
+	})
 
 	for w.buffer.Len() > 0 {
 		w.bufferMutex.Lock()

--- a/context/package.go
+++ b/context/package.go
@@ -25,6 +25,7 @@ const (
 	componentKey
 	jobIDKey
 	repositoryKey
+	jwtKey
 )
 
 // FromUUID generates a new context with the given context as its parent and
@@ -53,6 +54,13 @@ func FromComponent(ctx context.Context, component string) context.Context {
 // using JobIDFromContext.
 func FromJobID(ctx context.Context, jobID uint64) context.Context {
 	return context.WithValue(ctx, jobIDKey, jobID)
+}
+
+// FromJWT generates a new context with the given context as its parent and
+// stores the given JWT with the context. The JWT can be retrieved again using
+// JWTFromContext.
+func FromJWT(ctx context.Context, jwt string) context.Context {
+	return context.WithValue(ctx, jwtKey, jwt)
 }
 
 // FromRepository generates a new context with the given context as its parent
@@ -92,6 +100,14 @@ func ComponentFromContext(ctx context.Context) (string, bool) {
 func JobIDFromContext(ctx context.Context) (uint64, bool) {
 	jobID, ok := ctx.Value(jobIDKey).(uint64)
 	return jobID, ok
+}
+
+// JWTFromContext returns the jwt stored in the context with FromJWT. If no jwt
+// was stored in the context, the second argument is false. Otherwise it is
+// true.
+func JWTFromContext(ctx context.Context) (string, bool) {
+	jwt, ok := ctx.Value(jwtKey).(string)
+	return jwt, ok
 }
 
 // RepositoryFromContext returns the repository name stored in the context with

--- a/file_job.go
+++ b/file_job.go
@@ -40,11 +40,11 @@ func (j *fileJob) StartAttributes() *backend.StartAttributes {
 	return j.startAttributes
 }
 
-func (j *fileJob) Received() error {
+func (j *fileJob) Received(_ gocontext.Context) error {
 	return os.Rename(j.createdFile, j.receivedFile)
 }
 
-func (j *fileJob) Started() error {
+func (j *fileJob) Started(_ gocontext.Context) error {
 	return os.Rename(j.receivedFile, j.startedFile)
 }
 

--- a/file_job_queue.go
+++ b/file_job_queue.go
@@ -75,22 +75,22 @@ func NewFileJobQueue(baseDir, queue string, pollingInterval time.Duration) (*Fil
 }
 
 // Jobs returns a channel of jobs from the created directory
-func (f *FileJobQueue) Jobs(ctx gocontext.Context, ready <-chan struct{}) (<-chan Job, error) {
+func (f *FileJobQueue) Jobs(ctx gocontext.Context) (<-chan Job, error) {
 	if f.buildJobChan == nil {
 		f.buildJobChan = make(chan Job)
-		go f.pollInDirForJobs(ctx, ready)
+		go f.pollInDirForJobs(ctx)
 	}
 	return f.buildJobChan, nil
 }
 
-func (f *FileJobQueue) pollInDirForJobs(ctx gocontext.Context, ready <-chan struct{}) {
+func (f *FileJobQueue) pollInDirForJobs(ctx gocontext.Context) {
 	for {
-		f.pollInDirTick(ctx, ready)
+		f.pollInDirTick(ctx)
 		time.Sleep(f.pollingInterval)
 	}
 }
 
-func (f *FileJobQueue) pollInDirTick(ctx gocontext.Context, ready <-chan struct{}) {
+func (f *FileJobQueue) pollInDirTick(ctx gocontext.Context) {
 	logger := context.LoggerFromContext(ctx).WithField("self", "file_job_queue")
 	entries, err := ioutil.ReadDir(f.createdDir)
 	if err != nil {
@@ -148,7 +148,6 @@ func (f *FileJobQueue) pollInDirTick(ctx gocontext.Context, ready <-chan struct{
 		buildJob.logFile = filepath.Join(f.logDir, strings.Replace(entry.Name(), ".json", ".log", -1))
 		buildJob.bytes = fb
 
-		<-ready
 		f.buildJobChan <- buildJob
 	}
 }

--- a/http_job.go
+++ b/http_job.go
@@ -113,7 +113,7 @@ func (j *httpJob) Received(ctx gocontext.Context) error {
 	j.received = time.Now()
 	if j.refreshClaim != nil {
 		context.LoggerFromContext(ctx).WithField("self", "http_job").Debug("starting claim refresh goroutine")
-		go j.refreshClaim(ctx)
+		go j.refreshClaim(context.FromJWT(ctx, j.payload.JWT))
 	}
 	return j.sendStateUpdate(ctx, "queued", "received")
 }

--- a/http_job.go
+++ b/http_job.go
@@ -31,6 +31,8 @@ type httpJob struct {
 	finished        time.Time
 	stateCount      uint
 
+	refreshClaim func(gocontext.Context)
+
 	jobBoardURL *url.URL
 	site        string
 	workerID    string
@@ -104,20 +106,23 @@ func (j *httpJob) Requeue(ctx gocontext.Context) error {
 	j.received = time.Time{}
 	j.started = time.Time{}
 
-	return j.sendStateUpdate(j.currentState(), "created")
+	return j.sendStateUpdate(ctx, j.currentState(), "created")
 }
 
-func (j *httpJob) Received() error {
+func (j *httpJob) Received(ctx gocontext.Context) error {
 	j.received = time.Now()
-	return j.sendStateUpdate("queued", "received")
+	if j.refreshClaim != nil {
+		go j.refreshClaim(ctx)
+	}
+	return j.sendStateUpdate(ctx, "queued", "received")
 }
 
-func (j *httpJob) Started() error {
+func (j *httpJob) Started(ctx gocontext.Context) error {
 	j.started = time.Now()
 
 	metrics.TimeSince("travis.worker.job.start_time", j.received)
 
-	return j.sendStateUpdate("received", "started")
+	return j.sendStateUpdate(ctx, "received", "started")
 }
 
 func (j *httpJob) currentState() string {
@@ -208,7 +213,7 @@ func (j *httpJob) Finish(ctx gocontext.Context, state FinishState) error {
 		j.started = j.finished
 	}
 
-	return j.sendStateUpdate(j.currentState(), string(state))
+	return j.sendStateUpdate(ctx, j.currentState(), string(state))
 }
 
 func (j *httpJob) LogWriter(ctx gocontext.Context, defaultLogTimeout time.Duration) (LogWriter, error) {
@@ -233,7 +238,7 @@ func (j *httpJob) Generate(ctx gocontext.Context, job Job) ([]byte, error) {
 	return script, nil
 }
 
-func (j *httpJob) sendStateUpdate(curState, newState string) error {
+func (j *httpJob) sendStateUpdate(ctx gocontext.Context, curState, newState string) error {
 	j.stateCount++
 	payload := &httpJobStateUpdate{
 		CurrentState: curState,
@@ -268,6 +273,7 @@ func (j *httpJob) sendStateUpdate(curState, newState string) error {
 	if err != nil {
 		return errors.Wrap(err, "couldn't create request")
 	}
+	req = req.WithContext(ctx)
 
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", j.payload.JWT))
 	req.Header.Set("Content-Type", "application/json")

--- a/http_job_queue.go
+++ b/http_job_queue.go
@@ -1,7 +1,6 @@
 package worker
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -22,8 +21,8 @@ import (
 )
 
 var (
-	httpJobQueueNoJobsErr = fmt.Errorf("no jobs available")
-	mismatchedJobIDErr    = fmt.Errorf("returned job ID does not match expected")
+	httpJobQueueNoJobsErr  = fmt.Errorf("no jobs available")
+	httpJobRefreshClaimErr = fmt.Errorf("failed to refresh claim")
 )
 
 // HTTPJobQueue is a JobQueue that uses http
@@ -76,9 +75,16 @@ func (q *HTTPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 	})
 
 	go func() {
+		defer close(buildJobChan)
+
 		for {
 			logger.Debug("polling for job tick")
-			if !q.pollForJob(ctx, buildJobChan) {
+			keepPolling, readyChan := q.pollForJob(ctx, buildJobChan)
+			if readyChan != nil {
+				logger.Debug("blocking on ready channel recv")
+				<-readyChan
+			}
+			if !keepPolling {
 				return
 			}
 			time.Sleep(q.pollInterval)
@@ -88,7 +94,7 @@ func (q *HTTPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 	return outChan, nil
 }
 
-func (q *HTTPJobQueue) pollForJob(ctx gocontext.Context, buildJobChan chan Job) bool {
+func (q *HTTPJobQueue) pollForJob(ctx gocontext.Context, buildJobChan chan Job) (bool, <-chan struct{}) {
 	logger := context.LoggerFromContext(ctx).WithFields(logrus.Fields{
 		"self": "http_job_queue",
 		"inst": fmt.Sprintf("%p", q),
@@ -98,16 +104,16 @@ func (q *HTTPJobQueue) pollForJob(ctx gocontext.Context, buildJobChan chan Job) 
 	jobID, err := q.fetchJobID(ctx)
 	if err != nil {
 		logger.WithField("err", err).Debug("continuing after failing to get job id")
-		return true
+		return true, nil
 	}
 	logger.WithField("job_id", jobID).Debug("fetching complete job")
-	buildJob, err := q.fetchJob(ctx, jobID)
+	buildJob, readyChan, err := q.fetchJob(ctx, jobID)
 	if err != nil {
 		logger.WithFields(logrus.Fields{
 			"err": err,
 			"id":  jobID,
 		}).Warn("failed to get complete job")
-		return true
+		return true, nil
 	}
 
 	logger.WithField("job_id", jobID).Debug("sending job to output channel")
@@ -119,31 +125,14 @@ func (q *HTTPJobQueue) pollForJob(ctx gocontext.Context, buildJobChan chan Job) 
 			"source": "http",
 			"dur":    time.Since(jobSendBegin),
 		}).Info("sent job to output channel")
-		return true
+		return true, readyChan
 	case <-ctx.Done():
 		logger.WithField("err", ctx.Err()).Warn("returning from jobs loop due to context done")
-		return false
+		return false, nil
 	}
 }
 
 func (q *HTTPJobQueue) fetchJobID(ctx gocontext.Context) (uint64, error) {
-	return q.postJobs(ctx, []string{})
-}
-
-func (q *HTTPJobQueue) refreshJobClaim(ctx gocontext.Context, jobID uint64) error {
-	fetchedID, err := q.postJobs(ctx, []string{strconv.Itoa(int(jobID))})
-	if err != nil {
-		return err
-	}
-
-	if fetchedID != jobID {
-		return mismatchedJobIDErr
-	}
-
-	return nil
-}
-
-func (q *HTTPJobQueue) postJobs(ctx gocontext.Context, jobIDs []string) (uint64, error) {
 	logger := context.LoggerFromContext(ctx).WithFields(logrus.Fields{
 		"self": "http_job_queue",
 		"inst": fmt.Sprintf("%p", q),
@@ -153,24 +142,20 @@ func (q *HTTPJobQueue) postJobs(ctx gocontext.Context, jobIDs []string) (uint64,
 	if !ok {
 		processorID = "unknown-processor"
 	}
-	jobIDsJSON, err := json.Marshal(&httpFetchJobsRequest{Jobs: jobIDs})
-	if err != nil {
-		return 0, errors.Wrap(err, "failed to marshal job-board jobs request payload")
-	}
 
 	u := *q.jobBoardURL
 
 	query := u.Query()
 	query.Add("queue", q.queue)
 
-	u.Path = "/jobs"
+	u.Path = "/jobs/pop"
 	u.RawQuery = query.Encode()
 
 	client := &http.Client{}
 
-	req, err := http.NewRequest("POST", u.String(), bytes.NewReader(jobIDsJSON))
+	req, err := http.NewRequest("POST", u.String(), nil)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to create job-board jobs request")
+		return 0, errors.Wrap(err, "failed to create job-board job pop request")
 	}
 
 	req.Header.Add("Content-Type", "application/json")
@@ -180,30 +165,78 @@ func (q *HTTPJobQueue) postJobs(ctx gocontext.Context, jobIDs []string) (uint64,
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to make job-board jobs request")
+		return 0, errors.Wrap(err, "failed to make job-board job pop request")
 	}
 
 	defer resp.Body.Close()
-	fetchResponsePayload := &httpFetchJobsResponse{}
-	err = json.NewDecoder(resp.Body).Decode(&fetchResponsePayload)
-	if err != nil {
-		return 0, errors.Wrap(err, "failed to decode job-board jobs response")
-	}
 
-	logger.WithField("jobs", fetchResponsePayload.Jobs).Debug("fetched")
-	if len(fetchResponsePayload.Jobs) == 0 {
+	if resp.StatusCode == http.StatusNoContent {
 		return 0, httpJobQueueNoJobsErr
 	}
 
-	jobID, err := strconv.ParseUint(fetchResponsePayload.Jobs[0], 10, 64)
+	fetchResponsePayload := map[string]string{"job_id": ""}
+	err = json.NewDecoder(resp.Body).Decode(&fetchResponsePayload)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to decode job-board job pop response")
+	}
+
+	fetchedJobID, err := strconv.ParseUint(fetchResponsePayload["job_id"], 10, 64)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to parse job ID")
 	}
 
-	return jobID, nil
+	logger.WithField("job_id", fetchedJobID).Debug("fetched")
+	return fetchedJobID, nil
 }
 
-func (q *HTTPJobQueue) fetchJob(ctx gocontext.Context, jobID uint64) (Job, error) {
+func (q *HTTPJobQueue) refreshJobClaim(ctx gocontext.Context, jobID uint64) error {
+	logger := context.LoggerFromContext(ctx).WithFields(logrus.Fields{
+		"self":   "http_job_queue",
+		"job_id": jobID,
+		"inst":   fmt.Sprintf("%p", q),
+	})
+
+	processorID, ok := context.ProcessorFromContext(ctx)
+	if !ok {
+		processorID = "unknown-processor"
+	}
+
+	u := *q.jobBoardURL
+
+	query := u.Query()
+	query.Add("queue", q.queue)
+
+	u.Path = fmt.Sprintf("/jobs/%v/claim", jobID)
+	u.RawQuery = query.Encode()
+
+	client := &http.Client{}
+
+	req, err := http.NewRequest("POST", u.String(), nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to create job-board job claim request")
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Travis-Site", q.site)
+	req.Header.Add("From", processorID)
+	req = req.WithContext(ctx)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "failed to make job-board job claim request")
+	}
+
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		logger.WithField("response_code", resp.StatusCode).Debug("non-200 response code")
+		return httpJobRefreshClaimErr
+	}
+
+	logger.Debug("refreshed claim")
+	return nil
+}
+
+func (q *HTTPJobQueue) fetchJob(ctx gocontext.Context, jobID uint64) (Job, <-chan struct{}, error) {
 	logger := context.LoggerFromContext(ctx).WithFields(logrus.Fields{
 		"self": "http_job_queue",
 		"inst": fmt.Sprintf("%p", q),
@@ -214,13 +247,15 @@ func (q *HTTPJobQueue) fetchJob(ctx gocontext.Context, jobID uint64) (Job, error
 		processorID = "unknown-processor"
 	}
 
+	refreshClaimFunc, readyChan := q.generateJobRefreshClaimFunc(jobID)
+
 	buildJob := &httpJob{
 		payload: &httpJobPayload{
 			Data: &JobPayload{},
 		},
 		startAttributes: &backend.StartAttributes{},
 
-		refreshClaim: q.generateJobRefreshClaimFunc(jobID),
+		refreshClaim: refreshClaimFunc,
 
 		jobBoardURL: q.jobBoardURL,
 		site:        q.site,
@@ -237,7 +272,7 @@ func (q *HTTPJobQueue) fetchJob(ctx gocontext.Context, jobID uint64) (Job, error
 
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "couldn't make job-board job request")
+		return nil, nil, errors.Wrap(err, "couldn't make job-board job request")
 	}
 
 	// TODO: ensure infrastructure is not synonymous with providerName since
@@ -271,28 +306,28 @@ func (q *HTTPJobQueue) fetchJob(ctx gocontext.Context, jobID uint64) (Job, error
 	}, bo)
 
 	if err != nil {
-		return nil, errors.Wrap(err, "error making job-board job request")
+		return nil, nil, errors.Wrap(err, "error making job-board job request")
 	}
 
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, errors.Wrap(err, "error reading body from job-board job request")
+		return nil, nil, errors.Wrap(err, "error reading body from job-board job request")
 	}
 
 	err = json.Unmarshal(body, buildJob.payload)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal job-board payload")
+		return nil, nil, errors.Wrap(err, "failed to unmarshal job-board payload")
 	}
 
 	err = json.Unmarshal(body, &startAttrs)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal start attributes from job-board")
+		return nil, nil, errors.Wrap(err, "failed to unmarshal start attributes from job-board")
 	}
 
 	rawPayload, err := simplejson.NewJson(body)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse raw payload with simplejson")
+		return nil, nil, errors.Wrap(err, "failed to parse raw payload with simplejson")
 	}
 	buildJob.rawPayload = rawPayload.Get("data")
 
@@ -300,14 +335,21 @@ func (q *HTTPJobQueue) fetchJob(ctx gocontext.Context, jobID uint64) (Job, error
 	buildJob.startAttributes.VMType = buildJob.payload.Data.VMType
 	buildJob.startAttributes.SetDefaults(q.DefaultLanguage, q.DefaultDist, q.DefaultGroup, q.DefaultOS, VMTypeDefault)
 
-	return buildJob, nil
+	return buildJob, readyChan, nil
 }
 
-func (q *HTTPJobQueue) generateJobRefreshClaimFunc(jobID uint64) func(gocontext.Context) {
+func (q *HTTPJobQueue) generateJobRefreshClaimFunc(jobID uint64) (func(gocontext.Context), <-chan struct{}) {
+	readyChan := make(chan struct{})
+
 	return func(ctx gocontext.Context) {
+		defer func() {
+			readyChan <- struct{}{}
+			close(readyChan)
+		}()
+
 		for {
 			err := q.refreshJobClaim(ctx, jobID)
-			if err == httpJobQueueNoJobsErr {
+			if err == httpJobRefreshClaimErr {
 				context.LoggerFromContext(ctx).WithFields(logrus.Fields{
 					"err":    err,
 					"job_id": jobID,
@@ -328,7 +370,7 @@ func (q *HTTPJobQueue) generateJobRefreshClaimFunc(jobID uint64) func(gocontext.
 			case <-time.After(q.pollInterval):
 			}
 		}
-	}
+	}, (<-chan struct{})(readyChan)
 }
 
 // Name returns the name of this queue type, wow!

--- a/http_job_queue.go
+++ b/http_job_queue.go
@@ -85,7 +85,10 @@ func NewHTTPJobQueue(processors ProcessorEacherSizer, jobBoardURL *url.URL, site
 func (q *HTTPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err error) {
 	buildJobChan := make(chan Job)
 	outChan = buildJobChan
-	logger := context.LoggerFromContext(ctx).WithField("self", "http_job_queue")
+	logger := context.LoggerFromContext(ctx).WithFields(logrus.Fields{
+		"self": "http_job_queue",
+		"inst": fmt.Sprintf("%p", q),
+	})
 
 	go func() {
 		for {
@@ -105,7 +108,11 @@ func (q *HTTPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 }
 
 func (q *HTTPJobQueue) pollForJob(ctx gocontext.Context, buildJobChan chan Job) httpPollState {
-	logger := context.LoggerFromContext(ctx).WithField("self", "http_job_queue")
+	logger := context.LoggerFromContext(ctx).WithFields(logrus.Fields{
+		"self": "http_job_queue",
+		"inst": fmt.Sprintf("%p", q),
+	})
+
 	logger.Debug("fetching job id")
 	jobID, err := q.fetchJobID(ctx, 1, []uint64{})
 	if err != nil {
@@ -139,7 +146,11 @@ func (q *HTTPJobQueue) pollForJob(ctx gocontext.Context, buildJobChan chan Job) 
 }
 
 func (q *HTTPJobQueue) fetchJobID(ctx gocontext.Context, desired uint64, running []uint64) (uint64, error) {
-	logger := context.LoggerFromContext(ctx).WithField("self", "http_job_queue")
+	logger := context.LoggerFromContext(ctx).WithFields(logrus.Fields{
+		"self": "http_job_queue",
+		"inst": fmt.Sprintf("%p", q),
+	})
+
 	processorName, ok := context.ProcessorFromContext(ctx)
 	if !ok {
 		processorName = "unknown-processor"
@@ -218,7 +229,11 @@ func (q *HTTPJobQueue) fetchJobID(ctx gocontext.Context, desired uint64, running
 }
 
 func (q *HTTPJobQueue) fetchJob(ctx gocontext.Context, id uint64) (Job, error) {
-	logger := context.LoggerFromContext(ctx).WithField("self", "http_job_queue")
+	logger := context.LoggerFromContext(ctx).WithFields(logrus.Fields{
+		"self": "http_job_queue",
+		"inst": fmt.Sprintf("%p", q),
+	})
+
 	processorName, ok := context.ProcessorFromContext(ctx)
 	if !ok {
 		processorName = "unknown-processor"

--- a/http_job_queue.go
+++ b/http_job_queue.go
@@ -92,7 +92,8 @@ func (q *HTTPJobQueue) Jobs(ctx gocontext.Context, ready <-chan struct{}) (outCh
 							logger.WithFields(logrus.Fields{
 								"err": err,
 								"id":  id,
-							}).Warn("failed to get complete job")
+							}).Warn("failed to get complete job, sending nil job")
+							buildJobChan <- nil
 						} else {
 							jobSendBegin := time.Now()
 							buildJobChan <- buildJob
@@ -113,6 +114,7 @@ func (q *HTTPJobQueue) Jobs(ctx gocontext.Context, ready <-chan struct{}) (outCh
 				logger.WithField("err", ctx.Err()).Warn("returning from jobs loop due to context done")
 				q.buildJobChan = nil
 				return
+			default:
 			}
 		}
 	}()

--- a/http_job_queue.go
+++ b/http_job_queue.go
@@ -81,8 +81,10 @@ func (q *HTTPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 			logger.Debug("polling for job tick")
 			keepPolling, readyChan := q.pollForJob(ctx, buildJobChan)
 			if readyChan != nil {
+				readyWaitBegin := time.Now()
 				logger.Debug("blocking on ready channel recv")
 				<-readyChan
+				metrics.TimeSince("travis.worker.job_queue.http.ready_wait_time", readyWaitBegin)
 			}
 			if !keepPolling {
 				return

--- a/http_job_queue_test.go
+++ b/http_job_queue_test.go
@@ -22,8 +22,12 @@ func TestHTTPJobQueue(t *testing.T) {
 
 func TestHTTPJobQueue_Jobs(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc(`/jobs`, func(w http.ResponseWriter, req *http.Request) {
-		fmt.Fprintf(w, `{"jobs":["100001"]}`)
+	mux.HandleFunc(`/jobs/pop`, func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `{"job_id":"100001"}`)
+	})
+	mux.HandleFunc(`/jobs/100001/claim`, func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
 	})
 	mux.HandleFunc(`/jobs/100001`, func(w http.ResponseWriter, req *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/http_job_queue_test.go
+++ b/http_job_queue_test.go
@@ -95,21 +95,10 @@ func TestHTTPJobQueue_Jobs(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, hjq)
 
-	ready := make(chan struct{})
 	ctx := gocontext.TODO()
-	buildJobChan, err := hjq.Jobs(ctx, (<-chan struct{})(ready))
+	buildJobChan, err := hjq.Jobs(ctx)
 	assert.Nil(t, err)
 	assert.NotNil(t, buildJobChan)
-
-	buildJobChan2, err := hjq.Jobs(ctx, (<-chan struct{})(ready))
-	assert.Nil(t, err)
-	assert.Equal(t, buildJobChan, buildJobChan2)
-
-	select {
-	case ready <- struct{}{}:
-	case <-time.After(time.Second):
-		t.Fatalf("failed to send ready")
-	}
 
 	select {
 	case job := <-buildJobChan:

--- a/http_job_queue_test.go
+++ b/http_job_queue_test.go
@@ -1,0 +1,132 @@
+package worker
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	gocontext "context"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeHTTPProcessors struct {
+	processors []*Processor
+}
+
+func (fhp *fakeHTTPProcessors) Each(f func(i int, p *Processor)) {
+	procIDs := []string{}
+	procsByID := map[string]*Processor{}
+
+	for _, proc := range fhp.processors {
+		id := proc.ID.String()
+		procIDs = append(procIDs, id)
+		procsByID[id] = proc
+	}
+
+	sort.Strings(procIDs)
+
+	for i, procID := range procIDs {
+		f(i, procsByID[procID])
+	}
+}
+
+func (fhp *fakeHTTPProcessors) Size() int {
+	return len(fhp.processors)
+}
+
+func TestHTTPJobQueue(t *testing.T) {
+	hjq, err := NewHTTPJobQueue(nil, nil, "test", "fake", "fake", "test-worker-9001")
+	assert.Nil(t, err)
+	assert.NotNil(t, hjq)
+}
+
+func TestHTTPJobQueue_Jobs(t *testing.T) {
+	processors := &fakeHTTPProcessors{processors: []*Processor{
+		&Processor{CurrentStatus: "new"},
+		&Processor{CurrentStatus: "waiting", LastJobID: uint64(99998)},
+		&Processor{CurrentStatus: "processing", LastJobID: uint64(99999)},
+	}}
+	mux := http.NewServeMux()
+	mux.HandleFunc(`/jobs`, func(w http.ResponseWriter, req *http.Request) {
+		fmt.Fprintf(w, `{"jobs":["100001"]}`)
+	})
+	mux.HandleFunc(`/jobs/100001`, func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, strings.Replace(`{
+			"data": {
+				"type": "job",
+				"job": {
+					"id": 100001,
+					"number": "42.1",
+					"queued_at": "2011-04-01T11:05:55Z"
+				},
+				"source": {
+					"id": 100001,
+					"number": "42"
+				},
+				"repository": {
+					"id": 8490324,
+					"slug": "travis-ci/nonexistent-repository"
+				},
+				"uuid": "fafafaf",
+				"config": {},
+				"vm_type": "test",
+				"meta": {
+					"state_update_count": 0
+				}
+			}
+		}`, "\t", "  ", -1))
+	})
+
+	mux.HandleFunc(`/`, func(w http.ResponseWriter, req *http.Request) {
+		t.Fatalf("unknown URL requested: %#v", req.URL.Path)
+	})
+	jobBoardServer := httptest.NewServer(mux)
+	defer jobBoardServer.Close()
+
+	jobBoardURL, _ := url.Parse(jobBoardServer.URL)
+	hjq, err := NewHTTPJobQueue(processors, jobBoardURL, "test", "fake", "fake", "test-worker-9001")
+	assert.Nil(t, err)
+	assert.NotNil(t, hjq)
+
+	ready := make(chan struct{})
+	ctx := gocontext.TODO()
+	buildJobChan, err := hjq.Jobs(ctx, (<-chan struct{})(ready))
+	assert.Nil(t, err)
+	assert.NotNil(t, buildJobChan)
+
+	buildJobChan2, err := hjq.Jobs(ctx, (<-chan struct{})(ready))
+	assert.Nil(t, err)
+	assert.Equal(t, buildJobChan, buildJobChan2)
+
+	select {
+	case ready <- struct{}{}:
+	case <-time.After(time.Second):
+		t.Fatalf("failed to send ready")
+	}
+
+	select {
+	case job := <-buildJobChan:
+		assert.NotNil(t, job)
+	case <-time.After(time.Second):
+		t.Fatalf("failed to recv job")
+	}
+}
+
+func TestHTTPJobQueue_Name(t *testing.T) {
+	hjq, err := NewHTTPJobQueue(nil, nil, "test", "fake", "fake", "test-worker-9001")
+	assert.Nil(t, err)
+	assert.Equal(t, "http", hjq.Name())
+}
+
+func TestHTTPJobQueue_Cleanup(t *testing.T) {
+	hjq, err := NewHTTPJobQueue(nil, nil, "test", "fake", "fake", "test-worker-9001")
+	assert.Nil(t, err)
+	assert.Nil(t, hjq.Cleanup())
+}

--- a/http_job_test.go
+++ b/http_job_test.go
@@ -63,8 +63,8 @@ func newTestHTTPJob(t *testing.T) *httpJob {
 		rawPayload:      rawPayload,
 		startAttributes: startAttributes,
 
-		site:     "test",
-		workerID: "whee",
+		site:        "test",
+		processorID: "whee",
 	}
 }
 

--- a/http_job_test.go
+++ b/http_job_test.go
@@ -145,7 +145,7 @@ func TestHTTPJob_Received(t *testing.T) {
 	job.payload.JobPartsURL = ts.URL
 	job.jobBoardURL, _ = url.Parse(ts.URL)
 
-	err := job.Received()
+	err := job.Received(gocontext.TODO())
 	if err != nil {
 		t.Error(err)
 	}
@@ -161,7 +161,7 @@ func TestHTTPJob_Started(t *testing.T) {
 	job.payload.JobPartsURL = ts.URL
 	job.jobBoardURL, _ = url.Parse(ts.URL)
 
-	err := job.Started()
+	err := job.Started(gocontext.TODO())
 	if err != nil {
 		t.Error(err)
 	}

--- a/http_log_writer.go
+++ b/http_log_writer.go
@@ -55,7 +55,10 @@ func (w *httpLogWriter) Write(p []byte) (int, error) {
 		return 0, fmt.Errorf("attempted write to closed log")
 	}
 
-	logger := context.LoggerFromContext(w.ctx).WithField("self", "http_log_writer")
+	logger := context.LoggerFromContext(w.ctx).WithFields(logrus.Fields{
+		"self": "http_log_writer",
+		"inst": fmt.Sprintf("%p", w),
+	})
 
 	logger.WithFields(logrus.Fields{
 		"length": len(p),

--- a/job.go
+++ b/job.go
@@ -85,8 +85,8 @@ type Job interface {
 	RawPayload() *simplejson.Json
 	StartAttributes() *backend.StartAttributes
 
-	Received() error
-	Started() error
+	Received(gocontext.Context) error
+	Started(gocontext.Context) error
 	Error(gocontext.Context, string) error
 	Requeue(gocontext.Context) error
 	Finish(gocontext.Context, FinishState) error

--- a/job_queue.go
+++ b/job_queue.go
@@ -6,7 +6,7 @@ import (
 
 // JobQueue is the minimal interface needed by a ProcessorPool
 type JobQueue interface {
-	Jobs(gocontext.Context) (<-chan Job, error)
+	Jobs(gocontext.Context, <-chan struct{}) (<-chan Job, error)
 	Name() string
 	Cleanup() error
 }

--- a/job_queue.go
+++ b/job_queue.go
@@ -6,7 +6,7 @@ import (
 
 // JobQueue is the minimal interface needed by a ProcessorPool
 type JobQueue interface {
-	Jobs(gocontext.Context, <-chan struct{}) (<-chan Job, error)
+	Jobs(gocontext.Context) (<-chan Job, error)
 	Name() string
 	Cleanup() error
 }

--- a/multi_source_job_queue.go
+++ b/multi_source_job_queue.go
@@ -21,18 +21,16 @@ func NewMultiSourceJobQueue(queues ...JobQueue) *MultiSourceJobQueue {
 }
 
 // Jobs returns a Job channel that selects over each source queue Job channel
-func (msjq *MultiSourceJobQueue) Jobs(ctx gocontext.Context, ready <-chan struct{}) (outChan <-chan Job, err error) {
+func (msjq *MultiSourceJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err error) {
 	logger := context.LoggerFromContext(ctx).WithField("self", "multi_source_job_queue")
 
 	buildJobChan := make(chan Job)
 	outChan = buildJobChan
 
 	buildJobChans := map[string]<-chan Job{}
-	readyChans := map[string]chan struct{}{}
 
 	for i, queue := range msjq.queues {
-		qReady := make(chan struct{})
-		jc, err := queue.Jobs(ctx, (<-chan struct{})(qReady))
+		jc, err := queue.Jobs(ctx)
 		if err != nil {
 			logger.WithFields(logrus.Fields{
 				"err":  err,
@@ -42,40 +40,37 @@ func (msjq *MultiSourceJobQueue) Jobs(ctx gocontext.Context, ready <-chan struct
 		}
 		qName := fmt.Sprintf("%s.%d", queue.Name(), i)
 		buildJobChans[qName] = jc
-		readyChans[qName] = qReady
 	}
 
 	go func() {
 		for {
 			for queueName, bjc := range buildJobChans {
-				logger = logger.WithField("queue_name", queueName)
+				var job Job
 				jobSendBegin := time.Now()
+				logger = logger.WithField("queue_name", queueName)
+
+				logger.Debugf("about to receive job")
 				select {
-				case v := <-ready:
-					logger.Debugf("%#v <-ready", msjq)
-
-					logger.Debugf("about to %#v <- {}", readyChans[queueName])
-					readyChans[queueName] <- v
-					logger.Debugf("%#v <- {}", readyChans[queueName])
-
-					logger.Debugf("about to job := <-%#v", bjc)
-					job := <-bjc
-					logger.Debugf("job := %#v", job)
-
-					logger.Debugf("about to %#v [\"buildJobChan\"] <- %#v", buildJobChan, job)
-					buildJobChan <- job
-					logger.Debugf("%#v [\"buildJobChan\"] <- %#v", buildJobChan, job)
-
-					metrics.TimeSince("travis.worker.job_queue.multi.blocking_time", jobSendBegin)
-					logger.WithFields(logrus.Fields{
-						"source": queueName,
-						"dur":    time.Since(jobSendBegin),
-					}).Info("sent job to multi source output channel")
+				case job = <-bjc:
 				case <-ctx.Done():
 					return
 				case <-time.After(100 * time.Millisecond):
 					time.Sleep(time.Millisecond)
+					logger.Debugf("continuing after timeout waiting for job")
+					continue
 				}
+
+				logger.Debugf("job := %#v", job)
+
+				logger.Debugf("about to %#v [\"buildJobChan\"] <- %#v", buildJobChan, job)
+				buildJobChan <- job
+				logger.Debugf("%#v [\"buildJobChan\"] <- %#v", buildJobChan, job)
+
+				metrics.TimeSince("travis.worker.job_queue.multi.blocking_time", jobSendBegin)
+				logger.WithFields(logrus.Fields{
+					"source": queueName,
+					"dur":    time.Since(jobSendBegin),
+				}).Info("sent job to multi source output channel")
 			}
 		}
 	}()

--- a/multi_source_job_queue.go
+++ b/multi_source_job_queue.go
@@ -61,14 +61,17 @@ func (msjq *MultiSourceJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job
 					continue
 				}
 
-				logger.Debugf("job := %#v", job)
+				jobID := uint64(0)
+				if job.Payload() != nil {
+					jobID = job.Payload().Job.ID
+				}
 
-				logger.Debugf("about to %#v [\"buildJobChan\"] <- %#v", buildJobChan, job)
+				logger.WithField("job_id", jobID).Debug("about to send job to multi source output channel")
 				buildJobChan <- job
-				logger.Debugf("%#v [\"buildJobChan\"] <- %#v", buildJobChan, job)
 
 				metrics.TimeSince("travis.worker.job_queue.multi.blocking_time", jobSendBegin)
 				logger.WithFields(logrus.Fields{
+					"job_id": jobID,
 					"source": queueName,
 					"dur":    time.Since(jobSendBegin),
 				}).Info("sent job to multi source output channel")

--- a/multi_source_job_queue.go
+++ b/multi_source_job_queue.go
@@ -52,13 +52,12 @@ func (msjq *MultiSourceJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job
 				jobSendBegin := time.Now()
 				logger = logger.WithField("queue_name", queueName)
 
-				logger.Debugf("about to receive job")
+				logger.Debug("about to receive job")
 				select {
 				case job = <-bjc:
 				case <-ctx.Done():
 					return
 				case <-time.After(time.Second):
-					logger.Debug("continuing after timeout waiting for job")
 					continue
 				}
 

--- a/multi_source_job_queue.go
+++ b/multi_source_job_queue.go
@@ -22,7 +22,10 @@ func NewMultiSourceJobQueue(queues ...JobQueue) *MultiSourceJobQueue {
 
 // Jobs returns a Job channel that selects over each source queue Job channel
 func (msjq *MultiSourceJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err error) {
-	logger := context.LoggerFromContext(ctx).WithField("self", "multi_source_job_queue")
+	logger := context.LoggerFromContext(ctx).WithFields(logrus.Fields{
+		"self": "multi_source_job_queue",
+		"inst": fmt.Sprintf("%p", msjq),
+	})
 
 	buildJobChan := make(chan Job)
 	outChan = buildJobChan

--- a/multi_source_job_queue.go
+++ b/multi_source_job_queue.go
@@ -56,7 +56,7 @@ func (msjq *MultiSourceJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job
 					return
 				case <-time.After(100 * time.Millisecond):
 					time.Sleep(time.Millisecond)
-					logger.Debugf("continuing after timeout waiting for job")
+					logger.Debug("continuing after timeout waiting for job")
 					continue
 				}
 

--- a/multi_source_job_queue.go
+++ b/multi_source_job_queue.go
@@ -45,7 +45,7 @@ func (msjq *MultiSourceJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job
 	go func() {
 		for {
 			for queueName, bjc := range buildJobChans {
-				var job Job
+				var job Job = nil
 				jobSendBegin := time.Now()
 				logger = logger.WithField("queue_name", queueName)
 
@@ -54,8 +54,7 @@ func (msjq *MultiSourceJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job
 				case job = <-bjc:
 				case <-ctx.Done():
 					return
-				case <-time.After(100 * time.Millisecond):
-					time.Sleep(time.Millisecond)
+				case <-time.After(time.Second):
 					logger.Debug("continuing after timeout waiting for job")
 					continue
 				}

--- a/multi_source_job_queue_test.go
+++ b/multi_source_job_queue_test.go
@@ -8,38 +8,75 @@ import (
 	gocontext "context"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/travis-ci/worker/context"
 )
 
 func TestNewMultiSourceJobQueue(t *testing.T) {
+	ctx := gocontext.TODO()
+	logger := context.LoggerFromContext(ctx)
 	jq0 := &fakeJobQueue{c: make(chan Job)}
 	jq1 := &fakeJobQueue{c: make(chan Job)}
 	msjq := NewMultiSourceJobQueue(jq0, jq1)
 
 	assert.NotNil(t, msjq)
 
-	buildJobChan, err := msjq.Jobs(gocontext.TODO())
+	ready := make(chan struct{})
+	buildJobChan, err := msjq.Jobs(ctx, (<-chan struct{})(ready))
 	assert.Nil(t, err)
 	assert.NotNil(t, buildJobChan)
 
 	done := make(chan struct{})
 
 	go func() {
-		<-buildJobChan
-		<-buildJobChan
-		done <- struct{}{}
+		for {
+			logger.Debugf("about to ready <- {}")
+			ready <- struct{}{}
+			logger.Debugf("ready <- {}")
+		}
 	}()
 
 	go func() {
-		jq0.c <- &fakeJob{}
-		jq1.c <- &fakeJob{}
+		logger.Debugf("about to <-%#v [\"buildJobChan\"]", buildJobChan)
+		<-buildJobChan
+		logger.Debugf("<-%#v [\"buildJobChan\"]", buildJobChan)
+		logger.Debugf("about to <-%#v [\"buildJobChan\"]", buildJobChan)
+		<-buildJobChan
+		logger.Debugf("<-%#v [\"buildJobChan\"]", buildJobChan)
+		logger.Debugf("about to %#v [\"done\"] <- {}", done)
+		done <- struct{}{}
+		logger.Debugf("%#v [\"done\"] <- {}", done)
 	}()
 
-	for {
+	go func() {
+		logger.Debugf("about to %#v [\"jq0.c\"] <- &fakeJob{}", jq0.c)
+		jq0.c <- &fakeJob{}
+		logger.Debugf("%#v [\"jq0.c\"] <- &fakeJob{}", jq0.c)
+
+		logger.Debugf("about to %#v [\"done\"] <- {}", done)
+		done <- struct{}{}
+		logger.Debugf("%#v [\"done\"] <- {}", done)
+	}()
+
+	go func() {
+		logger.Debugf("about to %#v [\"jq1.c\"] <- &fakeJob{}", jq1.c)
+		jq1.c <- &fakeJob{}
+		logger.Debugf("%#v [\"jq1.c\"] <- &fakeJob{}", jq1.c)
+
+		logger.Debugf("about to %#v [\"done\"] <- {}", done)
+		done <- struct{}{}
+		logger.Debugf("%#v [\"done\"] <- {}", done)
+	}()
+
+	doneCount := 0
+	for doneCount < 3 {
+		logger.Debugf("entering for loop")
+		timeout := 5 * time.Second
 		select {
-		case <-time.After(3 * time.Second):
-			assert.FailNow(t, "jobs were not received within 3s")
+		case <-time.After(timeout):
+			assert.FailNow(t, fmt.Sprintf("jobs were not received within %v", timeout))
 		case <-done:
-			return
+			logger.Debugf("<-%#v [\"done\"]", done)
+			doneCount++
 		}
 	}
 }
@@ -66,12 +103,13 @@ func TestMultiSourceJobQueue_Jobs_uniqueChannels(t *testing.T) {
 	jq0 := &fakeJobQueue{c: make(chan Job)}
 	jq1 := &fakeJobQueue{c: make(chan Job)}
 	msjq := NewMultiSourceJobQueue(jq0, jq1)
+	ready := make(chan struct{})
 
-	buildJobChan0, err := msjq.Jobs(gocontext.TODO())
+	buildJobChan0, err := msjq.Jobs(gocontext.TODO(), (<-chan struct{})(ready))
 	assert.Nil(t, err)
 	assert.NotNil(t, buildJobChan0)
 
-	buildJobChan1, err := msjq.Jobs(gocontext.TODO())
+	buildJobChan1, err := msjq.Jobs(gocontext.TODO(), (<-chan struct{})(ready))
 	assert.Nil(t, err)
 	assert.NotNil(t, buildJobChan1)
 

--- a/multi_source_job_queue_test.go
+++ b/multi_source_job_queue_test.go
@@ -20,20 +20,11 @@ func TestNewMultiSourceJobQueue(t *testing.T) {
 
 	assert.NotNil(t, msjq)
 
-	ready := make(chan struct{})
-	buildJobChan, err := msjq.Jobs(ctx, (<-chan struct{})(ready))
+	buildJobChan, err := msjq.Jobs(ctx)
 	assert.Nil(t, err)
 	assert.NotNil(t, buildJobChan)
 
 	done := make(chan struct{})
-
-	go func() {
-		for {
-			logger.Debugf("about to ready <- {}")
-			ready <- struct{}{}
-			logger.Debugf("ready <- {}")
-		}
-	}()
 
 	go func() {
 		logger.Debugf("about to <-%#v [\"buildJobChan\"]", buildJobChan)
@@ -103,13 +94,12 @@ func TestMultiSourceJobQueue_Jobs_uniqueChannels(t *testing.T) {
 	jq0 := &fakeJobQueue{c: make(chan Job)}
 	jq1 := &fakeJobQueue{c: make(chan Job)}
 	msjq := NewMultiSourceJobQueue(jq0, jq1)
-	ready := make(chan struct{})
 
-	buildJobChan0, err := msjq.Jobs(gocontext.TODO(), (<-chan struct{})(ready))
+	buildJobChan0, err := msjq.Jobs(gocontext.TODO())
 	assert.Nil(t, err)
 	assert.NotNil(t, buildJobChan0)
 
-	buildJobChan1, err := msjq.Jobs(gocontext.TODO(), (<-chan struct{})(ready))
+	buildJobChan1, err := msjq.Jobs(gocontext.TODO())
 	assert.Nil(t, err)
 	assert.NotNil(t, buildJobChan1)
 

--- a/processor.go
+++ b/processor.go
@@ -137,11 +137,6 @@ func (p *Processor) Run() {
 				return
 			}
 
-			if buildJob == nil {
-				logger.Debug("received nil job, continuing")
-				continue
-			}
-
 			jobID := buildJob.Payload().Job.ID
 
 			hardTimeout := p.hardTimeout

--- a/processor.go
+++ b/processor.go
@@ -183,7 +183,7 @@ func (p *Processor) Run() {
 			}).Debug("updating processor status")
 			p.CurrentStatus = "waiting"
 			cancel()
-		case <-time.After(time.Second):
+		case <-time.After(10 * time.Second):
 			logger.Debug("timeout waiting for job, shutdown, or context done")
 		}
 	}

--- a/processor.go
+++ b/processor.go
@@ -144,6 +144,11 @@ func (p *Processor) Run() {
 				return
 			}
 
+			if buildJob == nil {
+				logger.Info("received nil job, continuing")
+				continue
+			}
+
 			hardTimeout := p.hardTimeout
 			if buildJob.Payload().Timeouts.HardLimit != 0 {
 				hardTimeout = time.Duration(buildJob.Payload().Timeouts.HardLimit) * time.Second

--- a/processor_pool.go
+++ b/processor_pool.go
@@ -1,6 +1,8 @@
 package worker
 
 import (
+	"fmt"
+	"os"
 	"sort"
 	"sync"
 	"time"
@@ -78,9 +80,8 @@ func (p *ProcessorPool) Each(f func(int, *Processor)) {
 	procsByID := map[string]*Processor{}
 
 	for _, proc := range p.processors {
-		id := proc.ID.String()
-		procIDs = append(procIDs, id)
-		procsByID[id] = proc
+		procIDs = append(procIDs, proc.ID)
+		procsByID[proc.ID] = proc
 	}
 
 	sort.Strings(procIDs)
@@ -179,7 +180,8 @@ func (p *ProcessorPool) Decr() {
 
 func (p *ProcessorPool) runProcessor(queue JobQueue) error {
 	processorUUID := uuid.NewRandom()
-	ctx := context.FromProcessor(p.Context, processorUUID.String())
+	processorID := fmt.Sprintf("%s@%d.%s", processorUUID.String(), os.Getpid(), p.Hostname)
+	ctx := context.FromProcessor(p.Context, processorID)
 
 	proc, err := NewProcessor(ctx, p.Hostname,
 		queue, p.Provider, p.Generator, p.CancellationBroadcaster,

--- a/step_send_received.go
+++ b/step_send_received.go
@@ -14,7 +14,7 @@ func (s *stepSendReceived) Run(state multistep.StateBag) multistep.StepAction {
 	buildJob := state.Get("buildJob").(Job)
 	ctx := state.Get("ctx").(gocontext.Context)
 
-	err := buildJob.Received()
+	err := buildJob.Received(ctx)
 	if err != nil {
 		context.LoggerFromContext(ctx).WithFields(logrus.Fields{
 			"err":  err,
@@ -25,5 +25,4 @@ func (s *stepSendReceived) Run(state multistep.StateBag) multistep.StepAction {
 	return multistep.ActionContinue
 }
 
-func (s *stepSendReceived) Cleanup(state multistep.StateBag) {
-}
+func (s *stepSendReceived) Cleanup(state multistep.StateBag) {}

--- a/step_sleep.go
+++ b/step_sleep.go
@@ -16,5 +16,4 @@ func (s *stepSleep) Run(state multistep.StateBag) multistep.StepAction {
 	return multistep.ActionContinue
 }
 
-func (s *stepSleep) Cleanup(state multistep.StateBag) {
-}
+func (s *stepSleep) Cleanup(state multistep.StateBag) {}

--- a/step_update_state.go
+++ b/step_update_state.go
@@ -15,7 +15,7 @@ func (s *stepUpdateState) Run(state multistep.StateBag) multistep.StepAction {
 	buildJob := state.Get("buildJob").(Job)
 	ctx := state.Get("ctx").(gocontext.Context)
 
-	err := buildJob.Started()
+	err := buildJob.Started(ctx)
 	if err != nil {
 		context.LoggerFromContext(ctx).WithFields(logrus.Fields{
 			"err":  err,


### PR DESCRIPTION
### What is the problem that this PR is trying to fix?

See #353

### What approach did you choose and why?

I decided to change the relationship between individual processors and job-board so that claims and delivery are handled at the processor level rather than being batched together through a shared job queue.  This is very similar to the way the AMQP job queue works.

### How can you test this?

I would like to deploy this to AWS staging with queue type of `amqp,http`.