### PR TITLE
Add defaultAllowReauth as an option to be set when connecting to Openstack

### DIFF
--- a/backend/openstack.go
+++ b/backend/openstack.go
@@ -46,6 +46,7 @@ const (
 	defaultOSSSHUser           = "travis"
 	defaultOSKeyPairName       = ""
 	defaultOSSSHKeyPath        = ""
+	defaultAllowReauth         = "true"
 )
 
 var (
@@ -74,6 +75,7 @@ var (
 		"BOOT_POLL_DIAL_SLEEP": fmt.Sprintf("sleep interval between connection dials (default %v)", defaultOSBootPollDialSleep),
 		"SSH_POLL_TIMEOUT":     fmt.Sprintf("Timeout after which VM is marked not sshable (default %v)", defaultOSSSHDialTimeout),
 		"SSH_DIAL_TIMEOUT":     fmt.Sprintf("connection timeout for ssh connections (default %v)", defaultOSSSHDialTimeout),
+		"ALLOW_REAUTH":         fmt.Sprintf("Defines if re-authentication need to be executed when a connection is requested (default %v)", defaultAllowReauth),
 	}
 )
 
@@ -194,6 +196,14 @@ func newOSProvider(cfg *config.ProviderConfig) (Provider, error) {
 		secGroup = cfg.Get("SECURITY_GROUP")
 	}
 	cfg.Set("SECURITY_GROUP", secGroup)
+
+	allowReauth := defaultAllowReauth
+	if cfg.IsSet("ALLOW_REAUTH") {
+		allowReauth, err = cfg.Get("ALLOW_REAUTH")
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	instName := defaultOSInstancePrefix + time.Now().Format("20060102150405")
 	if cfg.IsSet("INSTANCE_NAME") {
@@ -343,6 +353,7 @@ func buildOSComputeService(cfg *config.ProviderConfig) (*osClients, error) {
 			Username:         cfg.Get("OS_USERNAME"),
 			Password:         cfg.Get("OS_PASSWORD"),
 			TenantName:       cfg.Get("TENANT_NAME"),
+			AllowReauth:      cfg.Get("ALLOW_REAUTH"),
 		}
 	} else if keystoneApiVersion == "v3" {
 		opts = gophercloud.AuthOptions{
@@ -351,6 +362,7 @@ func buildOSComputeService(cfg *config.ProviderConfig) (*osClients, error) {
 			Password:         cfg.Get("OS_PASSWORD"),
 			TenantName:       cfg.Get("TENANT_NAME"),
 			DomainName:       cfg.Get("OS_DOMAIN"),
+			AllowReauth:      cfg.Get("ALLOW_REAUTH"),
 		}
 	}
 


### PR DESCRIPTION
 We have seen in worker logs msgs like below:
    "time="2017-08-21T13:36:00Z" level=error msg="couldn't start instance"
    *err="couldn't get image at Openstack backend: Unable to find image:"

    This error is caused because the Openstack driver interface of worker is
    initializing all the service client (keystone/nova/image) at the starting
    of the worker and these client objects are re-used during its entire
    life cycle. After a certain period of time, the token generated by the
    identity service expires and these client objects are not able to fulfill
    any request until worker is fully restarted. To overcome this issue
    "AllowReauth: true" needs to be added during Openstack client
    initialization to allow re-authentication to happen automatically.

    According the Openstack documentationi [1], if allow_reauth is True
    and connection token is going to expire soon then the method returns
    updated connection. The method invariant is the following: if
    self.allow_reauth is False then the method returns the same
    connection for every call. So the connection may expire.
    If self.allow_reauth is True the returned swift connection
    is always valid and cannot expire at least for
    swift_store_expire_soon_interval.

    [1] - https://docs.openstack.org/glance_store/latest/reference/api/\
    glance_store._drivers.swift.connection_manager.html

Signed-off-by: Spurti Chopra <spurti@us.ibm.com>
Signed-off-by: Rafael Peria de Sene <rpsene@br.ibm.com>