### PR TITLE
Move the PR template into `.github/`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## What is the problem that this PR is trying to fix?
+
+## What approach did you choose and why?
+
+## How can you test this?
+
+## What feedback would you like, if any?

--- a/PULL_REQUEST_TEMPLATE
+++ b/PULL_REQUEST_TEMPLATE
@@ -1,9 +1,0 @@
-Please make sure you cover the following points:
-
-1. What is the problem that this PR is trying to fix?
-
-2. What approach did you choose and why?
-
-3. How can you test this?
-
-(4. What feedback would you like?)


### PR DESCRIPTION
I have been modifying the current PR template every time so that the ordered list is headers, and this file path is also supported, and with an `.md` extension, too!
