### PR TITLE
Allows to re-authenticate automatically with Openstack identity service if/when token expires.

### DIFF
--- a/backend/openstack.go
+++ b/backend/openstack.go
@@ -343,6 +343,7 @@ func buildOSComputeService(cfg *config.ProviderConfig) (*osClients, error) {
 			Username:         cfg.Get("OS_USERNAME"),
 			Password:         cfg.Get("OS_PASSWORD"),
 			TenantName:       cfg.Get("TENANT_NAME"),
+			AllowReauth:      true, // TODO: limit the number of attempts using RoundTripper interface
 		}
 	} else if keystoneAPIVersion == "v3" {
 		opts = gophercloud.AuthOptions{
@@ -351,6 +352,7 @@ func buildOSComputeService(cfg *config.ProviderConfig) (*osClients, error) {
 			Password:         cfg.Get("OS_PASSWORD"),
 			TenantName:       cfg.Get("TENANT_NAME"),
 			DomainName:       cfg.Get("OS_DOMAIN"),
+			AllowReauth:      true, // TODO: limit the number of attempts using RoundTripper interface
 		}
 	}
 


### PR DESCRIPTION
# What is the problem that this PR is trying to fix?
As per current implementation of Openstack backend , authentication with the Keystone (identity service) happens at the very start of the worker . However, token generated by Identity Service may expire based on the Openstack configuration settings at Setup level. Once the token expires we cannot perform any API calls. Changes in this PR tries to overcome this issue by allowing automatic re authentication. 

## How can you test this?
Tested with a local Openstack cloud setup 