### PR TITLE
Handle nil incoming job in multi-source job queue

### DIFF
--- a/multi_source_job_queue.go
+++ b/multi_source_job_queue.go
@@ -55,6 +55,10 @@ func (msjq *MultiSourceJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job
 				logger.Debug("about to receive job")
 				select {
 				case job = <-bjc:
+					if job == nil {
+						logger.Debug("skipping nil job")
+						continue
+					}
 					jobID := uint64(0)
 					if job.Payload() != nil {
 						jobID = job.Payload().Job.ID


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The production rollout of v3.0.0 on GCE seems to have introduced this panic:

```
travis-worker: panic: runtime error: invalid memory address or nil pointer dereference 
travis-worker: [signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0xa82dfc] 
travis-worker: goroutine 210 [running]: 
travis-worker: github.com/travis-ci/worker.(*MultiSourceJobQueue).Jobs.func1(0xc420163ef0,0xc42000c4e0,0xc420631320, 0x1053520, 0xc4201c0880) 
travis-worker:     /home/travis/gopath/src/github.com/travis-ci/worker/multi_source_job_queue.go:59 +0x30c 
travis-worker: created by github.com/travis-ci/worker.(*MultiSourceJobQueue).Jobs 
travis-worker:     /home/travis/gopath/src/github.com/travis-ci/worker/multi_source_job_queue.go:79 +0x5b9 
```

## What approach did you choose and why?

I decided to check for `nil`, and if so, log and continue.  AFAICT neither the AMQP nor the HTTP job queue should send a `nil` job to this channel, so I think there's at least one other bug lurking...

## How can you test this?

It compiles!  Also, deploy to AWS staging :grin:

## What feedback would you like, if any?

Should this be approached differently?  Is a `panic` correct?
