### PR TITLE
Properly allocate CPU sets to containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Removed
 
 ### Fixed
+- backend/docker: properly allocate CPU sets
 
 ### Security
 

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -337,7 +337,7 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 		logger.WithField("err", err).Error("couldn't checkout CPUSets")
 		return nil, err
 	}
-	logger.Infof("Checked out CPU sets: %#v", cpuSets)
+	logger.WithField("cpu_sets", cpuSets).Info("checked out")
 
 	if cpuSets != "" {
 		dockerConfig.CPUSet = cpuSets


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

CPU sets aren't properly allocated to containers, meaning that some jobs use more than their share of CPUs.

## What approach did you choose and why?

I think this is a problem:

```
cpuSets, err := p.checkoutCPUSets()
if err != nil && cpuSets != "" {
return nil, err
}
```
because if the `checkoutCPUSets` func returns an error, the other value is always an empty string:

```
func (p *dockerProvider) checkoutCPUSets() (string, error) {
[...]
if len(cpuSets) != p.runCPUs {
return "", fmt.Errorf("not enough free CPUsets")
}
```
so `if err != nil && cpuSets != ""` will never be true, so the error is never caught (and in that case, containers are allocated the same CPU set as the host).

## How to test

Create some sample JSON payloads and put them in `10-created.d/`:

```
$ pwd
/home/aj/git/travis/worker/builds.ec2

$ ls -la
total 60
drwxr-xr-x  7 aj aj 4096 Sep  9 15:52 .
drwxr-xr-x 19 aj aj 4096 Sep  9 16:33 ..
drwxr-xr-x  2 aj aj 4096 Sep  9 16:15 10-created.d
drwxr-xr-x  2 aj aj 4096 Sep  9 16:15 30-received.d
drwxr-xr-x  2 aj aj 4096 Sep  9 16:16 50-started.d
drwxr-xr-x  2 aj aj 4096 Sep  9 16:16 70-finished.d
drwxr-xr-x  2 aj aj 4096 Sep  9 16:13 log
-rw-r--r--  1 aj aj 1415 Sep  9 13:59 sleep-10.json
-rw-r--r--  1 aj aj 1414 Sep  9 13:59 sleep-15.json
-rw-r--r--  1 aj aj 1415 Sep  9 13:59 sleep-20.json
-rw-r--r--  1 aj aj 1415 Sep  9 13:59 sleep-25.json
-rw-r--r--  1 aj aj 1415 Sep  9 13:59 sleep-30.json
-rw-r--r--  1 aj aj 1414 Sep  9 13:59 sleep-5.json
-rw-r--r--  1 aj aj 1415 Sep  9 15:52 sleep-50.json

$ cat sleep-10.json 
{"type":"test","vm_type":"default","queue":"builds.ec2","config":{"language":"bash","env":["SLEEP=10"],"script":"./sleep.sh $SLEEP",".result":"configured","group":"stable","dist":"trusty","os":"linux"},"env_vars":[],"job":{"id":623773,"number":"1.4","commit":"1fb2f95804ee662297c908124c74e966edc3f2c9","commit_range":"191f87a69f84...1fb2f95804ee","commit_message":"yay staging","branch":"trigger","ref":null,"tag":null,"pull_request":false,"state":"passed","secure_env_enabled":true,"secure_env_removed":false,"debug_options":{},"queued_at":"2017-09-08T12:12:36Z","allow_failure":false},"source":{"id":623769,"number":"1","event_type":"push"},"repository":{"id":60659,"github_id":102856467,"slug":"soulshake/autoscale-tester","source_url":"https://github.com/soulshake/autoscale-tester.git","api_url":"https://api.github.com/repos/soulshake/autoscale-tester","last_build_id":623769,"last_build_number":"1","last_build_started_at":"2017-09-08T12:12:37Z","last_build_finished_at":null,"last_build_duration":null,"last_build_state":"started","default_branch":"master","description":"Verify autoscaling behavior"},"ssh_key":null,"timeouts":{"hard_limit":null,"log_silence":null},"cache_settings":{"fetch_timeout":1200,"push_timeout":7200,"s3":{"access_key_id":"BLAHBLAHBLAH","aws_signature_version":"4","bucket":"travis-cache-staging-org","hostname":"s3.amazonaws.com","secret_access_key":"BLAHBLAHBLAH"},"type":"s3"}}

$ cp sleep-* 10-created.d/
```
Then run worker:
```
$ travis-worker --debug 9
```

And verify that CPUs are allocated as expected:
```
$ for cid in $(docker ps -q); do docker exec -ti $cid cat /sys/fs/cgroup/cpuset/cpuset.cpus; done
6-7
4-5
0-1
2-3
```
^ Each container should have 2 unique CPUs allocated to it. The remaining jobs should not be run until these have finished.

---

This _might_ address https://github.com/travis-pro/team-blue/issues/733, at least partially.