### PR TITLE
Add docker-build smoke-docker docker-push smoke-package back to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,12 @@ script:
 - make test
 - make crossbuild
 - make smoke
+- if [[ $TRAVIS_PULL_REQUEST = 'false' && $DOCKER_LOGIN_PASSWORD && $DOCKER_LOGIN_USERNAME ]]; then
+    make docker-build smoke-docker docker-push;
+  fi
+- if [[ $TRAVIS_PULL_REQUEST = 'false' && $PACKAGECLOUD_TOKEN ]]; then
+    make package smoke-package;
+  fi
 
 after_success:
   - echo "TRAVIS_PULL_REQUEST: $TRAVIS_PULL_REQUEST"

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN make build
 #################################
 
 FROM alpine:latest
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates curl bash
 
 COPY --from=builder /go/bin/travis-worker /usr/local/bin/travis-worker
 COPY --from=builder /go/src/github.com/travis-ci/worker/.docker-entrypoint.sh /docker-entrypoint.sh


### PR DESCRIPTION
This change is so we can continue pushing to packagecloud.io while pushing branches to [travisci/worker-testing](https://hub.docker.com/r/travisci/worker-testing) on Docker Hub.