### PR TITLE
Defer amqp channel close in the right scope

### DIFF
--- a/amqp_job.go
+++ b/amqp_job.go
@@ -154,7 +154,6 @@ func (j *amqpJob) sendStateUpdate(ctx gocontext.Context, event, state string) er
 	if err != nil {
 		return err
 	}
-	defer amqpChan.Close()
 
 	j.stateCount++
 	body := j.createStateUpdateBody(state)
@@ -166,6 +165,7 @@ func (j *amqpJob) sendStateUpdate(ctx gocontext.Context, event, state string) er
 
 	done := make(chan error)
 	go func() {
+		defer amqpChan.Close()
 		_, err = amqpChan.QueueDeclare("reporting.jobs.builds", true, false, false, false, nil)
 		if err != nil {
 			done <- err


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Errors in the RabbitMQ server logs seemed to indicate problems with how we're ordering some AMQP operations and channel closes.  This code was recently changed, and drew our attention, so the hope is that this change will address at least one source of errors.

## What approach did you choose and why?

Move the deferred channel close into the same function scope as where it is used so that it is not closed prior to use.

## How can you test this?

Tests + running it in staging.