### PR TITLE
Warn when shutdown signal received

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -493,10 +493,10 @@ func (i *CLI) signalHandler() {
 		case sig := <-signalChan:
 			switch sig {
 			case syscall.SIGINT:
-				i.logger.Info("SIGINT received, starting graceful shutdown")
+				i.logger.Warn("SIGINT received, starting graceful shutdown")
 				i.ProcessorPool.GracefulShutdown(false)
 			case syscall.SIGTERM:
-				i.logger.Info("SIGTERM received, shutting down immediately")
+				i.logger.Warn("SIGTERM received, shutting down immediately")
 				i.cancel()
 			case syscall.SIGTTIN:
 				i.logger.Info("SIGTTIN received, adding processor to pool")
@@ -505,7 +505,7 @@ func (i *CLI) signalHandler() {
 				i.logger.Info("SIGTTOU received, removing processor from pool")
 				i.ProcessorPool.Decr()
 			case syscall.SIGWINCH:
-				i.logger.Info("SIGWINCH received, toggling graceful shutdown and pause")
+				i.logger.Warn("SIGWINCH received, toggling graceful shutdown and pause")
 				i.ProcessorPool.GracefulShutdown(true)
 			case syscall.SIGUSR1:
 				i.logProcessorInfo("received SIGUSR1")


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Occasionally `travis-worker` will be in the `stop/waiting` state. This PR is intended to make it more obvious when this happens due to a signal.

For example, `SIGWINCH`--window size change--is interpreted by worker as a reason to trigger a graceful shutdown. This is nontraditional behavior and as such should be warned about.

## What approach did you choose and why?

Changed `i.logger.Info` to `i.logger.Warn` in `cli.signalHandler`.

## What feedback would you like, if any?

I haven't tested this. What could possibly go wrong?