### PR TITLE
Use processor context in "Finish" state update

### DIFF
--- a/backend/fake.go
+++ b/backend/fake.go
@@ -11,6 +11,7 @@ import (
 func init() {
 	Register("fake", "Fake", map[string]string{
 		"LOG_OUTPUT": "faked log output to write",
+		"RUN_SLEEP":  "faked runtime sleep duration",
 	}, newFakeProvider)
 }
 
@@ -51,6 +52,14 @@ func (i *fakeInstance) UploadScript(ctx context.Context, script []byte) error {
 }
 
 func (i *fakeInstance) RunScript(ctx context.Context, writer io.Writer) (*RunResult, error) {
+	if i.p.cfg.IsSet("RUN_SLEEP") {
+		rs, err := time.ParseDuration(i.p.cfg.Get("RUN_SLEEP"))
+		if err != nil {
+			return &RunResult{Completed: false}, err
+		}
+		time.Sleep(rs)
+	}
+
 	_, err := writer.Write([]byte(i.p.cfg.Get("LOG_OUTPUT")))
 	if err != nil {
 		return &RunResult{Completed: false}, err

--- a/processor.go
+++ b/processor.go
@@ -206,6 +206,7 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 	state := new(multistep.BasicStateBag)
 	state.Put("hostname", p.ID)
 	state.Put("buildJob", buildJob)
+	state.Put("procCtx", p.ctx)
 	state.Put("ctx", ctx)
 
 	logger := context.LoggerFromContext(ctx).WithFields(logrus.Fields{

--- a/processor_test.go
+++ b/processor_test.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -20,77 +21,118 @@ func (bsg buildScriptGeneratorFunction) Generate(ctx context.Context, job Job) (
 }
 
 func TestProcessor(t *testing.T) {
-	uuid := uuid.NewRandom()
-	ctx := workerctx.FromProcessor(context.TODO(), uuid.String())
-
-	provider, err := backend.NewBackendProvider("fake", config.ProviderConfigFromMap(map[string]string{
-		"LOG_OUTPUT": "hello, world",
-	}))
-	if err != nil {
-		t.Error(err)
-	}
-
-	generator := buildScriptGeneratorFunction(func(ctx context.Context, job Job) ([]byte, error) {
-		return []byte("hello, world"), nil
-	})
-
-	jobChan := make(chan Job)
-	jobQueue := &fakeJobQueue{c: jobChan}
-	cancellationBroadcaster := NewCancellationBroadcaster()
-
-	processor, err := NewProcessor(ctx, "test-hostname", jobQueue, provider, generator, cancellationBroadcaster, ProcessorConfig{
-		HardTimeout:             2 * time.Second,
-		LogTimeout:              time.Second,
-		ScriptUploadTimeout:     3 * time.Second,
-		StartupTimeout:          4 * time.Second,
-		MaxLogLength:            4500000,
-		PayloadFilterExecutable: "filter.py",
-	})
-	if err != nil {
-		t.Error(err)
-	}
-
-	doneChan := make(chan struct{})
-	go func() {
-		processor.Run()
-		doneChan <- struct{}{}
-	}()
-
-	rawPayload, _ := simplejson.NewJson([]byte("{}"))
-
-	job := &fakeJob{
-		rawPayload: rawPayload,
-		payload: &JobPayload{
-			Type: "job:test",
-			Job: JobJobPayload{
-				ID:     2,
-				Number: "3.1",
-			},
-			Build: BuildPayload{
-				ID:     1,
-				Number: "3",
-			},
-			Repository: RepositoryPayload{
-				ID:   4,
-				Slug: "green-eggs/ham",
-			},
-			UUID:     "foo-bar",
-			Config:   map[string]interface{}{},
-			Timeouts: TimeoutsPayload{},
+	for i, tc := range []struct {
+		runSleep           time.Duration
+		hardTimeout        time.Duration
+		stateEvents        []string
+		isCancelled        bool
+		hasBrokenLogWriter bool
+	}{
+		{
+			runSleep:    0 * time.Second,
+			hardTimeout: 5 * time.Second,
+			stateEvents: []string{"received", "started", string(FinishStatePassed)},
 		},
-		startAttributes: &backend.StartAttributes{},
-	}
-	jobChan <- job
+		{
+			runSleep:    3 * time.Second,
+			hardTimeout: 5 * time.Second,
+			stateEvents: []string{"received", "started", string(FinishStateCancelled)},
+			isCancelled: true,
+		},
+		{
+			runSleep:           0 * time.Second,
+			hardTimeout:        5 * time.Second,
+			stateEvents:        []string{"received", "started", "requeued"},
+			hasBrokenLogWriter: true,
+		},
+		{
+			runSleep:    5 * time.Second,
+			hardTimeout: 4 * time.Second,
+			stateEvents: []string{"received", "started", string(FinishStateErrored)},
+		},
+	} {
+		jobID := uint64(100 + i)
+		uuid := uuid.NewRandom()
+		ctx := workerctx.FromProcessor(context.TODO(), uuid.String())
 
-	processor.GracefulShutdown()
-	<-doneChan
+		provider, err := backend.NewBackendProvider("fake", config.ProviderConfigFromMap(map[string]string{
+			"RUN_SLEEP":  fmt.Sprintf("%s", tc.runSleep),
+			"LOG_OUTPUT": "hello, world",
+		}))
+		if err != nil {
+			t.Error(err)
+		}
 
-	if processor.ProcessedCount != 1 {
-		t.Errorf("processor.ProcessedCount = %d, expected %d", processor.ProcessedCount, 1)
-	}
+		generator := buildScriptGeneratorFunction(func(ctx context.Context, job Job) ([]byte, error) {
+			return []byte("hello, world"), nil
+		})
 
-	expectedEvents := []string{"received", "started", string(FinishStatePassed)}
-	if !reflect.DeepEqual(expectedEvents, job.events) {
-		t.Errorf("job.events = %#v, expected %#v", job.events, expectedEvents)
+		jobChan := make(chan Job)
+		jobQueue := &fakeJobQueue{c: jobChan}
+		cancellationBroadcaster := NewCancellationBroadcaster()
+
+		processor, err := NewProcessor(ctx, "test-hostname", jobQueue, provider, generator, cancellationBroadcaster, ProcessorConfig{
+			HardTimeout:             tc.hardTimeout,
+			LogTimeout:              time.Second,
+			ScriptUploadTimeout:     3 * time.Second,
+			StartupTimeout:          4 * time.Second,
+			MaxLogLength:            4500000,
+			PayloadFilterExecutable: "filter.py",
+		})
+		if err != nil {
+			t.Error(err)
+		}
+
+		doneChan := make(chan struct{})
+		go func() {
+			processor.Run()
+			doneChan <- struct{}{}
+		}()
+
+		rawPayload, _ := simplejson.NewJson([]byte("{}"))
+
+		job := &fakeJob{
+			rawPayload: rawPayload,
+			payload: &JobPayload{
+				Type: "job:test",
+				Job: JobJobPayload{
+					ID:     jobID,
+					Number: "3.1",
+				},
+				Build: BuildPayload{
+					ID:     1,
+					Number: "3",
+				},
+				Repository: RepositoryPayload{
+					ID:   4,
+					Slug: "green-eggs/ham",
+				},
+				UUID:     "foo-bar",
+				Config:   map[string]interface{}{},
+				Timeouts: TimeoutsPayload{},
+			},
+			startAttributes:    &backend.StartAttributes{},
+			hasBrokenLogWriter: tc.hasBrokenLogWriter,
+		}
+
+		if tc.isCancelled {
+			go func() {
+				time.Sleep(tc.runSleep - 1)
+				cancellationBroadcaster.Broadcast(jobID)
+			}()
+		}
+
+		jobChan <- job
+
+		processor.GracefulShutdown()
+		<-doneChan
+
+		if processor.ProcessedCount != 1 {
+			t.Errorf("processor.ProcessedCount = %d, expected %d", processor.ProcessedCount, 1)
+		}
+
+		if !reflect.DeepEqual(tc.stateEvents, job.events) {
+			t.Errorf("job.events = %#v, expected %#v", job.events, tc.stateEvents)
+		}
 	}
 }

--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -20,6 +20,7 @@ type stepStartInstance struct {
 
 func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 	buildJob := state.Get("buildJob").(Job)
+	procCtx := state.Get("procCtx").(gocontext.Context)
 	ctx := state.Get("ctx").(gocontext.Context)
 	logger := context.LoggerFromContext(ctx).WithField("self", "step_start_instance")
 
@@ -40,7 +41,7 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 			logWriter := state.Get("logWriter").(LogWriter)
 			logWriter.WriteAndClose([]byte(jobAbortErr.UserFacingErrorMessage()))
 
-			err = buildJob.Finish(ctx, FinishStateErrored)
+			err = buildJob.Finish(procCtx, FinishStateErrored)
 			if err != nil {
 				logger.WithField("err", err).WithField("state", FinishStateErrored).Error("couldn't mark job as finished")
 			}

--- a/step_update_state.go
+++ b/step_update_state.go
@@ -28,6 +28,7 @@ func (s *stepUpdateState) Run(state multistep.StateBag) multistep.StepAction {
 
 func (s *stepUpdateState) Cleanup(state multistep.StateBag) {
 	buildJob := state.Get("buildJob").(Job)
+	procCtx := state.Get("procCtx").(gocontext.Context)
 	ctx := state.Get("ctx").(gocontext.Context)
 
 	mresult, ok := state.GetOk("scriptResult")
@@ -39,11 +40,11 @@ func (s *stepUpdateState) Cleanup(state multistep.StateBag) {
 
 		switch result.ExitCode {
 		case 0:
-			err = buildJob.Finish(ctx, FinishStatePassed)
+			err = buildJob.Finish(procCtx, FinishStatePassed)
 		case 1:
-			err = buildJob.Finish(ctx, FinishStateFailed)
+			err = buildJob.Finish(procCtx, FinishStateFailed)
 		default:
-			err = buildJob.Finish(ctx, FinishStateErrored)
+			err = buildJob.Finish(procCtx, FinishStateErrored)
 		}
 
 		if err != nil {


### PR DESCRIPTION
to avoid racy issues with the job context being done.

## What is the problem that this PR is trying to fix?

State updates failing due to job-level context cancellation, such as happens at job timeout.  This change applies both to AMQP jobs, which we've seen appear to be running past the hard timeout, and to HTTP jobs, which we've seen running past when the `Finish` state update should be complete.

## What approach did you choose and why?

Use the processor-scope context instead so that we can still prevent resource leakage while also ensuring state updates can be sent.

## How can you test this?

Tests pass, so deploying to staging!

- [x] more tests!