### PR TITLE
 Use the stack-name as image-name in containers instead of the language tag

### DIFF
--- a/backend/docker.go
+++ b/backend/docker.go
@@ -325,7 +325,7 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 	if startAttributes.ImageName != "" {
 		imageName = startAttributes.ImageName
 	} else {
-		imageID, err := p.imageSelector.Select(&image.Params{
+		id, err := p.imageSelector.Select(&image.Params{
 			Language: startAttributes.Language,
 			Infra:    "docker",
 		})
@@ -333,6 +333,7 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 			logger.WithField("err", err).Error("couldn't select image")
 			return nil, err
 		}
+		imageID = id
 		imageName = p.dockerImageNameForID(ctx, imageID)
 	}
 

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -325,7 +325,7 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 	if startAttributes.ImageName != "" {
 		imageName = startAttributes.ImageName
 	} else {
-		id, err := p.imageSelector.Select(&image.Params{
+		selectedImageID, err := p.imageSelector.Select(&image.Params{
 			Language: startAttributes.Language,
 			Infra:    "docker",
 		})
@@ -333,7 +333,7 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 			logger.WithField("err", err).Error("couldn't select image")
 			return nil, err
 		}
-		imageID = id
+		imageID = selectedImageID
 		imageName = p.dockerImageNameForID(ctx, imageID)
 	}
 

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -681,15 +681,15 @@ func findDockerImageByTag(searchTags []string, images []dockertypes.ImageSummary
 	for _, searchTag := range searchTags {
 		for _, image := range images {
 			if searchTag == image.ID {
-				return image.ID, searchTag, nil
+				return image.ID, nil
 			}
 			for _, tag := range image.RepoTags {
 				if tag == searchTag {
-					return image.ID, searchTag, nil
+					return image.ID, nil
 				}
 			}
 		}
 	}
 
-	return "", "", fmt.Errorf("failed to find matching docker image tag")
+	return "", fmt.Errorf("failed to find matching docker image tag")
 }

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -353,7 +353,11 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 
 	cpuSets, err := p.checkoutCPUSets()
 	if err != nil {
-		logger.WithField("err", err).Error("couldn't checkout CPUSets")
+		logger.WithFields(logrus.Fields{
+			"err":            err,
+			"cpu_set_length": len(p.cpuSets),
+			"run_cpus":       p.runCPUs,
+		}).Error("couldn't checkout CPUSets")
 		return nil, err
 	}
 	logger.WithField("cpu_sets", cpuSets).Info("checked out")

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -295,7 +295,7 @@ func buildDockerImageSelector(selectorType string, client *docker.Client, cfg *c
 	}
 }
 
-// dockerImageNameForID returns a human-readable name for the image with the requests ID.
+// dockerImageNameForID returns a human-readable name for the image with the requested ID.
 // Currently, we are using the tag that includes the stack-name (e.g "travisci/ci-garnet:packer-1505167479") and reverting back to the ID if nothing is found.
 func (p *dockerProvider) dockerImageNameForID(ctx gocontext.Context, imageID string) string {
 	images, err := p.client.ImageList(ctx, dockertypes.ImageListOptions{All: true})

--- a/backend/docker_test.go
+++ b/backend/docker_test.go
@@ -131,7 +131,7 @@ func TestDockerProvider_Start(t *testing.T) {
 			}
 
 			if instance.ID() != "f2e475c:travisci/ci-amethyst:packer-1504724461" {
-				t.Errorf("Provider returned unexpected ID (\"%s\" != \"f2e475c:travis:jvm\"", instance.ID())
+				t.Errorf("Provider returned unexpected ID (\"%s\" != \"f2e475c:travisci/ci-amethyst:packer-1504724461\"", instance.ID())
 			}
 		}()
 	}
@@ -205,7 +205,7 @@ func TestDockerProvider_Start_WithPrivileged(t *testing.T) {
 			}
 
 			if instance.ID() != "f2e475c:travisci/ci-amethyst:packer-1504724461" {
-				t.Errorf("Provider returned unexpected ID (\"%s\" != \"f2e475c:travis:jvm\"", instance.ID())
+				t.Errorf("Provider returned unexpected ID (\"%s\" != \"f2e475c:travisci/ci-amethyst:packer-1504724461\"", instance.ID())
 			}
 		}()
 	}

--- a/backend/docker_test.go
+++ b/backend/docker_test.go
@@ -75,9 +75,9 @@ func TestDockerProvider_Start(t *testing.T) {
 			containerID := "f2e475c0ee1825418a3d4661d39d28bee478f4190d46e1a3984b73ea175c20c3"
 
 			imagesList := `[
-			{"Created":1423149832,"Id":"fc24f3225c15b08f8d9f70c1f7148d7fcbf4b41c3acce4b7da25af9371b90501","Labels":null,"ParentId":"2b412eda4314d97ff8a90d2f8c1b65677399723d6ecc4950f4e1247a5c2193c0","RepoDigests":[],"RepoTags":["quay.io/travisci/travis-ruby:latest","travis:ruby","travis:default"],"Size":729301088,"VirtualSize":4808391658},
-			{"Created":1423149832,"Id":"08a0d98600afe9d0ca4ca509b1829868cea39dcc75dea1f8dde0dc6325389b45","Labels":null,"ParentId":"2b412eda4314d97ff8a90d2f8c1b65677399723d6ecc4950f4e1247a5c2193c0","RepoDigests":[],"RepoTags":["quay.io/travisci/travis-go:latest","travis:go"],"Size":729301088,"VirtualSize":4808391658},
-			{"Created":1423150056,"Id":"570c738990e5859f3b78036f0fb6822fc54dc252f83cdd6d2127e3c1717bbbfd","Labels":null,"ParentId":"2b412eda4314d97ff8a90d2f8c1b65677399723d6ecc4950f4e1247a5c2193c0","RepoDigests":[],"RepoTags":["quay.io/travisci/travis-jvm:latest","travis:java","travis:jvm","travis:clojure","travis:groovy","travis:scala"],"Size":1092914295,"VirtualSize":5172004865}
+			{"Created":1423149832,"Id":"fc24f3225c15b08f8d9f70c1f7148d7fcbf4b41c3acce4b7da25af9371b90501","Labels":null,"ParentId":"2b412eda4314d97ff8a90d2f8c1b65677399723d6ecc4950f4e1247a5c2193c0","RepoDigests":[],"RepoTags":["travisci/ci-garnet:packer-1505167479","travis:ruby","travis:default"],"Size":729301088,"VirtualSize":4808391658},
+			{"Created":1423149832,"Id":"08a0d98600afe9d0ca4ca509b1829868cea39dcc75dea1f8dde0dc6325389b45","Labels":null,"ParentId":"2b412eda4314d97ff8a90d2f8c1b65677399723d6ecc4950f4e1247a5c2193c0","RepoDigests":[],"RepoTags":["travisci/ci-garnet:packer-1505167479","travis:go"],"Size":729301088,"VirtualSize":4808391658},
+			{"Created":1423150056,"Id":"570c738990e5859f3b78036f0fb6822fc54dc252f83cdd6d2127e3c1717bbbfd","Labels":null,"ParentId":"2b412eda4314d97ff8a90d2f8c1b65677399723d6ecc4950f4e1247a5c2193c0","RepoDigests":[],"RepoTags":["travisci/ci-amethyst:packer-1504724461","travis:java","travis:jvm","travis:clojure","travis:groovy","travis:scala"],"Size":1092914295,"VirtualSize":5172004865}
 		]`
 			dockerTestMux.HandleFunc(fmt.Sprintf("/v%s/images/json", dockerAPIVersion), func(w http.ResponseWriter, r *http.Request) {
 				fmt.Fprintf(w, imagesList)
@@ -130,7 +130,7 @@ func TestDockerProvider_Start(t *testing.T) {
 				t.Errorf("provider.Start() returned error: %v", err)
 			}
 
-			if instance.ID() != "f2e475c:travis:jvm" {
+			if instance.ID() != "f2e475c:travisci/ci-amethyst:packer-1504724461" {
 				t.Errorf("Provider returned unexpected ID (\"%s\" != \"f2e475c:travis:jvm\"", instance.ID())
 			}
 		}()
@@ -150,9 +150,9 @@ func TestDockerProvider_Start_WithPrivileged(t *testing.T) {
 			containerID := "f2e475c0ee1825418a3d4661d39d28bee478f4190d46e1a3984b73ea175c20c3"
 
 			imagesList := `[
-		{"Created":1423149832,"Id":"fc24f3225c15b08f8d9f70c1f7148d7fcbf4b41c3acce4b7da25af9371b90501","Labels":null,"ParentId":"2b412eda4314d97ff8a90d2f8c1b65677399723d6ecc4950f4e1247a5c2193c0","RepoDigests":[],"RepoTags":["quay.io/travisci/travis-ruby:latest","travis:ruby","travis:default"],"Size":729301088,"VirtualSize":4808391658},
-		{"Created":1423149832,"Id":"08a0d98600afe9d0ca4ca509b1829868cea39dcc75dea1f8dde0dc6325389b45","Labels":null,"ParentId":"2b412eda4314d97ff8a90d2f8c1b65677399723d6ecc4950f4e1247a5c2193c0","RepoDigests":[],"RepoTags":["quay.io/travisci/travis-go:latest","travis:go"],"Size":729301088,"VirtualSize":4808391658},
-		{"Created":1423150056,"Id":"570c738990e5859f3b78036f0fb6822fc54dc252f83cdd6d2127e3c1717bbbfd","Labels":null,"ParentId":"2b412eda4314d97ff8a90d2f8c1b65677399723d6ecc4950f4e1247a5c2193c0","RepoDigests":[],"RepoTags":["quay.io/travisci/travis-jvm:latest","travis:java","travis:jvm","travis:clojure","travis:groovy","travis:scala"],"Size":1092914295,"VirtualSize":5172004865}
+		{"Created":1423149832,"Id":"fc24f3225c15b08f8d9f70c1f7148d7fcbf4b41c3acce4b7da25af9371b90501","Labels":null,"ParentId":"2b412eda4314d97ff8a90d2f8c1b65677399723d6ecc4950f4e1247a5c2193c0","RepoDigests":[],"RepoTags":["travisci/ci-garnet:packer-1505167479","travis:ruby","travis:default"],"Size":729301088,"VirtualSize":4808391658},
+			{"Created":1423149832,"Id":"08a0d98600afe9d0ca4ca509b1829868cea39dcc75dea1f8dde0dc6325389b45","Labels":null,"ParentId":"2b412eda4314d97ff8a90d2f8c1b65677399723d6ecc4950f4e1247a5c2193c0","RepoDigests":[],"RepoTags":["travisci/ci-garnet:packer-1505167479","travis:go"],"Size":729301088,"VirtualSize":4808391658},
+			{"Created":1423150056,"Id":"570c738990e5859f3b78036f0fb6822fc54dc252f83cdd6d2127e3c1717bbbfd","Labels":null,"ParentId":"2b412eda4314d97ff8a90d2f8c1b65677399723d6ecc4950f4e1247a5c2193c0","RepoDigests":[],"RepoTags":["travisci/ci-amethyst:packer-1504724461","travis:java","travis:jvm","travis:clojure","travis:groovy","travis:scala"],"Size":1092914295,"VirtualSize":5172004865}
 	]`
 			dockerTestMux.HandleFunc(fmt.Sprintf("/v%s/images/json", dockerAPIVersion), func(w http.ResponseWriter, r *http.Request) {
 				fmt.Fprintf(w, imagesList)
@@ -204,7 +204,7 @@ func TestDockerProvider_Start_WithPrivileged(t *testing.T) {
 				t.Errorf("provider.Start() returned error: %v", err)
 			}
 
-			if instance.ID() != "f2e475c:travis:jvm" {
+			if instance.ID() != "f2e475c:travisci/ci-amethyst:packer-1504724461" {
 				t.Errorf("Provider returned unexpected ID (\"%s\" != \"f2e475c:travis:jvm\"", instance.ID())
 			}
 		}()


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
https://github.com/travis-pro/team-blue/issues/760
It is currently not easy to determine from the logs which image was used for a docker build, as opposed to GCE builds, which explicitly specify if garnet, amethyst or connie was used.

## What approach did you choose and why?
Included the image name as part of the instace information for docker builds as well. 
Since we were already using tags for this information, I decided to use the tag that included the stack-name (e.g. `travisci/ci-garnet:packer-1505167479`) instead of the language tag (e.g. `travis:ruby`) which was most frequently used.

## How can you test this?
* The updated unit-tests exhibit the correct behaviour
* Run it locally or in staging and check the instance information in the build logs