### PR TITLE
Do not attempt to remove links on container delete

### DIFF
--- a/backend/docker.go
+++ b/backend/docker.go
@@ -711,5 +711,5 @@ func containerNameFromContext(ctx gocontext.Context) string {
 	}
 
 	repoName = strings.Replace(repoName, "/", "-", -1)
-	return fmt.Sprintf("travis-job-%s-%s", repoName, jobID)
+	return fmt.Sprintf("travis-job-%v-%v", repoName, jobID)
 }

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -639,11 +639,12 @@ func (i *dockerInstance) Stop(ctx gocontext.Context) error {
 		return err
 	}
 
-	return i.client.ContainerRemove(ctx, i.container.ID, dockertypes.ContainerRemoveOptions{
-		RemoveVolumes: true,
-		RemoveLinks:   true,
-		Force:         true,
-	})
+	return i.client.ContainerRemove(ctx, i.container.ID,
+		dockertypes.ContainerRemoveOptions{
+			Force:         true,
+			RemoveLinks:   false,
+			RemoveVolumes: true,
+		})
 }
 
 func (i *dockerInstance) ID() string {


### PR DESCRIPTION
because attempting to remove them results in brokenness because we don't
create any links egad! :sweat_smile:

Also, set a container name with some meaning in it.

## What is the problem that this PR is trying to fix?

Closes #381 

## What approach did you choose and why?

Explicitly set `RemoveLinks: false` in the container removal config since the attempted link removal is breaking and we don't (shouldn't!) need to remove links that we never created.

## How can you test this?

- [x] staging ec2

## What feedback would you like, if any?

I folded in a different container naming here because I _thought_ it was related, but in the end it seems not to be.  Is the container naming sufficiently informative?
