### PR TITLE
Prepare for v3.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [3.1.0] - 2017-10-06
 
-_TODO_
+### Changed
+- backend/docker:
+    - switch to official client library
+    - display original image tag instead of language alias in log output
+    - set container name based on repo and job ID
+- cli: increase log level to "warn" for messages about receiving certain
+  signals.
+- processor: use the processor context when sending "Finish" state update
+
+### Fixed
+- backend/docker: do not remove links on container removal
 
 ## [3.0.2] - 2017-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Security
 
+## [3.1.0] - 2017-10-06
+
+_TODO_
+
 ## [3.0.2] - 2017-09-12
 
 ### Fixed
@@ -555,7 +559,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/travis-ci/worker/compare/v3.0.2...HEAD
+[Unreleased]: https://github.com/travis-ci/worker/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/travis-ci/worker/compare/v3.0.2...v3.1.0
 [3.0.2]: https://github.com/travis-ci/worker/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/travis-ci/worker/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/travis-ci/worker/compare/v2.11.0...v3.0.0


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Reducing the size of the Unreleased delta.

## What approach did you choose and why?

(prepare for) cutting a release!  [v3.0.2...v3.1.0](https://github.com/travis-ci/worker/compare/v3.0.2...HEAD)

## How can you test this?

- [x] staging deploy(s) + poking
- [x] production canary deploy(s)
- [x] fill in the v3.0.2...v3.1.0 changelog bits!
