### PR TITLE
Remove local var data race from processor test

### DIFF
--- a/processor_test.go
+++ b/processor_test.go
@@ -116,10 +116,10 @@ func TestProcessor(t *testing.T) {
 		}
 
 		if tc.isCancelled {
-			go func() {
-				time.Sleep(tc.runSleep - 1)
-				cancellationBroadcaster.Broadcast(jobID)
-			}()
+			go func(sl time.Duration, i uint64) {
+				time.Sleep(sl)
+				cancellationBroadcaster.Broadcast(i)
+			}(tc.runSleep-1, jobID)
 		}
 
 		jobChan <- job


### PR DESCRIPTION
Needed for #385 

## What is the problem that this PR is trying to fix?

Test failure due to data race.

## What approach did you choose and why?

Inject the values as func params instead of direct references to get around the race.

## How can you test this?

The tests!