### PR TITLE
Ensure container hostname does not exceed length limit

### DIFF
--- a/backend/docker_test.go
+++ b/backend/docker_test.go
@@ -593,7 +593,7 @@ func TestDocker_containerNameFromContext(t *testing.T) {
 		},
 		{
 			r: "very-SiLlY.nAmE.wat/por-cu-pine",
-			n: fmt.Sprintf("travis-job.very-SiLlY-nAmE-wat.por-cu-pine.%v", jobID),
+			n: fmt.Sprintf("travis-job.very-SiLlY-nAm.por-cu-pine.%v", jobID),
 		},
 	} {
 		ctx := context.FromRepository(context.FromJobID(gocontext.TODO(), jobID), tc.r)


### PR DESCRIPTION
Required for #385

## What is the problem that this PR is trying to fix?

Generated hostnames that exceed 64 characters result in an oci-level error inside docker, which is Not Good :tm:.

## What approach did you choose and why?

Enforce some limits to keep the generated container name and hostname at 64 chars and below.

## How can you test this?

Deploy + test on AWS staging

## What feedback would you like, if any?

Is allotting 10 chars for job id sufficient?