### PR TITLE
Add instance ID to StateUpdate metadata sent to hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
   colon-paired values in `TRAVIS_WORKER_DOCKER_BINDS`
 - http-job-queue: configurable new job polling interval
 - http-job: configurable job refresh claim interval
+- amqp-job: include instance name in state update sent to hub
 
 ### Changed
 - backend/gce: add site tag to job vms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- amqp-job: include instance name in state update sent to hub
 
 ### Changed
 
@@ -39,7 +40,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
   colon-paired values in `TRAVIS_WORKER_DOCKER_BINDS`
 - http-job-queue: configurable new job polling interval
 - http-job: configurable job refresh claim interval
-- amqp-job: include instance name in state update sent to hub
 
 ### Changed
 - backend/gce: add site tag to job vms

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ export TRAVIS_WORKER_DOCKER_CERT_PATH="/etc/secret-docker-cert-stuff"   # option
 
 #### Queue configuration
 
+#### File-based queue
+
 For the queue configuration, there is a file-based queue implementation so you
 don't have to mess around with RabbitMQ.
 
@@ -110,6 +112,23 @@ Place the file in the `$TRAVIS_WORKER_QUEUE_NAME/10-created.d/` directory, where
 it will be picked up by the worker.
 
 See `example-payload.json` for an example payload.
+
+#### AMQP-based queue
+
+```
+export TRAVIS_WORKER_QUEUE_TYPE='amqp'
+export TRAVIS_WORKER_AMQP_URI='amqp://guest:guest@localhost'
+```
+
+The web interface is accessible at http://localhost:15672/
+
+To verify your messages are being published, try:
+
+`$ rabbitmqadmin get queue=reporting.jobs.builds`
+
+Note: You will first need to install `rabbitmqadmin`. See http://localhost:15672/cli
+
+See `script/publish-example-payload` for a script to enqueue `example-payload.json`.
 
 ### Building and running
 

--- a/amqp_job.go
+++ b/amqp_job.go
@@ -125,7 +125,6 @@ func (j *amqpJob) LogWriter(ctx gocontext.Context, defaultLogTimeout time.Durati
 }
 
 func (j *amqpJob) createStateUpdateBody(ctx gocontext.Context, state string) map[string]interface{} {
-
 	body := map[string]interface{}{
 		"id":    j.Payload().Job.ID,
 		"state": state,

--- a/amqp_job_test.go
+++ b/amqp_job_test.go
@@ -179,7 +179,7 @@ func TestAMQPJob_Finish(t *testing.T) {
 
 func TestAMQPJob_createStateUpdateBody(t *testing.T) {
 	job := newTestAMQPJob(t)
-	body := job.createStateUpdateBody("foo")
+	body := job.createStateUpdateBody(gocontext.TODO(), "foo")
 
 	assert.Equal(t, "foo", body["state"])
 
@@ -194,15 +194,17 @@ func TestAMQPJob_createStateUpdateBody(t *testing.T) {
 		assert.Contains(t, body, key)
 	}
 
+	assert.Equal(t, body["meta"].(map[string]interface{})["instance_id"], nil)
+
 	job.received = time.Time{}
-	assert.NotContains(t, job.createStateUpdateBody("foo"), "received_at")
+	assert.NotContains(t, job.createStateUpdateBody(gocontext.TODO(), "foo"), "received_at")
 
 	job.Payload().Job.QueuedAt = nil
-	assert.NotContains(t, job.createStateUpdateBody("foo"), "queued_at")
+	assert.NotContains(t, job.createStateUpdateBody(gocontext.TODO(), "foo"), "queued_at")
 
 	job.started = time.Time{}
-	assert.NotContains(t, job.createStateUpdateBody("foo"), "started_at")
+	assert.NotContains(t, job.createStateUpdateBody(gocontext.TODO(), "foo"), "started_at")
 
 	job.finished = time.Time{}
-	assert.NotContains(t, job.createStateUpdateBody("foo"), "finished_at")
+	assert.NotContains(t, job.createStateUpdateBody(gocontext.TODO(), "foo"), "finished_at")
 }

--- a/backend/cloudbrain.go
+++ b/backend/cloudbrain.go
@@ -622,7 +622,11 @@ func (i *cbInstance) stepWaitForInstanceDeleted(c *cbInstanceStopContext) multis
 }
 
 func (i *cbInstance) ID() string {
-	return fmt.Sprintf("%s:%s", i.instance.ID, i.imageName)
+	return i.instance.ID
+}
+
+func (i *cbInstance) ImageName() string {
+	return i.imageName
 }
 
 func (i *cbInstance) StartupDuration() time.Duration {

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -691,7 +691,12 @@ func (i *dockerInstance) ID() string {
 	if i.container == nil {
 		return "{unidentified}"
 	}
-	return fmt.Sprintf("%s:%s", i.container.ID[0:7], i.imageName)
+
+	return i.container.ID[0:7]
+}
+
+func (i *dockerInstance) ImageName() string {
+	return i.imageName
 }
 
 func (i *dockerInstance) StartupDuration() time.Duration {

--- a/backend/docker_test.go
+++ b/backend/docker_test.go
@@ -606,8 +606,9 @@ func TestDockerInstance_ID(t *testing.T) {
 		startBooting: now,
 	}
 
-	assert.Equal(t, "beabeba:fafafaf", instance.ID())
+	assert.Equal(t, "beabeba", instance.ID())
+	assert.Equal(t, "fafafaf", instance.ImageName())
 
 	instance.container = nil
-	assert.Equal(t, "{unidentified}", instance.ImageName())
+	assert.Equal(t, "{unidentified}", instance.ID())
 }

--- a/backend/docker_test.go
+++ b/backend/docker_test.go
@@ -143,8 +143,12 @@ func TestDockerProvider_Start(t *testing.T) {
 				t.Errorf("provider.Start() returned error: %v", err)
 			}
 
-			if instance.ID() != "f2e475c:travisci/ci-amethyst:packer-1504724461" {
-				t.Errorf("Provider returned unexpected ID (\"%s\" != \"f2e475c:travisci/ci-amethyst:packer-1504724461\"", instance.ID())
+			if instance.ID() != "f2e475c" {
+				t.Errorf("Provider returned unexpected ID (\"%s\" != \"f2e475c\"", instance.ID())
+			}
+
+			if instance.ImageName() != "travisci/ci-amethyst:packer-1504724461" {
+				t.Errorf("Provider returned unexpected ImageName (\"%s\" != \"travisci/ci-amethyst:packer-1504724461\"", instance.ID())
 			}
 		}()
 	}
@@ -227,8 +231,12 @@ func TestDockerProvider_Start_WithPrivileged(t *testing.T) {
 				t.Errorf("provider.Start() returned error: %v", err)
 			}
 
-			if instance.ID() != "f2e475c:travisci/ci-amethyst:packer-1504724461" {
-				t.Errorf("Provider returned unexpected ID (\"%s\" != \"f2e475c:travisci/ci-amethyst:packer-1504724461\"", instance.ID())
+			if instance.ID() != "f2e475c" {
+				t.Errorf("Provider returned unexpected ID (\"%s\" != \"f2e475c\"", instance.ID())
+			}
+
+			if instance.ImageName() != "travisci/ci-amethyst:packer-1504724461" {
+				t.Errorf("Provider returned unexpected ImageName (\"%s\" != \"travisci/ci-amethyst:packer-1504724461\"", instance.ImageName())
 			}
 		}()
 	}
@@ -601,5 +609,5 @@ func TestDockerInstance_ID(t *testing.T) {
 	assert.Equal(t, "beabeba:fafafaf", instance.ID())
 
 	instance.container = nil
-	assert.Equal(t, "{unidentified}", instance.ID())
+	assert.Equal(t, "{unidentified}", instance.ImageName())
 }

--- a/backend/fake.go
+++ b/backend/fake.go
@@ -76,6 +76,10 @@ func (i *fakeInstance) ID() string {
 	return "fake"
 }
 
+func (i *fakeInstance) ImageName() string {
+	return "fake"
+}
+
 func (i *fakeInstance) StartupDuration() time.Duration {
 	return i.startupDuration
 }

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -653,7 +653,6 @@ func (p *gceProvider) Start(ctx gocontext.Context, startAttributes *StartAttribu
 		}
 	}(c)
 
-	logger.Info("starting instance")
 	go runner.Run(state)
 
 	logger.Debug("selecting over instance, error, and done channels")

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -1204,7 +1204,11 @@ func (i *gceInstance) stepWaitForInstanceDeleted(c *gceInstanceStopContext) mult
 }
 
 func (i *gceInstance) ID() string {
-	return fmt.Sprintf("%s:%s", i.instance.Name, i.imageName)
+	return i.instance.Name
+}
+
+func (i *gceInstance) ImageName() string {
+	return i.imageName
 }
 
 func (i *gceInstance) StartupDuration() time.Duration {

--- a/backend/jupiterbrain.go
+++ b/backend/jupiterbrain.go
@@ -363,7 +363,14 @@ func (i *jupiterBrainInstance) ID() string {
 	if i.payload == nil {
 		return "{unidentified}"
 	}
-	return fmt.Sprintf("%s:%s", i.payload.ID, i.payload.BaseImage)
+	return i.payload.ID
+}
+
+func (i *jupiterBrainInstance) ImageName() string {
+	if i.payload == nil {
+		return "{unidentified}"
+	}
+	return i.payload.BaseImage
 }
 
 func (i *jupiterBrainInstance) StartupDuration() time.Duration {

--- a/backend/local.go
+++ b/backend/local.go
@@ -118,4 +118,8 @@ func (i *localInstance) ID() string {
 	return fmt.Sprintf("local:%s", i.scriptPath)
 }
 
+func (i *localInstance) ImageName() string {
+	return ""
+}
+
 func (i *localInstance) StartupDuration() time.Duration { return zeroDuration }

--- a/backend/openstack.go
+++ b/backend/openstack.go
@@ -647,7 +647,11 @@ func (i *osInstance) ID() string {
 	if i.instance == nil {
 		return "{unidentified}"
 	}
-	return fmt.Sprintf("%s:%s", i.instance.ID, i.imageName)
+	return i.instance.ID
+}
+
+func (i *osInstance) ImageName() string {
+	return i.imageName
 }
 
 func (i *osInstance) StartupDuration() time.Duration {

--- a/backend/package.go
+++ b/backend/package.go
@@ -81,6 +81,9 @@ type Instance interface {
 	// ID is used when identifying the instance in logs and such
 	ID() string
 
+	// ImageName is the name of the image used to boot the instance
+	ImageName() string
+
 	// StartupDuration is the duration between "created" and "ready"
 	StartupDuration() time.Duration
 }

--- a/script/publish-example-payload
+++ b/script/publish-example-payload
@@ -1,0 +1,19 @@
+#!/usr/bin/python3
+import os
+import pika
+
+
+top = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+
+with open(os.path.join(top, 'example-payload.json'), 'r') as f:
+    data = f.read()
+
+connection = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
+channel = connection.channel()
+
+channel.basic_publish(exchange='',
+                      routing_key=os.environ["TRAVIS_WORKER_QUEUE_NAME"],
+                      body=data)
+print(" [x] Sent 'Enqueued the thing!'")
+
+connection.close()

--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -57,7 +57,11 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 
-	logger.WithField("boot_time", time.Since(startTime)).WithField("instance_id", instance.ID()).Info("started instance")
+	logger.WithFields(logrus.Fields{
+		"boot_time":   time.Since(startTime),
+		"instance_id": instance.ID(),
+		"image_name":  instance.ImageName(),
+	}).Info("started instance")
 
 	state.Put("instance", instance)
 

--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -59,9 +59,7 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 
 	logger.WithField("boot_time", time.Since(startTime)).WithField("instance_id", instance.ID()).Info("started instance")
 
-	ctx = context.FromInstanceID(ctx, instance.ID())
 	state.Put("instance", instance)
-	state.Put("ctx", ctx)
 
 	return multistep.ActionContinue
 }

--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -57,9 +57,11 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 
-	logger.WithField("boot_time", time.Since(startTime)).Info("started instance")
+	logger.WithField("boot_time", time.Since(startTime)).WithField("instance_id", instance.ID()).Info("started instance")
 
+	ctx = context.FromInstanceID(ctx, instance.ID())
 	state.Put("instance", instance)
+	state.Put("ctx", ctx)
 
 	return multistep.ActionContinue
 }

--- a/step_update_state.go
+++ b/step_update_state.go
@@ -17,13 +17,17 @@ func (s *stepUpdateState) Run(state multistep.StateBag) multistep.StepAction {
 	instanceID := instance.ID()
 
 	ctx := state.Get("ctx").(gocontext.Context)
-	ctx = context.FromInstanceID(ctx, instanceID)
+	if instanceID != "" {
+		ctx = context.FromInstanceID(ctx, instanceID)
+		state.Put("ctx", ctx)
+	}
 
 	err := buildJob.Started(ctx)
 	if err != nil {
 		context.LoggerFromContext(ctx).WithFields(logrus.Fields{
-			"err":  err,
-			"self": "step_update_state",
+			"err":         err,
+			"self":        "step_update_state",
+			"instance_id": instanceID,
 		}).Error("couldn't mark job as started")
 	}
 

--- a/step_update_state.go
+++ b/step_update_state.go
@@ -13,7 +13,11 @@ type stepUpdateState struct{}
 
 func (s *stepUpdateState) Run(state multistep.StateBag) multistep.StepAction {
 	buildJob := state.Get("buildJob").(Job)
+	instance := state.Get("instance").(backend.Instance)
+	instanceID := instance.ID()
+
 	ctx := state.Get("ctx").(gocontext.Context)
+	ctx = context.FromInstanceID(ctx, instanceID)
 
 	err := buildJob.Started(ctx)
 	if err != nil {

--- a/step_write_worker_info.go
+++ b/step_write_worker_info.go
@@ -21,7 +21,7 @@ func (s *stepWriteWorkerInfo) Run(state multistep.StateBag) multistep.StepAction
 			"\033[33;1mWorker information\033[0m",
 			fmt.Sprintf("hostname: %s", hostname),
 			fmt.Sprintf("version: %s %s", VersionString, RevisionURLString),
-			fmt.Sprintf("instance: %s (via %s)", instance.ID(), buildJob.Name()),
+			fmt.Sprintf("instance: %s %s (via %s)", instance.ID(), instance.ImageName(), buildJob.Name()),
 			fmt.Sprintf("startup: %v", instance.StartupDuration()),
 		}, "\n")))
 	}

--- a/step_write_worker_info_test.go
+++ b/step_write_worker_info_test.go
@@ -66,7 +66,7 @@ func TestStepWriteWorkerInfo_Run(t *testing.T) {
 	assert.Contains(t, out, "\033[33;1mWorker information\033[0m\n")
 	assert.Contains(t, out, "\nhostname: frizzlefry.example.local\n")
 	assert.Contains(t, out, "\nversion: "+VersionString+" "+RevisionURLString+"\n")
-	assert.Contains(t, out, "\ninstance: fake (via fake)\n")
+	assert.Contains(t, out, "\ninstance: fake fake (via fake)\n")
 	assert.Contains(t, out, "\nstartup: 42.17s\n")
 	assert.Contains(t, out, "\ntravis_fold:end:worker_info\r\033[0K")
 }


### PR DESCRIPTION
This PR:

* Adds instance ID to StateUpdate metadata. 
* Adds `script/publish-example-payload` to facilitate local development with AMQP.
* Updates README.md.

## What is the problem that this PR is trying to fix?

Addresses https://github.com/travis-pro/gcp-ddos-detector/issues/1

## What approach did you choose and why?

* Added an `instance` field to the `amqpJob` type
* If instance isn't null, copy its ID to the meta field of the body created in `createStateUpdateBody`

## How can you test this?

#### The easy way

`AMQP_URI="amqp://" go test -v . -test.run TestAMQPJob_createStateUpdateBody`

#### The hard way

* From the [aj-docker-bits](https://github.com/travis-ci/travis-hub/tree/aj-docker-bits) branch of `travis-hub`, run `docker-compose up`
* Export the environment variables that have been added to the README in this PR
* Run `travis-worker`
* Run `script/publish-example-payload` to add an example queue message
* Run `docker-compose exec rabbitmq bash`. In the container:
  * enable management plugin: `rabbitmq-plugins enable rabbitmq_management`
  * `apt update && apt install wget python`
  * `wget localhost:15672/cli/rabbitmqadmin && chmod +x /rabbitmqadmin`
* Run `./script/publish-example-payload` from your host

You should be able to see an extra key in the payload metadata by running the command below in the container:

```
root@2dffdc25e3c9:/# /rabbitmqadmin get queue=reporting.jobs.builds requeue=false -f long

--------------------------------------------------------------------------------

     routing_key: reporting.jobs.builds
        exchange: 
   message_count: 0
         payload: {"id":623773,"meta":{"instance_id":"unknown instance","state_update_count":2},"queued_at":"2017-09-08T12:12:36Z","received_at":"2017-10-11T18:23:30Z","state":"reset"}
   payload_bytes: 166
payload_encoding: string
     redelivered: False

--------------------------------------------------------------------------------
```

### On staging

`trvs redis-cli travis-staging REDIS_URL keys 'hub.instance_id_job.*'`

## What feedback would you like, if any?

1. Running this locally, I get an instance ID of `null`. I assume that's because I'm not GCE. Should this work on cloud VMs?

2. If so: Do I need to do something similar for the HTTP queue as well?