### PR TITLE
add site tag to gcp provider for instance filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 ### Changed
+- backend/gce:
+    - add site tag to job vms
 
 ### Deprecated
 

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -11,6 +11,7 @@ import (
 	mathrand "math/rand"
 	"net/http"
 	"net/url"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -342,8 +343,8 @@ func newGCEProvider(cfg *config.ProviderConfig) (Provider, error) {
 	}
 
 	site := "none"
-	if cfg.IsSet("TRAVIS_SITE") {
-		site = cfg.Get("TRAVIS_SITE")
+	if os.Getenv("TRAVIS_WORKER_TRAVIS_SITE") != "" {
+		site = os.Getenv("TRAVIS_WORKER_TRAVIS_SITE")
 	}
 
 	uploadRetries := defaultGCEUploadRetries

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -11,7 +11,6 @@ import (
 	mathrand "math/rand"
 	"net/http"
 	"net/url"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -343,8 +342,8 @@ func newGCEProvider(cfg *config.ProviderConfig) (Provider, error) {
 	}
 
 	site := "none"
-	if os.Getenv("TRAVIS_WORKER_TRAVIS_SITE") != "" {
-		site = os.Getenv("TRAVIS_WORKER_TRAVIS_SITE")
+	if cfg.IsSet("TRAVIS_SITE") {
+		site = cfg.Get("TRAVIS_SITE")
 	}
 
 	uploadRetries := defaultGCEUploadRetries

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -181,6 +181,7 @@ type gceInstanceConfig struct {
 	Preemptible        bool
 	PublicIP           bool
 	PublicIPConnect    bool
+	Site               string
 }
 
 type gceStartMultistepWrapper struct {
@@ -340,6 +341,11 @@ func newGCEProvider(cfg *config.ProviderConfig) (Provider, error) {
 		skipStopPoll = ssp
 	}
 
+	site := "none"
+	if cfg.IsSet("TRAVIS_SITE") {
+		site = cfg.Get("TRAVIS_SITE")
+	}
+
 	uploadRetries := defaultGCEUploadRetries
 	if cfg.IsSet("UPLOAD_RETRIES") {
 		ur, err := strconv.ParseUint(cfg.Get("UPLOAD_RETRIES"), 10, 64)
@@ -472,6 +478,7 @@ func newGCEProvider(cfg *config.ProviderConfig) (Provider, error) {
 			StopPollSleep:    stopPollSleep,
 			StopPrePollSleep: stopPrePollSleep,
 			SkipStopPoll:     skipStopPoll,
+			Site:             site,
 		},
 
 		imageSelector:     imageSelector,
@@ -923,6 +930,7 @@ func (p *gceProvider) buildInstance(startAttributes *StartAttributes, imageLink,
 		Tags: &compute.Tags{
 			Items: []string{
 				"testing",
+				"site-" + p.ic.Site,
 			},
 		},
 	}

--- a/cli.go
+++ b/cli.go
@@ -137,6 +137,10 @@ func (i *CLI) Setup() (bool, error) {
 
 	i.BuildScriptGenerator = generator
 
+	if i.Config.TravisSite != "" {
+		i.Config.ProviderConfig.Set("TRAVIS_SITE", i.Config.TravisSite)
+	}
+
 	provider, err := backend.NewBackendProvider(i.Config.ProviderName, i.Config.ProviderConfig)
 	if err != nil {
 		logger.WithField("err", err).Error("couldn't create backend provider")


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

We need the ability to filter instances by site in order to correctly route alerts in stackdriver to the correct webhook endpoint.

## What approach did you choose and why?

This patch allows the site to be specified via an env var, it will be attached as a network tag to all job VMs.

## How can you test this?

We can deploy it to staging and check a newly booted instance for its network tags. It should include `testing` and `site-<site>` -- e.g. `site-org`.

## What feedback would you like, if any?
