### PR TITLE
Switch from SIGWINCH to SIGUSR2 for graceful shutdown + pause

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -490,7 +490,7 @@ func (i *CLI) signalHandler() {
 	signal.Notify(signalChan,
 		syscall.SIGTERM, syscall.SIGINT, syscall.SIGUSR1,
 		syscall.SIGTTIN, syscall.SIGTTOU,
-		syscall.SIGWINCH)
+		syscall.SIGUSR2)
 
 	for {
 		select {
@@ -508,8 +508,8 @@ func (i *CLI) signalHandler() {
 			case syscall.SIGTTOU:
 				i.logger.Info("SIGTTOU received, removing processor from pool")
 				i.ProcessorPool.Decr()
-			case syscall.SIGWINCH:
-				i.logger.Warn("SIGWINCH received, toggling graceful shutdown and pause")
+			case syscall.SIGUSR2:
+				i.logger.Warn("SIGUSR2 received, toggling graceful shutdown and pause")
 				i.ProcessorPool.GracefulShutdown(true)
 			case syscall.SIGUSR1:
 				i.logProcessorInfo("received SIGUSR1")


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Running `travis-worker` inside anything that sends `SIGWINCH` runs the risk of unintentionally triggering a graceful shutdown with toggle pause.

## What approach did you choose and why?

Use `SIGUSR2` instead, since we weren't already using it and it's available.

## How can you test this?

Run `travis-worker`, send `SIGWINCH`, see it get ignored.

## What feedback would you like, if any?

Is `SIGUSR2` OK?
