### PR TITLE
Consistently construct GCE and Docker hostnames

### DIFF
--- a/backend/docker_test.go
+++ b/backend/docker_test.go
@@ -6,7 +6,6 @@ import (
 	gocontext "context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -19,7 +18,6 @@ import (
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/assert"
 	"github.com/travis-ci/worker/config"
-	"github.com/travis-ci/worker/context"
 )
 
 var (
@@ -581,28 +579,4 @@ func TestDockerInstance_ID(t *testing.T) {
 
 	instance.container = nil
 	assert.Equal(t, "{unidentified}", instance.ID())
-}
-
-func TestDocker_containerNameFromContext(t *testing.T) {
-	jobID := rand.Uint64()
-
-	for _, tc := range []struct{ r, n string }{
-		{
-			r: "friendly/fribble",
-			n: fmt.Sprintf("travis-job-friendly-fribble-%v", jobID),
-		},
-		{
-			r: "very-SiLlY.nAmE.wat/por-cu-pine",
-			n: fmt.Sprintf("travis-job-very-SiLlY-nAm-por-cu-pine-%v", jobID),
-		},
-	} {
-		ctx := context.FromRepository(context.FromJobID(gocontext.TODO(), jobID), tc.r)
-		assert.Equal(t, tc.n, containerNameFromContext(ctx))
-	}
-
-	randName := containerNameFromContext(gocontext.TODO())
-	randParts := strings.Split(randName, "-")
-	assert.Len(t, randParts, 9)
-	assert.Equal(t, "unk", randParts[2])
-	assert.Equal(t, "unk", randParts[3])
 }

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/cenk/backoff"
 	"github.com/mitchellh/multistep"
-	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/travis-ci/worker/config"
@@ -702,7 +701,7 @@ func (p *gceProvider) stepRenderScript(c *gceStartContext) multistep.StepAction 
 }
 
 func (p *gceProvider) stepInsertInstance(c *gceStartContext) multistep.StepAction {
-	inst := p.buildInstance(c.startAttributes, c.image.SelfLink, c.script)
+	inst := p.buildInstance(c.ctx, c.startAttributes, c.image.SelfLink, c.script)
 
 	context.LoggerFromContext(c.ctx).WithFields(logrus.Fields{
 		"self":     "backend/gce_provider",
@@ -863,7 +862,7 @@ func buildGCEImageSelector(selectorType string, cfg *config.ProviderConfig) (ima
 	}
 }
 
-func (p *gceProvider) buildInstance(startAttributes *StartAttributes, imageLink, startupScript string) *compute.Instance {
+func (p *gceProvider) buildInstance(ctx gocontext.Context, startAttributes *StartAttributes, imageLink, startupScript string) *compute.Instance {
 	var machineType *compute.MachineType
 	switch startAttributes.VMType {
 	case "premium":
@@ -915,7 +914,7 @@ func (p *gceProvider) buildInstance(startAttributes *StartAttributes, imageLink,
 			Preemptible: p.ic.Preemptible,
 		},
 		MachineType: machineType.SelfLink,
-		Name:        fmt.Sprintf("testing-gce-%s", uuid.NewRandom()),
+		Name:        hostnameFromContext(ctx),
 		Metadata: &compute.Metadata{
 			Items: []*compute.MetadataItems{
 				&compute.MetadataItems{

--- a/backend/package_test.go
+++ b/backend/package_test.go
@@ -1,11 +1,15 @@
 package backend
 
 import (
+	gocontext "context"
 	"fmt"
+	"math/rand"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/travis-ci/worker/context"
 )
 
 type recordingHTTPTransport struct {
@@ -17,7 +21,7 @@ func (t *recordingHTTPTransport) RoundTrip(req *http.Request) (*http.Response, e
 	return nil, fmt.Errorf("recording HTTP transport impl")
 }
 
-func TestAsBool(t *testing.T) {
+func Test_asBool(t *testing.T) {
 	for s, b := range map[string]bool{
 		"yes":     true,
 		"on":      true,
@@ -35,4 +39,28 @@ func TestAsBool(t *testing.T) {
 	} {
 		assert.Equal(t, b, asBool(s))
 	}
+}
+
+func Test_hostnameFromContext(t *testing.T) {
+	jobID := rand.Uint64()
+
+	for _, tc := range []struct{ r, n string }{
+		{
+			r: "friendly/fribble",
+			n: fmt.Sprintf("travis-job-friendly-fribble-%v", jobID),
+		},
+		{
+			r: "very-SiLlY.nAmE.wat/por-cu-pine",
+			n: fmt.Sprintf("travis-job-very-SiLlY-nAm-por-cu-pine-%v", jobID),
+		},
+	} {
+		ctx := context.FromRepository(context.FromJobID(gocontext.TODO(), jobID), tc.r)
+		assert.Equal(t, tc.n, hostnameFromContext(ctx))
+	}
+
+	randName := hostnameFromContext(gocontext.TODO())
+	randParts := strings.Split(randName, "-")
+	assert.Len(t, randParts, 9)
+	assert.Equal(t, "unk", randParts[2])
+	assert.Equal(t, "unk", randParts[3])
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Inconsistent hostname generation between the two most-used backends in production.

## What approach did you choose and why?

Use the same hostname generation func in both cases.

## How can you test this?

The tests + canary deployment in staging.

## What feedback would you like, if any?

Should this be applied to other backends where possible?
