### PR TITLE
change site tag from site-{org,com} to just {org,com}

### DIFF
--- a/backend/gce.go
+++ b/backend/gce.go
@@ -340,7 +340,7 @@ func newGCEProvider(cfg *config.ProviderConfig) (Provider, error) {
 		skipStopPoll = ssp
 	}
 
-	site := "none"
+	site := ""
 	if cfg.IsSet("TRAVIS_SITE") {
 		site = cfg.Get("TRAVIS_SITE")
 	}
@@ -895,6 +895,11 @@ func (p *gceProvider) buildInstance(ctx gocontext.Context, startAttributes *Star
 		}
 	}
 
+	tags := []string{"testing"}
+	if p.ic.Site != "" {
+		tags = append(tags, p.ic.Site)
+	}
+
 	return &compute.Instance{
 		Description: fmt.Sprintf("Travis CI %s test VM", startAttributes.Language),
 		Disks: []*compute.AttachedDisk{
@@ -927,10 +932,7 @@ func (p *gceProvider) buildInstance(ctx gocontext.Context, startAttributes *Star
 			networkInterface,
 		},
 		Tags: &compute.Tags{
-			Items: []string{
-				"testing",
-				"site-" + p.ic.Site,
-			},
+			Items: tags,
 		},
 	}
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

this patch is a follow-up to https://github.com/travis-ci/worker/pull/389.

this change was made in order for tag names to be consistent. the naming change is in line with other resources managed by terraform.
