### PR TITLE
Check CPUsets back in if not needed, and be verbose about it.

### DIFF
--- a/backend/docker.go
+++ b/backend/docker.go
@@ -366,7 +366,7 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 		},
 	}
 
-	cpuSets, err := p.checkoutCPUSets()
+	cpuSets, err := p.checkoutCPUSets(ctx)
 	if err != nil {
 		logger.WithFields(logrus.Fields{
 			"err":            err,
@@ -375,7 +375,6 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 		}).Error("couldn't checkout CPUSets")
 		return nil, err
 	}
-	logger.WithField("cpu_sets", cpuSets).Info("checked out")
 
 	if cpuSets != "" {
 		dockerHostConfig.Resources.CpusetCpus = cpuSets
@@ -390,6 +389,9 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 		ctx, dockerConfig, dockerHostConfig, nil, containerName)
 
 	if err != nil {
+		logger.WithField("err", err).Error("couldn't create container")
+		defer p.checkinCPUSets(ctx, cpuSets)
+
 		err := p.client.ContainerRemove(ctx, container.ID,
 			dockertypes.ContainerRemoveOptions{
 				Force:         true,
@@ -450,7 +452,7 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 
 func (p *dockerProvider) Setup(ctx gocontext.Context) error { return nil }
 
-func (p *dockerProvider) checkoutCPUSets() (string, error) {
+func (p *dockerProvider) checkoutCPUSets(ctx gocontext.Context) (string, error) {
 	p.cpuSetsMutex.Lock()
 	defer p.cpuSetsMutex.Unlock()
 
@@ -477,19 +479,33 @@ func (p *dockerProvider) checkoutCPUSets() (string, error) {
 		cpuSetsString = append(cpuSetsString, fmt.Sprintf("%d", cpuSet))
 	}
 
+	logger := context.LoggerFromContext(ctx).WithField("self", "backend/docker_provider")
+	logger.WithField("cpu_sets", cpuSetsString).Info("checked out")
 	return strings.Join(cpuSetsString, ","), nil
 }
 
-func (p *dockerProvider) checkinCPUSets(sets string) {
+func (p *dockerProvider) checkinCPUSets(ctx gocontext.Context, sets string) {
 	p.cpuSetsMutex.Lock()
 	defer p.cpuSetsMutex.Unlock()
+	logger := context.LoggerFromContext(ctx).WithField("self", "backend/docker_provider")
 
 	for _, cpuString := range strings.Split(sets, ",") {
 		cpu, err := strconv.ParseUint(cpuString, 10, 64)
 		if err != nil {
+			logger.WithFields(logrus.Fields{
+				"err":        err,
+				"cpu_string": cpuString,
+			}).Error("couldn't checkin CPU")
 			continue
 		}
+
+		if !p.cpuSets[int(cpu)] {
+			logger.WithField("cpu_set", cpuString).Info("already checked in")
+			continue
+		}
+
 		p.cpuSets[int(cpu)] = false
+		logger.WithField("cpu_sets", sets).Info("checked in")
 	}
 }
 
@@ -636,7 +652,7 @@ func (i *dockerInstance) runScriptSSH(ctx gocontext.Context, output io.Writer) (
 }
 
 func (i *dockerInstance) Stop(ctx gocontext.Context) error {
-	defer i.provider.checkinCPUSets(i.container.HostConfig.Resources.CpusetCpus)
+	defer i.provider.checkinCPUSets(ctx, i.container.HostConfig.Resources.CpusetCpus)
 
 	timeout := 30 * time.Second
 	err := i.client.ContainerStop(ctx, i.container.ID, &timeout)
@@ -656,7 +672,6 @@ func (i *dockerInstance) ID() string {
 	if i.container == nil {
 		return "{unidentified}"
 	}
-
 	return fmt.Sprintf("%s:%s", i.container.ID[0:7], i.imageName)
 }
 

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -409,6 +409,7 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 
 	err = p.client.ContainerStart(ctx, container.ID, dockertypes.ContainerStartOptions{})
 	if err != nil {
+		defer p.checkinCPUSets(ctx, cpuSets)
 		return nil, err
 	}
 

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -512,7 +512,7 @@ func (p *dockerProvider) checkinCPUSets(ctx gocontext.Context, sets string) {
 			logger.WithFields(logrus.Fields{
 				"err":        err,
 				"cpu_string": cpuString,
-			}).Error("couldn't checkin CPU")
+			}).Error("couldn't parse CPU string; CPU set not checked in")
 			continue
 		}
 

--- a/backend/docker_test.go
+++ b/backend/docker_test.go
@@ -115,6 +115,7 @@ func TestDockerProvider_Start(t *testing.T) {
 
 			dockerTestMux.HandleFunc(fmt.Sprintf("/v%s/containers/%s/json", dockerAPIVersion, containerName), func(w http.ResponseWriter, r *http.Request) {
 				containerStatusBytes, _ := json.Marshal(containerStatus)
+				w.WriteHeader(404)
 				w.Write(containerStatusBytes)
 			})
 

--- a/backend/docker_test.go
+++ b/backend/docker_test.go
@@ -133,7 +133,7 @@ func TestDockerProvider_Start(t *testing.T) {
 				w.WriteHeader(400)
 			})
 
-			instance, err := dockerTestProvider.Start(gocontext.TODO(), &StartAttributes{
+			instance, err := dockerTestProvider.Start(ctx, &StartAttributes{
 				Language: "jvm",
 				Group:    "",
 			})

--- a/backend/docker_test.go
+++ b/backend/docker_test.go
@@ -73,7 +73,7 @@ func TestDockerProvider_Start(t *testing.T) {
 			defer dockerTestTeardown()
 
 			ctx := context.FromJobID(gocontext.TODO(), 123)
-			ctx = context.FromRepository(ctx, "foobar")
+			ctx = context.FromRepository(ctx, "foobar/quux")
 			containerName := hostnameFromContext(ctx)
 
 			// The client expects this to be sufficiently long

--- a/backend/package.go
+++ b/backend/package.go
@@ -127,13 +127,17 @@ func hostnameFromContext(ctx gocontext.Context) string {
 	randName := fmt.Sprintf("travis-job-unk-unk-%s", uuid.NewRandom())
 	jobID, ok := context.JobIDFromContext(ctx)
 	if !ok {
+		fmt.Println("no job ID found")
 		return randName
 	}
+	fmt.Println("found job id", jobID)
 
 	repoName, ok := context.RepositoryFromContext(ctx)
 	if !ok {
+		fmt.Println("no repoName found")
 		return randName
 	}
+	fmt.Println("found repoName ", repoName)
 
 	nameParts := []string{"travis-job"}
 	for _, part := range strings.Split(repoName, "/") {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

- Container creation fails when a stray container exists with the same name.
- CPUsets aren't getting checked back in when container creation fails.

This combination results in cascading requeues (each time a job is requeued on the same instance, the worker loses track of that CPU set).

## What approach did you choose and why?

- Make worker check for a preexisting container with the same name. If it exists, delete it.
- Check CPU sets back in when container creation fails.
- Add some logging around the above.

## How can you test this?

Run some jobs. Restart docker while the jobs are running, which should result in `Exited` containers (`docker ps -a`). Logs should show CPU sets being checked back in, and `Exited` containers being deleted.

## What feedback would you like, if any?
