### PR TITLE
pin docker version

### DIFF
--- a/bin/travis-worker-install
+++ b/bin/travis-worker-install
@@ -185,11 +185,9 @@ __install_docker() {
 
   apt-get update
 
-  if ! docker version &>/dev/null; then
-    apt-get install -y \
-      "linux-image-extra-$(uname -r)" \
-      docker-ce
-  fi
+  apt-get install -y \
+    "linux-image-extra-$(uname -r)" \
+    docker-ce=17.09.0~ce-0~ubuntu
 
   if [[ $AWS == true ]]; then
     local docker_mount_point='--graph=/mnt/docker'


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The version of docker we're running (`17.03.1-ce`) is outdated because we only install it if it's not already present:
```
  if ! docker version &>/dev/null; then
    apt-get install -y \
      "linux-image-extra-$(uname -r)" \
      docker-ce
  fi
```

## What approach did you choose and why?

Instead of installing if not present, we install a specific version of Docker.
