### PR TITLE
Use polling and refresh claim intervals from response if present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 - http-job-queue: use polling and refresh claim intervals from job delivery
   responses, if available
-- amqp-job: include instance name in state update sent to hub
 
 ### Changed
 - processor: improved logging around requeue conditions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- http-job-queue: use polling and refresh claim intervals from job delivery
+  responses, if available
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
-- http-job-queue: use polling and refresh claim intervals from job delivery
-  responses, if available
 
 ### Changed
+- http-job-queue: use polling and refresh claim intervals from job delivery
+  responses, if available
 
 ### Deprecated
 


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The intervals used in the job polling loop and job claim refresh loop are tunable, but ideal values remain TBD.  Changing worker configuration is very disruptive.

## What approach did you choose and why?

Use polling and refresh claim intervals returned in responses from job-board, if present.  See https://github.com/travis-ci/job-board/pull/76.

## How can you test this?

Tests + staging deploy
