### PR TITLE
Ensure hostname does not contain "_"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Removed
 
 ### Fixed
+- backend: ensure generated hostnames do not contain `_`
 
 ### Security
 

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -63,8 +62,6 @@ var (
 		"IMAGE_SELECTOR_URL":  "URL for image selector API, used only when image selector is \"api\"",
 		"BINDS":               "Bind mount a volume (example: \"/var/run/docker.sock:/var/run/docker.sock\", default \"\")",
 	}
-
-	containerNamePartDisallowed = regexp.MustCompile("[^a-zA-Z0-9_-]+")
 )
 
 func init() {

--- a/backend/package.go
+++ b/backend/package.go
@@ -32,6 +32,7 @@ import (
 	gocontext "context"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 	"time"
 
@@ -50,6 +51,9 @@ var (
 	ErrMissingEndpointConfig = fmt.Errorf("expected config key endpoint")
 
 	zeroDuration time.Duration
+
+	hostnamePartsDisallowed = regexp.MustCompile("[^a-zA-Z0-9-]+")
+	multiDash               = regexp.MustCompile("-+")
 )
 
 // Provider represents some kind of instance provider. It can point to an
@@ -137,7 +141,7 @@ func hostnameFromContext(ctx gocontext.Context) string {
 
 	nameParts := []string{"travis-job"}
 	for _, part := range strings.Split(repoName, "/") {
-		cleanedPart := containerNamePartDisallowed.ReplaceAllString(part, "-")
+		cleanedPart := hostnamePartsDisallowed.ReplaceAllString(part, "-")
 		// NOTE: the part limit of 14 is meant to ensure a maximum hostname of
 		// 64 characters, given:
 		// travis-job-{part}-{part}-{job-id}.travisci.net
@@ -150,5 +154,6 @@ func hostnameFromContext(ctx gocontext.Context) string {
 		nameParts = append(nameParts, cleanedPart)
 	}
 
-	return strings.Join(append(nameParts, fmt.Sprintf("%v", jobID)), "-")
+	joined := strings.Join(append(nameParts, fmt.Sprintf("%v", jobID)), "-")
+	return multiDash.ReplaceAllString(joined, "-")
 }

--- a/backend/package_test.go
+++ b/backend/package_test.go
@@ -50,7 +50,7 @@ func Test_hostnameFromContext(t *testing.T) {
 			n: fmt.Sprintf("travis-job-friendly-fribble-%v", jobID),
 		},
 		{
-			r: "very-SiLlY.nAmE.wat/por-cu-pine",
+			r: "very-SiLlY.nAmE.wat/por-cu___-pine",
 			n: fmt.Sprintf("travis-job-very-SiLlY-nAm-por-cu-pine-%v", jobID),
 		},
 	} {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Hostnames that include `_` are not valid and fail to allocate in GCE.

## What approach did you choose and why?

Replace any `_`, as well as replacing multiple `-` with a single `-` so that the generated hostname adheres to the GCE enforced regex of `(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)`.

## How can you test this?

Tests + staging deploy
