### PR TITLE
Ensure generated hostnames are lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Removed
 
 ### Fixed
-- backend: ensure generated hostnames do not contain `_`
+- backend: ensure generated hostnames do not contain `_` and are lowercase
 
 ### Security
 

--- a/backend/package.go
+++ b/backend/package.go
@@ -158,5 +158,5 @@ func hostnameFromContext(ctx gocontext.Context) string {
 	}
 
 	joined := strings.Join(append(nameParts, fmt.Sprintf("%v", jobID)), "-")
-	return multiDash.ReplaceAllString(joined, "-")
+	return strings.ToLower(multiDash.ReplaceAllString(joined, "-"))
 }

--- a/backend/package_test.go
+++ b/backend/package_test.go
@@ -51,7 +51,7 @@ func Test_hostnameFromContext(t *testing.T) {
 		},
 		{
 			r: "very-SiLlY.nAmE.wat/por-cu___-pine",
-			n: fmt.Sprintf("travis-job-very-SiLlY-nAm-por-cu-pine-%v", jobID),
+			n: fmt.Sprintf("travis-job-very-silly-nam-por-cu-pine-%v", jobID),
 		},
 	} {
 		ctx := context.FromRepository(context.FromJobID(gocontext.TODO(), jobID), tc.r)


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Errors coming back from GCE API of `Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'`

## What approach did you choose and why?

Downcase it! :sweat_smile:

## How can you test this?

Tests + staging deploy