### PR TITLE
Add INSPECT_INTERVAL to customize the duration between container inspections

### DIFF
--- a/backend/docker.go
+++ b/backend/docker.go
@@ -170,11 +170,11 @@ func newDockerProvider(cfg *config.ProviderConfig) (Provider, error) {
 
 	inspectInterval := defaultInspectInterval
 	if cfg.IsSet("INSPECT_INTERVAL") {
-		v, err := strconv.ParseInt(cfg.Get("INSPECT_INTERVAL"), 10, 64)
+		v, err := time.ParseDuration(cfg.Get("INSPECT_INTERVAL"))
 		if err != nil {
 			return nil, err
 		}
-		inspectInterval = time.Duration(v) * time.Millisecond
+		inspectInterval = v
 	}
 
 	binds := []string{}
@@ -250,7 +250,7 @@ func newDockerProvider(cfg *config.ProviderConfig) (Provider, error) {
 		imageSelector: imageSelector,
 
 		execCmd:         execCmd,
-		inspectInterval: time.Duration(inspectInterval),
+		inspectInterval: inspectInterval,
 		tmpFs:           tmpFs,
 
 		cpuSets: make([]bool, cpuSetSize),

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -51,7 +51,7 @@ var (
 		"CERT_PATH":           "directory where ca.pem, cert.pem, and key.pem are located (default \"\")",
 		"CMD":                 "command (CMD) to run when creating containers (default \"/sbin/init\")",
 		"EXEC_CMD":            fmt.Sprintf("command to run via exec/ssh (default %q)", defaultExecCmd),
-		"INSPECT_INTERVAL":    fmt.Sprintf("time to wait between container inspections in ms (default %q)", defaultInspectInterval),
+		"INSPECT_INTERVAL":    fmt.Sprintf("time to wait between container inspections as duration (default %q)", defaultInspectInterval),
 		"TMPFS_MAP":           fmt.Sprintf("space-delimited key:value map of tmpfs mounts (default %q)", defaultTmpfsMap),
 		"MEMORY":              "memory to allocate to each container (0 disables allocation, default \"4G\")",
 		"SHM":                 "/dev/shm to allocate to each container (0 disables allocation, default \"64MiB\")",

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -43,6 +43,7 @@ const (
 var (
 	defaultDockerNumCPUer       dockerNumCPUer = &stdlibNumCPUer{}
 	defaultDockerSSHDialTimeout                = 5 * time.Second
+	defaultInspectInterval                     = 500 * time.Millisecond
 	defaultExecCmd                             = "bash /home/travis/build.sh"
 	defaultTmpfsMap                            = map[string]string{"/run": "rw,nosuid,nodev,exec,noatime,size=65536k"}
 	dockerHelp                                 = map[string]string{
@@ -50,6 +51,7 @@ var (
 		"CERT_PATH":           "directory where ca.pem, cert.pem, and key.pem are located (default \"\")",
 		"CMD":                 "command (CMD) to run when creating containers (default \"/sbin/init\")",
 		"EXEC_CMD":            fmt.Sprintf("command to run via exec/ssh (default %q)", defaultExecCmd),
+		"INSPECT_INTERVAL":    fmt.Sprintf("time to wait between container inspections in ms (default %q)", defaultInspectInterval),
 		"TMPFS_MAP":           fmt.Sprintf("space-delimited key:value map of tmpfs mounts (default %q)", defaultTmpfsMap),
 		"MEMORY":              "memory to allocate to each container (0 disables allocation, default \"4G\")",
 		"SHM":                 "/dev/shm to allocate to each container (0 disables allocation, default \"64MiB\")",
@@ -83,16 +85,17 @@ type dockerProvider struct {
 	sshDialer      ssh.Dialer
 	sshDialTimeout time.Duration
 
-	runPrivileged bool
-	runCmd        []string
-	runBinds      []string
-	runMemory     uint64
-	runShm        uint64
-	runCPUs       int
-	runNative     bool
-	execCmd       []string
-	tmpFs         map[string]string
-	imageSelector image.Selector
+	runPrivileged   bool
+	runCmd          []string
+	runBinds        []string
+	runMemory       uint64
+	runShm          uint64
+	runCPUs         int
+	runNative       bool
+	execCmd         []string
+	inspectInterval time.Duration
+	tmpFs           map[string]string
+	imageSelector   image.Selector
 
 	cpuSetsMutex sync.Mutex
 	cpuSets      []bool
@@ -163,6 +166,15 @@ func newDockerProvider(cfg *config.ProviderConfig) (Provider, error) {
 	execCmd := strings.Split(defaultExecCmd, " ")
 	if cfg.IsSet("EXEC_CMD") {
 		execCmd = strings.Split(cfg.Get("EXEC_CMD"), " ")
+	}
+
+	inspectInterval := defaultInspectInterval
+	if cfg.IsSet("INSPECT_INTERVAL") {
+		v, err := strconv.ParseInt(cfg.Get("INSPECT_INTERVAL"), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		inspectInterval = time.Duration(v) * time.Millisecond
 	}
 
 	binds := []string{}
@@ -237,8 +249,9 @@ func newDockerProvider(cfg *config.ProviderConfig) (Provider, error) {
 		runNative:     runNative,
 		imageSelector: imageSelector,
 
-		execCmd: execCmd,
-		tmpFs:   tmpFs,
+		execCmd:         execCmd,
+		inspectInterval: time.Duration(inspectInterval),
+		tmpFs:           tmpFs,
 
 		cpuSets: make([]bool, cpuSetSize),
 	}, nil
@@ -648,7 +661,7 @@ func (i *dockerInstance) runScriptExec(ctx gocontext.Context, output io.Writer) 
 		}
 
 		select {
-		case <-time.After(500 * time.Millisecond):
+		case <-time.After(i.provider.inspectInterval):
 			continue
 		case <-ctx.Done():
 			return &RunResult{Completed: false}, ctx.Err()

--- a/backend/docker_test.go
+++ b/backend/docker_test.go
@@ -341,7 +341,7 @@ func TestNewDockerProvider_WithCMD(t *testing.T) {
 
 func TestNewDockerProvider_WithInspectInterval(t *testing.T) {
 	provider, err := dockerTestSetup(t, config.ProviderConfigFromMap(map[string]string{
-		"INSPECT_INTERVAL": "1500",
+		"INSPECT_INTERVAL": "1500ms",
 	}))
 	defer dockerTestTeardown()
 
@@ -356,7 +356,7 @@ func TestNewDockerProvider_WithInvalidInspectInterval(t *testing.T) {
 	defer dockerTestTeardown()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, "strconv.ParseInt: parsing \"mraaaaaaa\": invalid syntax", err.Error())
+	assert.Equal(t, "time: invalid duration mraaaaaaa", err.Error())
 	assert.Nil(t, provider)
 }
 

--- a/backend/docker_test.go
+++ b/backend/docker_test.go
@@ -339,6 +339,27 @@ func TestNewDockerProvider_WithCMD(t *testing.T) {
 	assert.Equal(t, []string{"/bin/bash", "/fancy-docker-init-thing"}, provider.runCmd)
 }
 
+func TestNewDockerProvider_WithInspectInterval(t *testing.T) {
+	provider, err := dockerTestSetup(t, config.ProviderConfigFromMap(map[string]string{
+		"INSPECT_INTERVAL": "1500",
+	}))
+	defer dockerTestTeardown()
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1500*time.Millisecond, provider.inspectInterval)
+}
+
+func TestNewDockerProvider_WithInvalidInspectInterval(t *testing.T) {
+	provider, err := dockerTestSetup(t, config.ProviderConfigFromMap(map[string]string{
+		"INSPECT_INTERVAL": "mraaaaaaa",
+	}))
+	defer dockerTestTeardown()
+
+	assert.NotNil(t, err)
+	assert.Equal(t, "strconv.ParseInt: parsing \"mraaaaaaa\": invalid syntax", err.Error())
+	assert.Nil(t, provider)
+}
+
 func TestNewDockerProvider_WithMemory(t *testing.T) {
 	provider, err := dockerTestSetup(t, config.ProviderConfigFromMap(map[string]string{
 		"MEMORY": "99MB",


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Currently, travis-worker inspects containers every 500 milliseconds, and this is not configurable. This may be contributing to the docker stalls described in https://github.com/travis-pro/team-blue/issues/704.

## What approach did you choose and why?

This PR adds an environment variable `TRAVIS_WORKER_DOCKER_INSPECT_INTERVAL` where this value can be defined (in milliseconds).

## How can you test this?

### The easy way

`$ go test -v ./backend -test.run InspectInterval`

### The hard way

Set `"debug": true` in `/etc/docker/daemon.json` and run `sudo kill -s SIGHUP $(pidof dockerd)` to reload its configuration.

```
$ make build
$ export TRAVIS_WORKER_DOCKER_INSPECT_INTERVAL=1500
$ travis-worker
```

Enqueue some jobs via the file queue, and observe the duration between container inspections in the docker debug log.

## What feedback would you like, if any?

Tell me everything <3