### PR TITLE
Experimental Librato metrics library swap

### DIFF
--- a/amqp_job.go
+++ b/amqp_job.go
@@ -75,7 +75,7 @@ func (j *amqpJob) Received(ctx gocontext.Context) error {
 	j.received = time.Now()
 
 	if j.payload.Job.QueuedAt != nil {
-		metrics.TimeSince("travis.worker.job.queue_time", *j.payload.Job.QueuedAt)
+		metrics.Gauge("travis.worker.job.queue_time", int64(time.Since(*j.payload.Job.QueuedAt)))
 	}
 
 	return j.sendStateUpdate(ctx, "job:test:receive", "received")
@@ -84,7 +84,7 @@ func (j *amqpJob) Received(ctx gocontext.Context) error {
 func (j *amqpJob) Started(ctx gocontext.Context) error {
 	j.started = time.Now()
 
-	metrics.TimeSince("travis.worker.job.start_time", j.received)
+	metrics.Gauge("travis.worker.job.start_time", int64(time.Since(j.received)))
 
 	return j.sendStateUpdate(ctx, "job:test:start", "started")
 }

--- a/amqp_job.go
+++ b/amqp_job.go
@@ -75,7 +75,7 @@ func (j *amqpJob) Received(ctx gocontext.Context) error {
 	j.received = time.Now()
 
 	if j.payload.Job.QueuedAt != nil {
-		metrics.Gauge("travis.worker.job.queue_time", int64(time.Since(*j.payload.Job.QueuedAt)))
+		metrics.Since("travis.worker.job.queue_time", *j.payload.Job.QueuedAt)
 	}
 
 	return j.sendStateUpdate(ctx, "job:test:receive", "received")
@@ -84,7 +84,7 @@ func (j *amqpJob) Received(ctx gocontext.Context) error {
 func (j *amqpJob) Started(ctx gocontext.Context) error {
 	j.started = time.Now()
 
-	metrics.Gauge("travis.worker.job.start_time", int64(time.Since(j.received)))
+	metrics.Since("travis.worker.job.start_time", j.received)
 
 	return j.sendStateUpdate(ctx, "job:test:start", "started")
 }

--- a/amqp_job_queue.go
+++ b/amqp_job_queue.go
@@ -144,7 +144,7 @@ func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 				jobSendBegin := time.Now()
 				select {
 				case buildJobChan <- buildJob:
-					metrics.Gauge("travis.worker.job_queue.amqp.blocking_time", int64(time.Since(jobSendBegin)))
+					metrics.Since("travis.worker.job_queue.amqp.blocking_time", jobSendBegin)
 					logger.WithFields(logrus.Fields{
 						"source": "amqp",
 						"dur":    time.Since(jobSendBegin),

--- a/amqp_job_queue.go
+++ b/amqp_job_queue.go
@@ -144,7 +144,7 @@ func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 				jobSendBegin := time.Now()
 				select {
 				case buildJobChan <- buildJob:
-					metrics.TimeSince("travis.worker.job_queue.amqp.blocking_time", jobSendBegin)
+					metrics.Gauge("travis.worker.job_queue.amqp.blocking_time", int64(time.Since(jobSendBegin)))
 					logger.WithFields(logrus.Fields{
 						"source": "amqp",
 						"dur":    time.Since(jobSendBegin),

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -444,7 +444,7 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 
 	select {
 	case container := <-containerReady:
-		metrics.TimeSince("worker.vm.provider.docker.boot", startBooting)
+		metrics.Gauge("worker.vm.provider.docker.boot", int64(time.Since(startBooting)))
 		return &dockerInstance{
 			client:       p.client,
 			provider:     p,

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -457,7 +457,7 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 
 	select {
 	case container := <-containerReady:
-		metrics.Gauge("worker.vm.provider.docker.boot", int64(time.Since(startBooting)))
+		metrics.Since("worker.vm.provider.docker.boot", startBooting)
 		return &dockerInstance{
 			client:       p.client,
 			provider:     p,

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -507,7 +507,7 @@ func newGCEProvider(cfg *config.ProviderConfig) (Provider, error) {
 func (p *gceProvider) apiRateLimit(ctx gocontext.Context) error {
 	metrics.Gauge("travis.worker.vm.provider.gce.rate-limit.queue", int64(p.rateLimitQueueDepth))
 	startWait := time.Now()
-	defer metrics.TimeSince("travis.worker.vm.provider.gce.rate-limit", startWait)
+	defer metrics.Gauge("travis.worker.vm.provider.gce.rate-limit", int64(time.Since(startWait)))
 
 	atomic.AddUint64(&p.rateLimitQueueDepth, 1)
 	// This decrements the counter, see the docs for atomic.AddUint64

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -507,7 +507,7 @@ func newGCEProvider(cfg *config.ProviderConfig) (Provider, error) {
 func (p *gceProvider) apiRateLimit(ctx gocontext.Context) error {
 	metrics.Gauge("travis.worker.vm.provider.gce.rate-limit.queue", int64(p.rateLimitQueueDepth))
 	startWait := time.Now()
-	defer metrics.Gauge("travis.worker.vm.provider.gce.rate-limit", int64(time.Since(startWait)))
+	defer metrics.Since("travis.worker.vm.provider.gce.rate-limit", startWait)
 
 	atomic.AddUint64(&p.rateLimitQueueDepth, 1)
 	// This decrements the counter, see the docs for atomic.AddUint64

--- a/backend/jupiterbrain.go
+++ b/backend/jupiterbrain.go
@@ -280,9 +280,9 @@ func (p *jupiterBrainProvider) Start(ctx gocontext.Context, startAttributes *Sta
 		return nil, err
 	}
 
-	metrics.Gauge("worker.vm.provider.jupiterbrain.boot", int64(time.Since(startBooting)))
+	metrics.Since("worker.vm.provider.jupiterbrain.boot", startBooting)
 	normalizedImageName := string(metricNameCleanRegexp.ReplaceAll([]byte(imageName), []byte("-")))
-	metrics.Gauge(fmt.Sprintf("worker.vm.provider.jupiterbrain.boot.image.%s", normalizedImageName), int64(time.Since(startBooting)))
+	metrics.Since(fmt.Sprintf("worker.vm.provider.jupiterbrain.boot.image.%s", normalizedImageName), startBooting)
 	logger.WithField("instance_uuid", payload.ID).Info("booted instance")
 
 	if payload.BaseImage == "" {

--- a/backend/jupiterbrain.go
+++ b/backend/jupiterbrain.go
@@ -280,9 +280,9 @@ func (p *jupiterBrainProvider) Start(ctx gocontext.Context, startAttributes *Sta
 		return nil, err
 	}
 
-	metrics.TimeSince("worker.vm.provider.jupiterbrain.boot", startBooting)
+	metrics.Gauge("worker.vm.provider.jupiterbrain.boot", int64(time.Since(startBooting)))
 	normalizedImageName := string(metricNameCleanRegexp.ReplaceAll([]byte(imageName), []byte("-")))
-	metrics.TimeSince(fmt.Sprintf("worker.vm.provider.jupiterbrain.boot.image.%s", normalizedImageName), startBooting)
+	metrics.Gauge(fmt.Sprintf("worker.vm.provider.jupiterbrain.boot.image.%s", normalizedImageName), int64(time.Since(startBooting)))
 	logger.WithField("instance_uuid", payload.ID).Info("booted instance")
 
 	if payload.BaseImage == "" {

--- a/backend/openstack.go
+++ b/backend/openstack.go
@@ -531,7 +531,7 @@ func (p *osProvider) Start(ctx gocontext.Context, startAttributes *StartAttribut
 		}
 	}
 
-	metrics.TimeSince("worker.vm.provider.openstack.boot", startBooting)
+	metrics.Gauge("worker.vm.provider.openstack.boot", int64(time.Since(startBooting)))
 	logger.WithField("instance_id", inst.ID).Info("booted instance")
 	return &osInstance{
 		client:          p.client,

--- a/backend/openstack.go
+++ b/backend/openstack.go
@@ -531,7 +531,7 @@ func (p *osProvider) Start(ctx gocontext.Context, startAttributes *StartAttribut
 		}
 	}
 
-	metrics.Gauge("worker.vm.provider.openstack.boot", int64(time.Since(startBooting)))
+	metrics.Since("worker.vm.provider.openstack.boot", startBooting)
 	logger.WithField("instance_id", inst.ID).Info("booted instance")
 	return &osInstance{
 		client:          p.client,

--- a/build_script_generator.go
+++ b/build_script_generator.go
@@ -149,7 +149,7 @@ func (g *webBuildScriptGenerator) Generate(ctx gocontext.Context, job Job) ([]by
 	}
 
 	defer resp.Body.Close()
-	metrics.Gauge("worker.job.script.api", int64(time.Since(startRequest)))
+	metrics.Since("worker.job.script.api", startRequest)
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/build_script_generator.go
+++ b/build_script_generator.go
@@ -149,7 +149,7 @@ func (g *webBuildScriptGenerator) Generate(ctx gocontext.Context, job Job) ([]by
 	}
 
 	defer resp.Body.Close()
-	metrics.TimeSince("worker.job.script.api", startRequest)
+	metrics.Gauge("worker.job.script.api", int64(time.Since(startRequest)))
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/cli.go
+++ b/cli.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -24,15 +23,13 @@ import (
 
 	"github.com/cenk/backoff"
 	"github.com/getsentry/raven-go"
-	"github.com/mihasya/go-metrics-librato"
 	"github.com/pkg/errors"
-	"github.com/rcrowley/go-metrics"
 	"github.com/sirupsen/logrus"
 	"github.com/streadway/amqp"
 	"github.com/travis-ci/worker/backend"
 	"github.com/travis-ci/worker/config"
 	"github.com/travis-ci/worker/context"
-	travismetrics "github.com/travis-ci/worker/metrics"
+	"github.com/travis-ci/worker/metrics"
 	cli "gopkg.in/urfave/cli.v1"
 )
 
@@ -309,19 +306,21 @@ func (i *CLI) setupSentry() {
 }
 
 func (i *CLI) setupMetrics() {
-	go travismetrics.ReportMemstatsMetrics()
+	go metrics.ReportMemstatsMetrics()
 
 	if i.Config.LibratoEmail != "" && i.Config.LibratoToken != "" && i.Config.LibratoSource != "" {
 		i.logger.Info("starting librato metrics reporter")
 
-		go librato.Librato(metrics.DefaultRegistry, time.Minute,
-			i.Config.LibratoEmail, i.Config.LibratoToken, i.Config.LibratoSource,
-			[]float64{0.50, 0.75, 0.90, 0.95, 0.99, 0.999, 1.0}, time.Millisecond)
+		// TODO: replace this bit with go-librato's way
+		// go librato.Librato(metrics.DefaultRegistry, time.Minute,
+		// i.Config.LibratoEmail, i.Config.LibratoToken, i.Config.LibratoSource,
+		// []float64{0.50, 0.75, 0.90, 0.95, 0.99, 0.999, 1.0}, time.Millisecond)
 	} else if !i.c.Bool("silence-metrics") {
 		i.logger.Info("starting logger metrics reporter")
 
-		go metrics.Log(metrics.DefaultRegistry, time.Minute,
-			log.New(os.Stderr, "metrics: ", log.Lmicroseconds))
+		// TODO: replace this bit with go-librato's way
+		// go metrics.Log(metrics.DefaultRegistry, time.Minute,
+		// log.New(os.Stderr, "metrics: ", log.Lmicroseconds))
 	}
 }
 

--- a/cli.go
+++ b/cli.go
@@ -207,7 +207,7 @@ func (i *CLI) Run() {
 
 	defer func() {
 		if metrics.DefaultClient != nil {
-			metrics.DefaultClient.Close()
+			metrics.DefaultClient.Stop()
 		}
 	}()
 
@@ -327,6 +327,7 @@ func (i *CLI) setupMetrics() {
 		PublishTick:   10 * time.Second,
 		Max:           uint(10000),
 	}, i.logger)
+	metrics.DefaultClient.Start()
 	go metrics.ReportMemstatsMetrics()
 }
 

--- a/http_job.go
+++ b/http_job.go
@@ -101,7 +101,7 @@ func (j *httpJob) Received(ctx gocontext.Context) error {
 func (j *httpJob) Started(ctx gocontext.Context) error {
 	j.started = time.Now()
 
-	metrics.TimeSince("travis.worker.job.start_time", j.received)
+	metrics.Gauge("travis.worker.job.start_time", int64(time.Since(j.received)))
 
 	return j.sendStateUpdate(ctx, "received", "started")
 }

--- a/http_job.go
+++ b/http_job.go
@@ -101,7 +101,7 @@ func (j *httpJob) Received(ctx gocontext.Context) error {
 func (j *httpJob) Started(ctx gocontext.Context) error {
 	j.started = time.Now()
 
-	metrics.Gauge("travis.worker.job.start_time", int64(time.Since(j.received)))
+	metrics.Since("travis.worker.job.start_time", j.received)
 
 	return j.sendStateUpdate(ctx, "received", "started")
 }

--- a/http_job_queue.go
+++ b/http_job_queue.go
@@ -103,7 +103,7 @@ func (q *HTTPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 				readyWaitBegin := time.Now()
 				logger.Debug("blocking on ready channel recv")
 				<-readyChan
-				metrics.Gauge("travis.worker.job_queue.http.ready_wait_time", int64(time.Since(readyWaitBegin)))
+				metrics.Since("travis.worker.job_queue.http.ready_wait_time", readyWaitBegin)
 			}
 			if !keepPolling {
 				return
@@ -147,7 +147,7 @@ func (q *HTTPJobQueue) pollForJob(ctx gocontext.Context, buildJobChan chan Job) 
 	jobSendBegin := time.Now()
 	select {
 	case buildJobChan <- buildJob:
-		metrics.Gauge("travis.worker.job_queue.http.blocking_time", int64(time.Since(jobSendBegin)))
+		metrics.Since("travis.worker.job_queue.http.blocking_time", jobSendBegin)
 		logger.WithFields(logrus.Fields{
 			"source": "http",
 			"dur":    time.Since(jobSendBegin),

--- a/http_job_queue.go
+++ b/http_job_queue.go
@@ -103,7 +103,7 @@ func (q *HTTPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 				readyWaitBegin := time.Now()
 				logger.Debug("blocking on ready channel recv")
 				<-readyChan
-				metrics.TimeSince("travis.worker.job_queue.http.ready_wait_time", readyWaitBegin)
+				metrics.Gauge("travis.worker.job_queue.http.ready_wait_time", int64(time.Since(readyWaitBegin)))
 			}
 			if !keepPolling {
 				return
@@ -147,7 +147,7 @@ func (q *HTTPJobQueue) pollForJob(ctx gocontext.Context, buildJobChan chan Job) 
 	jobSendBegin := time.Now()
 	select {
 	case buildJobChan <- buildJob:
-		metrics.TimeSince("travis.worker.job_queue.http.blocking_time", jobSendBegin)
+		metrics.Gauge("travis.worker.job_queue.http.blocking_time", int64(time.Since(jobSendBegin)))
 		logger.WithFields(logrus.Fields{
 			"source": "http",
 			"dur":    time.Since(jobSendBegin),

--- a/metrics/client.go
+++ b/metrics/client.go
@@ -1,0 +1,156 @@
+package metrics
+
+import (
+	"sync"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/henrikhodne/go-librato/librato"
+)
+
+type Client struct {
+	lc       *librato.Client
+	source   string
+	max      uint
+	measures chan interface{}
+	done     chan struct{}
+	st       time.Duration
+	pm       sync.Mutex
+}
+
+func NewClient(email, token, source string, sampleTimeout, publishTick time.Duration,
+	max uint, log *logrus.Entry) *Client {
+
+	c := &Client{
+		lc:       librato.NewClient(email, token),
+		log:      log.WithField("self", "metrics_client"),
+		source:   source,
+		max:      max,
+		measures: make(chan interface{}, max),
+		done:     make(chan struct{}),
+		st:       sampleTimeout,
+		pm:       sync.Mutex{},
+	}
+	go c.run(publishTick)
+	return c
+}
+
+func (cl *Client) Close() {
+	select {
+	case cl.done <- struct{}{}:
+	case <-time.After(10 * time.Second):
+		cl.log.Error("failed to close within 10s")
+	}
+}
+
+func (cl *Client) AddGauge(g *librato.GaugeMeasurement) {
+	if g.MeasureTime == nil {
+		g.MeasureTime = librato.Uint(uint(time.Now().Unix()))
+	}
+	select {
+	case l.measures <- g:
+	default:
+		cl.log.Error("failed to add gauge measurement")
+	}
+}
+
+func (cl *Client) AddCounter(c *librato.Measurement) {
+	if c.MeasureTime == nil {
+		c.MeasureTime = librato.Uint(uint(time.Now().Unix()))
+	}
+	select {
+	case l.measures <- c:
+	default:
+		cl.log.Error("failed to add counter measurement")
+	}
+}
+
+func (cl *Client) run(publishTick time.Duration) {
+	t := time.NewTicker(publishTick)
+
+	for {
+		select {
+		case <-t.C:
+			cl.push()
+		case <-c.done:
+			t.Stop()
+			cl.push()
+			return
+		}
+	}
+}
+
+func (cl *Client) push() {
+	cl.pm.Lock()
+	defer cl.pm.Unlock()
+
+	s := cl.takeSample()
+	if s == nil {
+		return
+	}
+
+	gauges := []interface{}{}
+	counters := []interface{}{}
+
+	ms := &librato.MeasurementSubmissions{
+		MeasureTime: librato.Uint(uint(time.Now().UTC().Unix())),
+		Source:      librato.String(cl.source),
+		Gauges:      s.gauges,
+		Counters:    s.counters,
+	}
+
+	resp, err := cl.lc.Metrics.Create(ms)
+	defer func() {
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
+	}()
+
+	if err != nil {
+		cl.log.WithField("err", err).Error("failed to publish metrics")
+	}
+}
+
+func (cl *Client) takeSample() sample {
+	s := sample{
+		gauges:   []interface{}{},
+		counters: []interface{}{},
+	}
+
+	done := make(chan struct{})
+	cancel := make(chan struct{})
+	defer func() {
+		cancel <- struct{}{}
+	}()
+
+	func() {
+		for i := 0; i < cl.max; i++ {
+			select {
+			case m := <-cl.measures:
+				switch m.(type) {
+				case *librato.GaugeMeasurement:
+					s.gauges = append(s.gauges, m.(*librato.GaugeMeasurement))
+				case *librato.Measurement:
+					s.counters = append(s.counters, m.(*librato.Measurement))
+				}
+			case <-cancel:
+				return
+			default:
+				done <- struct{}{}
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-time.After(cl.st):
+	case <-done:
+	}
+
+	return s
+}
+
+type sample struct {
+	gauges   []interface{}
+	counters []interface{}
+}

--- a/metrics/memstats.go
+++ b/metrics/memstats.go
@@ -20,8 +20,8 @@ func ReportMemstatsMetrics() {
 		runtime.ReadMemStats(memStats)
 		now := time.Now()
 
-		for n, c := range map[string]interface{}{
-			"goroutines":            runtime.NumGoroutine(),
+		for n, c := range map[string]uint64{
+			"goroutines":            uint64(runtime.NumGoroutine()),
 			"memory.allocated":      memStats.Alloc,
 			"memory.mallocs":        memStats.Mallocs,
 			"memory.frees":          memStats.Frees,
@@ -29,7 +29,7 @@ func ReportMemstatsMetrics() {
 			"memory.gc.heap":        memStats.HeapAlloc,
 			"memory.gc.stack":       memStats.StackInuse,
 		} {
-			Gauge(fmt.Sprintf("travis.worker.%s", n), c.(int64))
+			Gauge(fmt.Sprintf("travis.worker.%s", n), int64(c))
 		}
 
 		if lastPauseNs > 0 {

--- a/metrics/memstats.go
+++ b/metrics/memstats.go
@@ -1,13 +1,16 @@
 package metrics
 
 import (
+	"fmt"
 	"runtime"
 	"time"
+
+	"github.com/henrikhodne/go-librato/librato"
 )
 
 // ReportMemstatsMetrics will send runtime Memstats metrics every 10 seconds,
 // and will block forever.
-func ReportMemstatsMetrics() {
+func ReportMemstatsMetrics(c *Client) {
 	memStats := &runtime.MemStats{}
 	lastSampleTime := time.Now()
 	var lastPauseNs uint64
@@ -17,42 +20,54 @@ func ReportMemstatsMetrics() {
 
 	for {
 		runtime.ReadMemStats(memStats)
-
 		now := time.Now()
 
-		// TODO: replace this bit with go-librato's way
-		//		metrics.GetOrRegisterGauge("travis.worker.goroutines", metrics.DefaultRegistry).Update(int64(runtime.NumGoroutine()))
-		//		metrics.GetOrRegisterGauge("travis.worker.memory.allocated", metrics.DefaultRegistry).Update(int64(memStats.Alloc))
-		//		metrics.GetOrRegisterGauge("travis.worker.memory.mallocs", metrics.DefaultRegistry).Update(int64(memStats.Mallocs))
-		//		metrics.GetOrRegisterGauge("travis.worker.memory.frees", metrics.DefaultRegistry).Update(int64(memStats.Frees))
-		//		metrics.GetOrRegisterGauge("travis.worker.memory.gc.total_pause", metrics.DefaultRegistry).Update(int64(memStats.PauseTotalNs))
-		//		metrics.GetOrRegisterGauge("travis.worker.memory.gc.heap", metrics.DefaultRegistry).Update(int64(memStats.HeapAlloc))
-		//		metrics.GetOrRegisterGauge("travis.worker.memory.gc.stack", metrics.DefaultRegistry).Update(int64(memStats.StackInuse))
-		//
-		//		if lastPauseNs > 0 {
-		//			pauseSinceLastSample := memStats.PauseTotalNs - lastPauseNs
-		//			metrics.GetOrRegisterGauge("travis.worker.memory.gc.pause_per_second", metrics.DefaultRegistry).Update(int64(float64(pauseSinceLastSample) / sleep.Seconds()))
-		//		}
-		//		lastPauseNs = memStats.PauseTotalNs
-		//
-		//		countGC := int(uint64(memStats.NumGC) - lastNumGC)
-		//		if lastNumGC > 0 {
-		//			diff := float64(countGC)
-		//			diffTime := now.Sub(lastSampleTime).Seconds()
-		//			metrics.GetOrRegisterGauge("travis.worker.memory.gc.gc_per_second", metrics.DefaultRegistry).Update(int64(diff / diffTime))
-		//		}
-		//
-		//		if countGC > 0 {
-		//			if countGC > 256 {
-		//				countGC = 256
-		//			}
-		//
-		//			for i := 0; i < countGC; i++ {
-		//				idx := int((memStats.NumGC-uint32(i))+255) % 256
-		//				pause := time.Duration(memStats.PauseNs[idx])
-		//				metrics.GetOrRegisterTimer("travis.worker.memory.gc.pause", metrics.DefaultRegistry).Update(pause)
-		//			}
-		//		}
+		for n, c := range map[string]interface{}{
+			"goroutines":            runtime.NumGoroutine(),
+			"memory.allocated":      memStats.Alloc,
+			"memory.mallocs":        memStats.Mallocs,
+			"memory.frees":          memStats.Frees,
+			"memory.gc.total_pause": memStats.PauseTotalNs,
+			"memory.gc.heap":        memStats.HeapAlloc,
+			"memory.gc.stack":       memStats.StackInuse,
+		} {
+			c.AddGauge(&librato.GaugeMeasurement{
+				Name:  fmt.Sprintf("travis.worker.%s", n),
+				Count: librato.Uint(uint(c)),
+			})
+		}
+
+		if lastPauseNs > 0 {
+			pauseSinceLastSample := memStats.PauseTotalNs - lastPauseNs
+			c.AddGauge(&librato.GaugeMeasurement{
+				Name:  "travis.worker.memory.gc.pause_per_second",
+				Count: librato.Uint(uint(float64(pauseSinceLastSample) / sleep.Seconds())),
+			})
+		}
+		lastPauseNs = memStats.PauseTotalNs
+
+		countGC := int(uint64(memStats.NumGC) - lastNumGC)
+		if lastNumGC > 0 {
+			diff := float64(countGC)
+			diffTime := now.Sub(lastSampleTime).Seconds()
+			c.AddGauge(&librato.GaugeMeasurement{
+				Name:  "travis.worker.memory.gc.gc_per_second",
+				Count: librato.Uint(uint(diff / diffTime)),
+			})
+		}
+
+		// TODO: do this the go-librato way
+		// if countGC > 0 {
+		// if countGC > 256 {
+		// countGC = 256
+		// }
+
+		// for i := 0; i < countGC; i++ {
+		// idx := int((memStats.NumGC-uint32(i))+255) % 256
+		// pause := time.Duration(memStats.PauseNs[idx])
+		// metrics.GetOrRegisterTimer("travis.worker.memory.gc.pause", metrics.DefaultRegistry).Update(pause)
+		// }
+		// }
 
 		lastNumGC = uint64(memStats.NumGC)
 		lastSampleTime = now

--- a/metrics/memstats.go
+++ b/metrics/memstats.go
@@ -3,8 +3,6 @@ package metrics
 import (
 	"runtime"
 	"time"
-
-	"github.com/rcrowley/go-metrics"
 )
 
 // ReportMemstatsMetrics will send runtime Memstats metrics every 10 seconds,
@@ -22,38 +20,39 @@ func ReportMemstatsMetrics() {
 
 		now := time.Now()
 
-		metrics.GetOrRegisterGauge("travis.worker.goroutines", metrics.DefaultRegistry).Update(int64(runtime.NumGoroutine()))
-		metrics.GetOrRegisterGauge("travis.worker.memory.allocated", metrics.DefaultRegistry).Update(int64(memStats.Alloc))
-		metrics.GetOrRegisterGauge("travis.worker.memory.mallocs", metrics.DefaultRegistry).Update(int64(memStats.Mallocs))
-		metrics.GetOrRegisterGauge("travis.worker.memory.frees", metrics.DefaultRegistry).Update(int64(memStats.Frees))
-		metrics.GetOrRegisterGauge("travis.worker.memory.gc.total_pause", metrics.DefaultRegistry).Update(int64(memStats.PauseTotalNs))
-		metrics.GetOrRegisterGauge("travis.worker.memory.gc.heap", metrics.DefaultRegistry).Update(int64(memStats.HeapAlloc))
-		metrics.GetOrRegisterGauge("travis.worker.memory.gc.stack", metrics.DefaultRegistry).Update(int64(memStats.StackInuse))
-
-		if lastPauseNs > 0 {
-			pauseSinceLastSample := memStats.PauseTotalNs - lastPauseNs
-			metrics.GetOrRegisterGauge("travis.worker.memory.gc.pause_per_second", metrics.DefaultRegistry).Update(int64(float64(pauseSinceLastSample) / sleep.Seconds()))
-		}
-		lastPauseNs = memStats.PauseTotalNs
-
-		countGC := int(uint64(memStats.NumGC) - lastNumGC)
-		if lastNumGC > 0 {
-			diff := float64(countGC)
-			diffTime := now.Sub(lastSampleTime).Seconds()
-			metrics.GetOrRegisterGauge("travis.worker.memory.gc.gc_per_second", metrics.DefaultRegistry).Update(int64(diff / diffTime))
-		}
-
-		if countGC > 0 {
-			if countGC > 256 {
-				countGC = 256
-			}
-
-			for i := 0; i < countGC; i++ {
-				idx := int((memStats.NumGC-uint32(i))+255) % 256
-				pause := time.Duration(memStats.PauseNs[idx])
-				metrics.GetOrRegisterTimer("travis.worker.memory.gc.pause", metrics.DefaultRegistry).Update(pause)
-			}
-		}
+		// TODO: replace this bit with go-librato's way
+		//		metrics.GetOrRegisterGauge("travis.worker.goroutines", metrics.DefaultRegistry).Update(int64(runtime.NumGoroutine()))
+		//		metrics.GetOrRegisterGauge("travis.worker.memory.allocated", metrics.DefaultRegistry).Update(int64(memStats.Alloc))
+		//		metrics.GetOrRegisterGauge("travis.worker.memory.mallocs", metrics.DefaultRegistry).Update(int64(memStats.Mallocs))
+		//		metrics.GetOrRegisterGauge("travis.worker.memory.frees", metrics.DefaultRegistry).Update(int64(memStats.Frees))
+		//		metrics.GetOrRegisterGauge("travis.worker.memory.gc.total_pause", metrics.DefaultRegistry).Update(int64(memStats.PauseTotalNs))
+		//		metrics.GetOrRegisterGauge("travis.worker.memory.gc.heap", metrics.DefaultRegistry).Update(int64(memStats.HeapAlloc))
+		//		metrics.GetOrRegisterGauge("travis.worker.memory.gc.stack", metrics.DefaultRegistry).Update(int64(memStats.StackInuse))
+		//
+		//		if lastPauseNs > 0 {
+		//			pauseSinceLastSample := memStats.PauseTotalNs - lastPauseNs
+		//			metrics.GetOrRegisterGauge("travis.worker.memory.gc.pause_per_second", metrics.DefaultRegistry).Update(int64(float64(pauseSinceLastSample) / sleep.Seconds()))
+		//		}
+		//		lastPauseNs = memStats.PauseTotalNs
+		//
+		//		countGC := int(uint64(memStats.NumGC) - lastNumGC)
+		//		if lastNumGC > 0 {
+		//			diff := float64(countGC)
+		//			diffTime := now.Sub(lastSampleTime).Seconds()
+		//			metrics.GetOrRegisterGauge("travis.worker.memory.gc.gc_per_second", metrics.DefaultRegistry).Update(int64(diff / diffTime))
+		//		}
+		//
+		//		if countGC > 0 {
+		//			if countGC > 256 {
+		//				countGC = 256
+		//			}
+		//
+		//			for i := 0; i < countGC; i++ {
+		//				idx := int((memStats.NumGC-uint32(i))+255) % 256
+		//				pause := time.Duration(memStats.PauseNs[idx])
+		//				metrics.GetOrRegisterTimer("travis.worker.memory.gc.pause", metrics.DefaultRegistry).Update(pause)
+		//			}
+		//		}
 
 		lastNumGC = uint64(memStats.NumGC)
 		lastSampleTime = now

--- a/metrics/package.go
+++ b/metrics/package.go
@@ -2,29 +2,27 @@
 package metrics
 
 import (
-	"time"
+	"github.com/henrikhodne/go-librato/librato"
 )
 
 // Mark increases the meter metric with the given name by 1
 func Mark(name string) {
-	// TODO: replace this bit with go-librato's way
-	// metrics.GetOrRegisterMeter(name, metrics.DefaultRegistry).Mark(1)
-}
-
-// TimeSince increases the timer metric with the given name by the time since the given time
-func TimeSince(name string, since time.Time) {
-	// TODO: replace this bit with go-librato's way
-	// metrics.GetOrRegisterTimer(name, metrics.DefaultRegistry).UpdateSince(since)
-}
-
-// TimeDuration increases the timer metric with the given name by the given duration
-func TimeDuration(name string, duration time.Duration) {
-	// TODO: replace this bit with go-librato's way
-	// metrics.GetOrRegisterTimer(name, metrics.DefaultRegistry).Update(duration)
+	if DefaultClient == nil {
+		return
+	}
+	DefaultClient.AddCounter(&librato.Measurement{
+		Name:  name,
+		Value: librato.Float(float64(1)),
+	})
 }
 
 // Gauge sets a gauge metric to a given value
 func Gauge(name string, value int64) {
-	// TODO: replace this bit with go-librato's way
-	// metrics.GetOrRegisterGauge(name, metrics.DefaultRegistry).Update(value)
+	if DefaultClient == nil {
+		return
+	}
+	DefaultClient.AddGauge(&librato.GaugeMeasurement{
+		Measurement: &librato.Measurement{Name: name},
+		Count:       librato.Uint(uint(value)),
+	})
 }

--- a/metrics/package.go
+++ b/metrics/package.go
@@ -2,6 +2,8 @@
 package metrics
 
 import (
+	"time"
+
 	"github.com/henrikhodne/go-librato/librato"
 )
 
@@ -25,4 +27,9 @@ func Gauge(name string, value int64) {
 		Measurement: &librato.Measurement{Name: name},
 		Count:       librato.Uint(uint(value)),
 	})
+}
+
+// Since sets a gauge metric to a given time.Since(timestamp)
+func Since(name string, timestamp time.Time) {
+	Gauge(name, int64(time.Since(timestamp)))
 }

--- a/metrics/package.go
+++ b/metrics/package.go
@@ -3,26 +3,28 @@ package metrics
 
 import (
 	"time"
-
-	"github.com/rcrowley/go-metrics"
 )
 
 // Mark increases the meter metric with the given name by 1
 func Mark(name string) {
-	metrics.GetOrRegisterMeter(name, metrics.DefaultRegistry).Mark(1)
+	// TODO: replace this bit with go-librato's way
+	// metrics.GetOrRegisterMeter(name, metrics.DefaultRegistry).Mark(1)
 }
 
 // TimeSince increases the timer metric with the given name by the time since the given time
 func TimeSince(name string, since time.Time) {
-	metrics.GetOrRegisterTimer(name, metrics.DefaultRegistry).UpdateSince(since)
+	// TODO: replace this bit with go-librato's way
+	// metrics.GetOrRegisterTimer(name, metrics.DefaultRegistry).UpdateSince(since)
 }
 
 // TimeDuration increases the timer metric with the given name by the given duration
 func TimeDuration(name string, duration time.Duration) {
-	metrics.GetOrRegisterTimer(name, metrics.DefaultRegistry).Update(duration)
+	// TODO: replace this bit with go-librato's way
+	// metrics.GetOrRegisterTimer(name, metrics.DefaultRegistry).Update(duration)
 }
 
 // Gauge sets a gauge metric to a given value
 func Gauge(name string, value int64) {
-	metrics.GetOrRegisterGauge(name, metrics.DefaultRegistry).Update(value)
+	// TODO: replace this bit with go-librato's way
+	// metrics.GetOrRegisterGauge(name, metrics.DefaultRegistry).Update(value)
 }

--- a/multi_source_job_queue.go
+++ b/multi_source_job_queue.go
@@ -67,7 +67,7 @@ func (msjq *MultiSourceJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job
 					logger.WithField("job_id", jobID).Debug("about to send job to multi source output channel")
 					buildJobChan <- job
 
-					metrics.Gauge("travis.worker.job_queue.multi.blocking_time", int64(time.Since(jobSendBegin)))
+					metrics.Since("travis.worker.job_queue.multi.blocking_time", jobSendBegin)
 					logger.WithFields(logrus.Fields{
 						"job_id": jobID,
 						"source": queueName,

--- a/multi_source_job_queue.go
+++ b/multi_source_job_queue.go
@@ -67,7 +67,7 @@ func (msjq *MultiSourceJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job
 					logger.WithField("job_id", jobID).Debug("about to send job to multi source output channel")
 					buildJobChan <- job
 
-					metrics.TimeSince("travis.worker.job_queue.multi.blocking_time", jobSendBegin)
+					metrics.Gauge("travis.worker.job_queue.multi.blocking_time", int64(time.Since(jobSendBegin)))
 					logger.WithFields(logrus.Fields{
 						"job_id": jobID,
 						"source": queueName,

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -129,6 +129,15 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/google/go-querystring/query",
+			"repository": "https://github.com/google/go-querystring",
+			"vcs": "git",
+			"revision": "53e6ce116135b80d037921a7fdd5138cf32d7a8a",
+			"branch": "master",
+			"path": "/query",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/gorilla/context",
 			"repository": "https://github.com/gorilla/context",
 			"vcs": "git",
@@ -153,6 +162,15 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/henrikhodne/go-librato/librato",
+			"repository": "https://github.com/henrikhodne/go-librato",
+			"vcs": "git",
+			"revision": "cd4baae4da94deaa0cfcf819c048a0e6a041c37a",
+			"branch": "master",
+			"path": "/librato",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/jtacoma/uritemplates",
 			"repository": "https://github.com/jtacoma/uritemplates",
 			"vcs": "git",
@@ -165,14 +183,6 @@
 			"repository": "https://github.com/kr/fs",
 			"vcs": "git",
 			"revision": "2788f0dbd16903de03cb8186e5c7d97b69ad387b",
-			"branch": "master",
-			"notests": true
-		},
-		{
-			"importpath": "github.com/mihasya/go-metrics-librato",
-			"repository": "https://github.com/mihasya/go-metrics-librato",
-			"vcs": "git",
-			"revision": "0ec8d5e8bf04a48fc5c96792bfd016b08afdabad",
 			"branch": "master",
 			"notests": true
 		},
@@ -221,14 +231,6 @@
 			"repository": "https://github.com/rackspace/gophercloud",
 			"vcs": "git",
 			"revision": "e00690e87603abe613e9f02c816c7c4bef82e063",
-			"branch": "master",
-			"notests": true
-		},
-		{
-			"importpath": "github.com/rcrowley/go-metrics",
-			"repository": "https://github.com/rcrowley/go-metrics",
-			"vcs": "git",
-			"revision": "1f30fe9094a513ce4c700b9a54458bbb0c96996c",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The metrics libraries we currently use are reporting metrics that sometimes (always?) do not match up with log output, such as the requeue counts reported on GCE workers in the hundreds/min while logs show tens/min.

## What approach did you choose and why?

Use the Librato client library recommended by Librato, plus some request aggregation code.

## How can you test this?

- [ ] canary production deployment