### PR TITLE
Add container labels for job id, repo and dist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- backend/docker: add repo, job ID, and dist as container labels
 
 ### Changed
 

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -373,11 +373,26 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 		}
 	}
 
+	labels := map[string]string{
+		"travis.dist": startAttributes.Dist,
+	}
+
+	r, ok := context.RepositoryFromContext(ctx)
+	if ok {
+		labels["travis.repo"] = r
+	}
+
+	jid, ok := context.JobIDFromContext(ctx)
+	if ok {
+		labels["travis.job_id"] = strconv.FormatUint(jid, 10)
+	}
+
 	dockerConfig := &dockercontainer.Config{
 		Cmd:        p.runCmd,
 		Image:      imageID,
 		Hostname:   strings.ToLower(containerName),
 		Domainname: "travisci.net",
+		Labels:     labels,
 	}
 
 	dockerHostConfig := &dockercontainer.HostConfig{


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

There's no easy way to track down all containers currently running for a given repo on worker instances.

## What approach did you choose and why?

This PR adds 3 labels to containers run by worker: repo, job ID, and dist.

This will allow us to filter running containers by label:
```
$ docker ps --filter "label=travis.repo=soulshake/autoscale-tester"
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS                  PORTS               NAMES
241af0b720b9        74e2c8c6197c        "/sbin/init"        2 seconds ago       Up Less than a second   22/tcp              travis-job-soulshake-autoscale-test-623773
```

## How can you test this?

Run worker locally, feed it some jobs, then:

```
$ docker ps --format "table {{.ID}}\t{{.Labels}}"
CONTAINER ID        LABELS
3c5089e0a1e5        net.travis.dist=trusty,net.travis.job_id=623773,net.travis.repo=soulshake/autoscale-tester
```
## What feedback would you like, if any?

- Any reason not to do this?
- Are there any other labels that should be added?