### PR TITLE
Disable docker cpuset allocation when CPUS is 0

### DIFF
--- a/backend/docker_test.go
+++ b/backend/docker_test.go
@@ -275,7 +275,7 @@ func TestNewDockerProvider_WithRequiredConfig(t *testing.T) {
 	assert.Equal(t, uint64(1024*1024*1024*4), provider.runMemory)
 	assert.Equal(t, 3, len(provider.cpuSets))
 	assert.Equal(t, []string{"/sbin/init"}, provider.runCmd)
-	assert.Equal(t, 2, provider.runCPUs)
+	assert.Equal(t, uint(2), provider.runCPUs)
 }
 
 func TestNewDockerProvider_WithNative(t *testing.T) {
@@ -371,13 +371,17 @@ func TestNewDockerProvider_WithMemory(t *testing.T) {
 }
 
 func TestNewDockerProvider_WithCPUs(t *testing.T) {
-	provider, err := dockerTestSetup(t, config.ProviderConfigFromMap(map[string]string{
-		"CPUS": "4",
-	}))
-	defer dockerTestTeardown()
+	for _, v := range []uint{4, 1, 0} {
+		func(cpus uint) {
+			provider, err := dockerTestSetup(t, config.ProviderConfigFromMap(map[string]string{
+				"CPUS": fmt.Sprintf("%d", cpus),
+			}))
+			defer dockerTestTeardown()
 
-	assert.Nil(t, err)
-	assert.Equal(t, 4, provider.runCPUs)
+			assert.Nil(t, err)
+			assert.Equal(t, cpus, provider.runCPUs)
+		}(v)
+	}
 }
 
 func TestDockerProvider_Setup(t *testing.T) {


### PR DESCRIPTION
as advertised in the help text, but not currently true

## What is the problem that this PR is trying to fix?

The help text claims that setting `CPUS` to 0 will disable cpuset allocation, but this is not currently true.

## What approach did you choose and why?

Do like the help text claims.

## How can you test this?

- [x] staging deployment with `export TRAVIS_WORKER_DOCKER_CPUS=0`

## What feedback would you like, if any?
