### PR TITLE
Add support for env-based image selection to Docker backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- backend/docker: support for env-based image selection
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,42 @@ built-in help system:
 travis-worker --help
 ```
 
+### Environment-based image selection configuration
+
+Some backend providers supports image selection based on environment variables.
+The required format uses keys that are prefixed with the provider-specific
+prefix:
+
+- `TRAVIS_WORKER_{UPPERCASE_PROVIDER}_IMAGE_ALIASES`: comma-delimited strings used for
+  looking up full image name strings from other environment variables
+- `TRAVIS_WORKER_{UPPERCASE_PROVIDER}_IMAGE_ALIAS_{UPPERCASE_ALIAS}`: contains
+  an alias name which will be used to look up another environment variable, such
+as when routing multiple languages to the same image
+- `TRAVIS_WORKER_{UPPERCASE_PROVIDER}_IMAGE_{UPPERCASE_ALIAS}`: contains a full image name
+  string to be used by the backend provider
+
+The following example is for use with the Docker backend:
+
+``` bash
+# declare aliases for `dist: trusty`, `os: linux`, and `group: dev`
+export TRAVIS_WORKER_DOCKER_IMAGE_ALIASES=dist_trusty,os_linux,group_dev
+export TRAVIS_WORKER_DOCKER_IMAGE_ALIAS_GROUP_DEV=bionic
+export TRAVIS_WORKER_DOCKER_IMAGE_ALIAS_DIST_TRUSTY=trusty
+export TRAVIS_WORKER_DOCKER_IMAGE_ALIAS_OS_LINUX=trusty
+
+# resolves the above alias of `trusty`
+export TRAVIS_WORKER_DOCKER_IMAGE_TRUSTY=travisci/ci-connie:packer-1420290255-fafafaf
+
+# resolves the above alias of `bionic`
+export TRAVIS_WORKER_DOCKER_IMAGE_BIONIC=registry.business.com/fancy/ubuntu:bionic
+
+# resolves as the fallback default image
+export TRAVIS_WORKER_DOCKER_IMAGE_DEFAULT=travisci/ci-garnet:packer-1410230255-fafafaf
+
+# resolves for `language: ruby`
+export TRAVIS_WORKER_DOCKER_IMAGE_LANGUAGE_RUBY=registry.business.com/travisci/ci-ruby:whatever
+```
+
 
 ## Development: Running Travis Worker locally
 

--- a/README.md
+++ b/README.md
@@ -66,34 +66,26 @@ Some backend providers supports image selection based on environment variables.
 The required format uses keys that are prefixed with the provider-specific
 prefix:
 
-- `TRAVIS_WORKER_{UPPERCASE_PROVIDER}_IMAGE_ALIASES`: comma-delimited strings used for
-  looking up full image name strings from other environment variables
-- `TRAVIS_WORKER_{UPPERCASE_PROVIDER}_IMAGE_ALIAS_{UPPERCASE_ALIAS}`: contains
-  an alias name which will be used to look up another environment variable, such
-as when routing multiple languages to the same image
-- `TRAVIS_WORKER_{UPPERCASE_PROVIDER}_IMAGE_{UPPERCASE_ALIAS}`: contains a full image name
+- `TRAVIS_WORKER_{UPPERCASE_PROVIDER}_IMAGE_{UPPERCASE_NAME}`: contains an image name
   string to be used by the backend provider
 
 The following example is for use with the Docker backend:
 
 ``` bash
-# declare aliases for `dist: trusty`, `os: linux`, and `group: dev`
-export TRAVIS_WORKER_DOCKER_IMAGE_ALIASES=dist_trusty,os_linux,group_dev
-export TRAVIS_WORKER_DOCKER_IMAGE_ALIAS_GROUP_DEV=bionic
-export TRAVIS_WORKER_DOCKER_IMAGE_ALIAS_DIST_TRUSTY=trusty
-export TRAVIS_WORKER_DOCKER_IMAGE_ALIAS_OS_LINUX=trusty
+# matches on `dist: trusty`
+export TRAVIS_WORKER_DOCKER_IMAGE_DIST_TRUSTY=travisci/ci-connie:packer-1420290255-fafafaf
 
-# resolves the above alias of `trusty`
-export TRAVIS_WORKER_DOCKER_IMAGE_TRUSTY=travisci/ci-connie:packer-1420290255-fafafaf
-
-# resolves the above alias of `bionic`
-export TRAVIS_WORKER_DOCKER_IMAGE_BIONIC=registry.business.com/fancy/ubuntu:bionic
-
-# resolves as the fallback default image
-export TRAVIS_WORKER_DOCKER_IMAGE_DEFAULT=travisci/ci-garnet:packer-1410230255-fafafaf
+# matches on `dist: bionic`
+export TRAVIS_WORKER_DOCKER_IMAGE_DIST_BIONIC=registry.business.com/fancy/ubuntu:bionic
 
 # resolves for `language: ruby`
-export TRAVIS_WORKER_DOCKER_IMAGE_LANGUAGE_RUBY=registry.business.com/travisci/ci-ruby:whatever
+export TRAVIS_WORKER_DOCKER_IMAGE_RUBY=registry.business.com/travisci/ci-ruby:whatever
+
+# resolves for `group: edge` + `language: python`
+export TRAVIS_WORKER_DOCKER_IMAGE_GROUP_EDGE_PYTHON=travisci/ci-garnet:packer-1530230255-fafafaf
+
+# used when no dist, language, or group matches
+export TRAVIS_WORKER_DOCKER_IMAGE_DEFAULT=travisci/ci-garnet:packer-1410230255-fafafaf
 ```
 
 

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -60,7 +60,7 @@ var (
 		"NATIVE":              "upload and run build script via docker API instead of over ssh (default false)",
 		"PRIVILEGED":          "run containers in privileged mode (default false)",
 		"SSH_DIAL_TIMEOUT":    fmt.Sprintf("connection timeout for ssh connections (default %v)", defaultDockerSSHDialTimeout),
-		"IMAGE_SELECTOR_TYPE": fmt.Sprintf("image selector type (\"tag\" or \"api\", default %q)", defaultDockerImageSelectorType),
+		"IMAGE_SELECTOR_TYPE": fmt.Sprintf("image selector type (\"tag\", \"api\", or \"env\", default %q)", defaultDockerImageSelectorType),
 		"IMAGE_SELECTOR_URL":  "URL for image selector API, used only when image selector is \"api\"",
 		"BINDS":               "Bind mount a volume (example: \"/var/run/docker.sock:/var/run/docker.sock\", default \"\")",
 	}
@@ -226,10 +226,6 @@ func newDockerProvider(cfg *config.ProviderConfig) (Provider, error) {
 		imageSelectorType = cfg.Get("IMAGE_SELECTOR_TYPE")
 	}
 
-	if imageSelectorType != "tag" && imageSelectorType != "api" {
-		return nil, fmt.Errorf("invalid image selector type %q", imageSelectorType)
-	}
-
 	imageSelector, err := buildDockerImageSelector(imageSelectorType, client, cfg)
 	if err != nil {
 		return nil, errors.Wrap(err, "couldn't build docker image selector")
@@ -304,6 +300,8 @@ func buildDockerImageSelector(selectorType string, client *docker.Client, cfg *c
 	switch selectorType {
 	case "tag":
 		return &dockerTagImageSelector{client: client}, nil
+	case "env":
+		return image.NewEnvSelector(cfg)
 	case "api":
 		baseURL, err := url.Parse(cfg.Get("IMAGE_SELECTOR_URL"))
 		if err != nil {

--- a/image/api_selector.go
+++ b/image/api_selector.go
@@ -190,24 +190,27 @@ func (as *APISelector) buildCandidateTags(params *Params) ([]*tagSet, error) {
 	}
 
 	hasLang := params.Language != ""
+	hasDist := params.Dist != ""
+	hasGroup := params.Group != ""
+	hasOS := params.OS != ""
 
 	if params.OS == "osx" && params.OsxImage != "" {
 		addTags("osx_image:"+params.OsxImage, "os:osx")
 	}
 
-	if params.Dist != "" && params.Group != "" && hasLang {
+	if hasDist && hasGroup && hasLang {
 		addTags("dist:"+params.Dist, "group_"+params.Group+":true", "language_"+params.Language+":true")
 	}
 
-	if params.Dist != "" && hasLang {
+	if hasDist && hasLang {
 		addTags("dist:"+params.Dist, "language_"+params.Language+":true")
 	}
 
-	if params.Group != "" && hasLang {
+	if hasGroup && hasLang {
 		addTags("group_"+params.Group+":true", "language_"+params.Language+":true")
 	}
 
-	if params.OS != "" && hasLang {
+	if hasOS && hasLang {
 		addTags("os:"+params.OS, "language_"+params.Language+":true")
 	}
 
@@ -219,15 +222,15 @@ func (as *APISelector) buildCandidateTags(params *Params) ([]*tagSet, error) {
 		addDefaultTag("osx_image:" + params.OsxImage)
 	}
 
-	if params.Dist != "" {
+	if hasDist {
 		addDefaultTag("dist:" + params.Dist)
 	}
 
-	if params.Group != "" {
+	if hasGroup {
 		addDefaultTag("group_" + params.Group + ":true")
 	}
 
-	if params.OS != "" {
+	if hasOS {
 		addDefaultTag("os:" + params.OS)
 	}
 

--- a/image/env_selector.go
+++ b/image/env_selector.go
@@ -44,6 +44,9 @@ func (es *EnvSelector) buildImageAliasMap() error {
 
 	for _, aliasName := range aliasNamesSlice {
 		normalizedAliasName := strings.ToUpper(string(nonAlphaNumRegexp.ReplaceAll([]byte(aliasName), []byte("_"))))
+		if len(normalizedAliasName) == 0 {
+			continue
+		}
 
 		key := fmt.Sprintf("IMAGE_ALIAS_%s", normalizedAliasName)
 		if !es.c.IsSet(key) {

--- a/image/env_selector_test.go
+++ b/image/env_selector_test.go
@@ -15,19 +15,21 @@ var (
 	}{
 		{
 			E: map[string]string{
-				"IMAGE_DEFAULT":         "travis:default",
-				"IMAGE_DEFAULT_LINUX":   "travis:linux",
-				"IMAGE_DIST_XENIAL":     "travis:xenial",
-				"IMAGE_GROUP_EDGE":      "travis:edge",
-				"IMAGE_GROUP_EDGE_RUBY": "travis:ruby9001",
-				"IMAGE_LANGUAGE_RUBY":   "travis:ruby8999",
-				"IMAGE_PYTHON":          "travis:python",
+				"IMAGE_DEFAULT":            "travis:default",
+				"IMAGE_LINUX":              "travis:linux",
+				"IMAGE_DIST_XENIAL":        "travis:xenial",
+				"IMAGE_DIST_XENIAL_PYTHON": "travis:py3k",
+				"IMAGE_GROUP_EDGE":         "travis:edge",
+				"IMAGE_GROUP_EDGE_RUBY":    "travis:ruby9001",
+				"IMAGE_LANGUAGE_RUBY":      "travis:ruby8999",
+				"IMAGE_PYTHON":             "travis:python",
 			},
 			O: []*testEnvCase{
 				{E: "travis:default", P: &Params{Language: "clojure"}},
 				{E: "travis:default", P: &Params{Language: "java"}},
 				{E: "travis:edge", P: &Params{Language: "java", Group: "edge"}},
 				{E: "travis:linux", P: &Params{Language: "bf", Group: "wat", OS: "linux"}},
+				{E: "travis:py3k", P: &Params{Language: "python", Dist: "xenial"}},
 				{E: "travis:ruby8999", P: &Params{Language: "ruby"}},
 				{E: "travis:ruby9001", P: &Params{Language: "ruby", Group: "edge"}},
 				{E: "travis:xenial", P: &Params{Language: "java", Dist: "xenial"}},

--- a/image/env_selector_test.go
+++ b/image/env_selector_test.go
@@ -2,7 +2,6 @@ package image
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -16,78 +15,43 @@ var (
 	}{
 		{
 			E: map[string]string{
-				"IMAGE_ALIASES": strings.Join([]string{
-					"language_haskell",
-					"language_java",
-				}, ","),
-				"IMAGE_ALIAS_LANGUAGE_HASKELL": "language_ruby",
-				"IMAGE_ALIAS_LANGUAGE_JAVA":    "legacy",
-				"IMAGE_LANGUAGE_RUBY":          "travis-ci-ruby-9001",
-				"IMAGE_LEGACY":                 "travis-ci-legacy-00",
-				"IMAGE_DEFAULT":                "travis-ci-default",
+				"IMAGE_DEFAULT":         "travis:default",
+				"IMAGE_DEFAULT_LINUX":   "travis:linux",
+				"IMAGE_DIST_XENIAL":     "travis:xenial",
+				"IMAGE_GROUP_EDGE":      "travis:edge",
+				"IMAGE_GROUP_EDGE_RUBY": "travis:ruby9001",
+				"IMAGE_LANGUAGE_RUBY":   "travis:ruby8999",
+				"IMAGE_PYTHON":          "travis:python",
 			},
 			O: []*testEnvCase{
-				{E: "travis-ci-ruby-9001", P: &Params{Language: "haskell"}},
-				{E: "travis-ci-legacy-00", P: &Params{Language: "java"}},
-				{E: "travis-ci-default", P: &Params{Language: "clojure"}},
-				{E: "travis-ci-ruby-9001", P: &Params{Language: "ruby"}},
+				{E: "travis:default", P: &Params{Language: "clojure"}},
+				{E: "travis:default", P: &Params{Language: "java"}},
+				{E: "travis:edge", P: &Params{Language: "java", Group: "edge"}},
+				{E: "travis:linux", P: &Params{Language: "bf", Group: "wat", OS: "linux"}},
+				{E: "travis:ruby8999", P: &Params{Language: "ruby"}},
+				{E: "travis:ruby9001", P: &Params{Language: "ruby", Group: "edge"}},
+				{E: "travis:xenial", P: &Params{Language: "java", Dist: "xenial"}},
 			},
 		},
 		{
 			E: map[string]string{
-				"IMAGE_ALIASES": strings.Join([]string{
-					"dist_trusty_ruby",
-					"dist_trusty",
-				}, ","),
-				"IMAGE_ALIAS_DIST_TRUSTY":      "trusty",
-				"IMAGE_ALIAS_DIST_TRUSTY_RUBY": "travis-ci-ruby",
-				"IMAGE_TRUSTY":                 "travis-ci-mega",
+				"IMAGE_DEFAULT":           "travisci/ci-garnet:packer-1410230255-fafafaf",
+				"IMAGE_DIST_BIONIC":       "registry.business.com/fancy/ubuntu:bionic",
+				"IMAGE_DIST_TRUSTY":       "travisci/ci-connie:packer-1420290255-fafafaf",
+				"IMAGE_DIST_TRUSTY_RUBY":  "registry.business.com/travisci/ci-ruby:whatever",
+				"IMAGE_GROUP_EDGE_PYTHON": "travisci/ci-garnet:packer-1530230255-fafafaf",
+				"IMAGE_LANGUAGE_RUBY":     "registry.business.com/travisci/ci-ruby:whatever",
 			},
 			O: []*testEnvCase{
-				{E: "travis-ci-mega", P: &Params{Dist: "trusty"}},
-				{E: "travis-ci-ruby", P: &Params{Dist: "trusty", Language: "ruby"}},
-			},
-		},
-		{
-			E: map[string]string{
-				"IMAGE_ALIASES": strings.Join([]string{
-					"group_dev",
-					"group_dev_go",
-					"dist_trusty",
-					"osx_image_xcode6.4",
-					"osx_image_xcode7_swift",
-					"os_linux",
-					"linux_java",
-					"language_haskell",
-					"default_solaris",
-				}, ","),
-				"IMAGE_ALIAS_GROUP_DEV":              "vivid",
-				"IMAGE_ALIAS_GROUP_DEV_GO":           "utopic",
-				"IMAGE_ALIAS_DIST_TRUSTY":            "trusty",
-				"IMAGE_ALIAS_OSX_IMAGE_XCODE6_4":     "xcode6",
-				"IMAGE_ALIAS_OSX_IMAGE_XCODE7_SWIFT": "xcode7_swift",
-				"IMAGE_ALIAS_OS_LINUX":               "trusty",
-				"IMAGE_ALIAS_LINUX_JAVA":             "utopic",
-				"IMAGE_ALIAS_LANGUAGE_HASKELL":       "trusty",
-				"IMAGE_ALIAS_DEFAULT_SOLARIS":        "smartos",
-				"IMAGE_DEFAULT_OSX":                  "xcode7",
-				"IMAGE_TRUSTY":                       "travis-ci-mega",
-				"IMAGE_XCODE7":                       "travis-xcode7b4",
-				"IMAGE_XCODE7_SWIFT":                 "travis-xcode7b6",
-				"IMAGE_SMARTOS":                      "base64-20150902",
-			},
-			O: []*testEnvCase{
-				{E: "travis-ci-mega", P: &Params{OS: "linux", Dist: "trusty"}},
-				{E: "travis-ci-mega", P: &Params{OS: "linux", Dist: "trusty", Language: "ruby"}},
-				{E: "travis-xcode7b6", P: &Params{OS: "osx", OsxImage: "xcode7", Language: "swift"}},
-				{E: "travis-xcode7b4", P: &Params{OS: "osx", Language: "objective-c"}},
-				{E: "base64-20150902", P: &Params{OS: "solaris", Language: "ruby"}},
-				{E: "base64-20150902", P: &Params{OS: "smartos"}},
-				{E: "utopic", P: &Params{OS: "linux", Language: "java"}},
-				{E: "vivid", P: &Params{OS: "linux", Group: "dev", Language: "java"}},
-				{E: "utopic", P: &Params{OS: "linux", Group: "dev", Language: "go"}},
-				{E: "travis-ci-mega", P: &Params{OS: "linux", Language: "haskell"}},
-				{E: "xcode6", P: &Params{OS: "osx", OsxImage: "xcode6.4"}},
+				{E: "registry.business.com/fancy/ubuntu:bionic", P: &Params{Language: "bash", Dist: "bionic"}},
+				{E: "registry.business.com/fancy/ubuntu:bionic", P: &Params{Language: "ruby", Dist: "bionic"}},
+				{E: "registry.business.com/travisci/ci-ruby:whatever", P: &Params{Language: "ruby", Dist: "trusty"}},
+				{E: "registry.business.com/travisci/ci-ruby:whatever", P: &Params{Language: "ruby"}},
+				{E: "travisci/ci-connie:packer-1420290255-fafafaf", P: &Params{Language: "wat", Dist: "trusty"}},
+				{E: "travisci/ci-garnet:packer-1410230255-fafafaf", P: &Params{Language: "python", Group: "stable"}},
+				{E: "travisci/ci-garnet:packer-1410230255-fafafaf", P: &Params{Language: "python"}},
+				{E: "travisci/ci-garnet:packer-1410230255-fafafaf", P: &Params{Language: "wat"}},
+				{E: "travisci/ci-garnet:packer-1530230255-fafafaf", P: &Params{Language: "python", Group: "edge"}},
 			},
 		},
 	}


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Image selection in the Docker backend is currently limited to tag-based and api-based strategies, which means that the only "local" strategy (tag-based) will only allow for selection based on `language`, which means that multiple distro images cannot be used in the same Docker API.

## What approach did you choose and why?

Add support for env-based image selection.

## How can you test this?

The env-based image selector itself is well-tested.  Testing this in a canary deployment would be nice, too!

- [x] add docs to README about how to configure env-based image selection
- [x] does it work?