### PR TITLE
[WIP] Add systemd support

### DIFF
--- a/packaging/config.bash
+++ b/packaging/config.bash
@@ -11,7 +11,7 @@ export DATE
 export PC_USER='travisci'
 export PC_REPO='worker'
 
-export PKG_PLATFORMS=('ubuntu:14.04' 'centos:7')
+export PKG_PLATFORMS=('ubuntu:14.04' 'centos:7' 'ubuntu:16.04')
 
 __define_version
 __define_shell_flags

--- a/packaging/templates.d/systemd/travis-worker.service
+++ b/packaging/templates.d/systemd/travis-worker.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Travis CI Worker <contact+travis-worker-systemd@travis-ci.com>
+After=syslog.target network.target sshd.service
+
+[Service]
+Environment=GOMAXPROCS=nproc
+ExecStart=/usr/local/bin/travis-worker
+Restart=always
+EnvironmentFile=/etc/default/travis-worker


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Add missing systemd support for Enterprise packaging.

## What approach did you choose and why?

This PR is a WIP, it starts by adding a systemd service for `travis-worker`. It requires that configuration options which where defined in `/etc/default/travis-worker` and `/etc/default/travis-enterprise` are now all defined in `/etc/default/travis-worker`. Example:

```
AMQP_URI="amqp://travis:<password>@enterprise.example.com/travis"
BUILD_API_URI="https://enterprise.example.com/__build__/script"
TRAVIS_WORKER_BUILD_API_INSECURE_SKIP_VERIFY='true'
POOL_SIZE='2'
PROVIDER_NAME='docker'
QUEUE_NAME='builds.linux'
```

## How can you test this?

## What feedback would you like, if any?

I'd like to have feedback on how to best ship the config file with the `.deb` package and if anything else is needed to build `.deb` packages for Ubuntu 16.04.
