### PR TITLE
Run job-board-redis container earlier to prevent test from intermittently failing

### DIFF
--- a/script/http-job-test
+++ b/script/http-job-test
@@ -12,6 +12,10 @@ main() {
     "${JOB_BOARD_CLONE_URL}" "${JOB_BOARD_CLONE_DIR}"
 
   docker run -d \
+    --name job-board-redis \
+    redis
+
+  docker run -d \
     --name job-board-postgres \
     -e POSTGRES_PASSWORD=yay \
     postgres
@@ -27,11 +31,7 @@ main() {
   docker exec \
     --user postgres \
     job-board-postgres psql -l
-
-  docker run -d \
-    --name job-board-redis \
-    redis
-
+  
   docker run \
     --rm \
     --name travis-worker-http-job-test \

--- a/script/http-job-test
+++ b/script/http-job-test
@@ -31,7 +31,7 @@ main() {
   docker exec \
     --user postgres \
     job-board-postgres psql -l
-  
+
   docker run \
     --rm \
     --name travis-worker-http-job-test \


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
I've noticed that the integration tests fail every now and then with:
```Error response from daemon: No such container: job-board-redis``` ([example job](https://travis-ci.org/travis-ci/worker/jobs/335990272))
We should try to avoid flakiness in tests as much as possible.

## What approach did you choose and why?
I thought that by trying to run this container first, it will be available by the time we actually need it, thus preventing the failures.

## How can you test this?
Keep an eye on the integration tests randomly failing here?!

## What feedback would you like, if any?
I **think** this should be enough for now and we can resort to introducing more checks (like blocking until the container is up) if this keeps happening. However, there's nothing stopping us from doing that now.
