### PR TITLE
[WIP] Send worker events to Honeycomb

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cenk/backoff"
 	"github.com/getsentry/raven-go"
+	libhoney "github.com/honeycombio/libhoney-go"
 	"github.com/mihasya/go-metrics-librato"
 	"github.com/pkg/errors"
 	"github.com/rcrowley/go-metrics"
@@ -190,6 +191,7 @@ func (i *CLI) Setup() (bool, error) {
 // returns from its Run func
 func (i *CLI) Run() {
 	i.logger.Info("starting")
+	defer libhoney.Close()
 
 	i.handleStartHook()
 	defer i.handleStopHook()
@@ -322,6 +324,13 @@ func (i *CLI) setupMetrics() {
 
 		go metrics.Log(metrics.DefaultRegistry, time.Minute,
 			log.New(os.Stderr, "metrics: ", log.Lmicroseconds))
+	}
+
+	if i.Config.HoneycombWriteKey != "" {
+		libhoney.Init(libhoney.Config{
+			WriteKey: i.Config.HoneycombWriteKey,
+			Dataset:  "worker",
+		})
 	}
 }
 

--- a/cli.go
+++ b/cli.go
@@ -329,7 +329,7 @@ func (i *CLI) setupMetrics() {
 	if i.Config.HoneycombWriteKey != "" {
 		libhoney.Init(libhoney.Config{
 			WriteKey: i.Config.HoneycombWriteKey,
-			Dataset:  "worker",
+			Dataset:  i.Config.HoneycombDataset,
 		})
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -108,6 +108,9 @@ var (
 		NewConfigDef("HoneycombWriteKey", &cli.StringFlag{
 			Usage: "Honeycomb.io write key",
 		}),
+		NewConfigDef("HoneycombDataset", &cli.StringFlag{
+			Usage: `The Honeycomb dataset to send metrics to (should be "worker" or "worker-staging")`,
+		}),
 		NewConfigDef("Hostname", &cli.StringFlag{
 			Value: defaultHostname,
 			Usage: "Host name used in log output to identify the source of a job",
@@ -323,6 +326,7 @@ type Config struct {
 	LibratoSource     string `config:"librato-source"`
 	SentryDSN         string `config:"sentry-dsn"`
 	HoneycombWriteKey string `config:"honeycomb-write-key"`
+	HoneycombDataset  string `config:"honeycomb-dataset"`
 	Hostname          string `config:"hostname"`
 	DefaultLanguage   string `config:"default-language"`
 	DefaultDist       string `config:"default-dist"`

--- a/config/config.go
+++ b/config/config.go
@@ -105,6 +105,9 @@ var (
 		NewConfigDef("SentryHookErrors", &cli.BoolFlag{
 			Usage: "Add logrus.ErrorLevel to logrus sentry hook",
 		}),
+		NewConfigDef("HoneycombWriteKey", &cli.StringFlag{
+			Usage: "Honeycomb.io write key",
+		}),
 		NewConfigDef("Hostname", &cli.StringFlag{
 			Value: defaultHostname,
 			Usage: "Host name used in log output to identify the source of a job",
@@ -305,27 +308,28 @@ func NewConfigDef(fieldName string, flag cli.Flag) *ConfigDef {
 
 // Config contains all the configuration needed to run the worker.
 type Config struct {
-	ProviderName    string `config:"provider-name"`
-	QueueType       string `config:"queue-type"`
-	AmqpURI         string `config:"amqp-uri"`
-	AmqpInsecure    bool   `config:"amqp-insecure"`
-	AmqpTlsCert     string `config:"amqp-tls-cert"`
-	AmqpTlsCertPath string `config:"amqp-tls-cert-path"`
-	BaseDir         string `config:"base-dir"`
-	PoolSize        int    `config:"pool-size"`
-	BuildAPIURI     string `config:"build-api-uri"`
-	QueueName       string `config:"queue-name"`
-	LibratoEmail    string `config:"librato-email"`
-	LibratoToken    string `config:"librato-token"`
-	LibratoSource   string `config:"librato-source"`
-	SentryDSN       string `config:"sentry-dsn"`
-	Hostname        string `config:"hostname"`
-	DefaultLanguage string `config:"default-language"`
-	DefaultDist     string `config:"default-dist"`
-	DefaultGroup    string `config:"default-group"`
-	DefaultOS       string `config:"default-os"`
-	JobBoardURL     string `config:"job-board-url"`
-	TravisSite      string `config:"travis-site"`
+	ProviderName      string `config:"provider-name"`
+	QueueType         string `config:"queue-type"`
+	AmqpURI           string `config:"amqp-uri"`
+	AmqpInsecure      bool   `config:"amqp-insecure"`
+	AmqpTlsCert       string `config:"amqp-tls-cert"`
+	AmqpTlsCertPath   string `config:"amqp-tls-cert-path"`
+	BaseDir           string `config:"base-dir"`
+	PoolSize          int    `config:"pool-size"`
+	BuildAPIURI       string `config:"build-api-uri"`
+	QueueName         string `config:"queue-name"`
+	LibratoEmail      string `config:"librato-email"`
+	LibratoToken      string `config:"librato-token"`
+	LibratoSource     string `config:"librato-source"`
+	SentryDSN         string `config:"sentry-dsn"`
+	HoneycombWriteKey string `config:"honeycomb-write-key"`
+	Hostname          string `config:"hostname"`
+	DefaultLanguage   string `config:"default-language"`
+	DefaultDist       string `config:"default-dist"`
+	DefaultGroup      string `config:"default-group"`
+	DefaultOS         string `config:"default-os"`
+	JobBoardURL       string `config:"job-board-url"`
+	TravisSite        string `config:"travis-site"`
 
 	FilePollingInterval      time.Duration `config:"file-polling-interval"`
 	HTTPPollingInterval      time.Duration `config:"http-polling-interval"`

--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -68,10 +68,11 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 	}).Info("started instance")
 
 	libhoney.SendNow(map[string]interface{}{
+		"provider":    s.provider,
+		"job_id":      buildJob.Payload().Job.ID,
 		"boot_time":   time.Since(startTime),
 		"instance_id": instance.ID(),
 		"image_name":  instance.ImageName(),
-		"provider":    s.provider,
 	})
 
 	state.Put("instance", instance)

--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -71,7 +71,7 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 		"boot_time":   time.Since(startTime),
 		"instance_id": instance.ID(),
 		"image_name":  instance.ImageName(),
-		"provider": s.provider
+		"provider":    s.provider,
 	})
 
 	state.Put("instance", instance)

--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -5,6 +5,7 @@ import (
 
 	gocontext "context"
 
+	libhoney "github.com/honeycombio/libhoney-go"
 	"github.com/mitchellh/multistep"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -65,6 +66,13 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 		"instance_id": instance.ID(),
 		"image_name":  instance.ImageName(),
 	}).Info("started instance")
+
+	libhoney.SendNow(map[string]interface{}{
+		"boot_time":   time.Since(startTime),
+		"instance_id": instance.ID(),
+		"image_name":  instance.ImageName(),
+		"provider": s.provider
+	})
 
 	state.Put("instance", instance)
 

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -85,6 +85,30 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/facebookgo/clock",
+			"repository": "https://github.com/facebookgo/clock",
+			"vcs": "git",
+			"revision": "600d898af40aa09a7a93ecb9265d87b0504b6f03",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/facebookgo/limitgroup",
+			"repository": "https://github.com/facebookgo/limitgroup",
+			"vcs": "git",
+			"revision": "6abd8d71ec01451d7f1929eacaa263bbe2935d05",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/facebookgo/muster",
+			"repository": "https://github.com/facebookgo/muster",
+			"vcs": "git",
+			"revision": "fd3d7953fd52354a74b9f6b3d70d0c9650c4ec2a",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/garyburd/redigo/internal",
 			"repository": "https://github.com/garyburd/redigo",
 			"vcs": "git",
@@ -149,6 +173,14 @@
 			"repository": "https://github.com/hashicorp/go-cleanhttp",
 			"vcs": "git",
 			"revision": "3573b8b52aa7b37b9358d966a898feb387f62437",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/honeycombio/libhoney-go",
+			"repository": "https://github.com/honeycombio/libhoney-go",
+			"vcs": "git",
+			"revision": "9bdca6032bc1b4f0bcbd590f3dc71102b38106dd",
 			"branch": "master",
 			"notests": true
 		},
@@ -394,6 +426,14 @@
 			"repository": "https://gopkg.in/airbrake/gobrake.v2",
 			"vcs": "git",
 			"revision": "668876711219e8b0206e2994bf0a59d889c775aa",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "gopkg.in/alexcesaro/statsd.v2",
+			"repository": "https://gopkg.in/alexcesaro/statsd.v2",
+			"vcs": "git",
+			"revision": "7fea3f0d2fab1ad973e641e51dba45443a311a90",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
[Honeycomb](https://honeycomb.io/) is a pretty cool tool (see [Igor's blogpost](https://builders.travis-ci.com/blog/2017-10-18-honeycomb/)) and we can always use more info about what our systems are doing.

## What approach did you choose and why?
Hook worker up to Honeycomb. I've limited this PR to just one random event, since it's just meant to be the initial set-up phase. 

This will need keychain/terraform changes too (for the configuration bits), but it shouldn't fail without them.

## How can you test this?
Since this is just the set-up and experimentation, I haven't added any unit-tests, although I think they are useful on the long run. (I will probably add them before this PR is merged if we decide to go the Honeycomb route)
- [ ] Deploy to staging and check that data flows into Honeycomb
- [ ] Deploy to production and check that data flows into Honeycomb

## What feedback would you like, if any?
Honeycomb sends the events asynchronously and uses a separate channel to return the responses (see [docs](https://honeycomb.io/docs/connect/go/#handling-responses)). I left response handling out for now to keep things simpler, but I think we do eventually want to check whether we're having issues sending events, right?  

Any other comments are of course welcome!