### PR TITLE
Restructure the use of RabbitMQ channels for logs and state updates

### DIFF
--- a/amqp_canceller_test.go
+++ b/amqp_canceller_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func newTestAMQPCanceller(t *testing.T, cancellationBroadcaster *CancellationBroadcaster) *AMQPCanceller {
-	amqpConn, _ := setupAMQPConn(t)
+	amqpConn, _, _ := setupAMQPConn(t)
 
 	uuid := uuid.NewRandom()
 	ctx := context.FromUUID(gocontext.TODO(), uuid.String())

--- a/amqp_job.go
+++ b/amqp_job.go
@@ -18,7 +18,7 @@ import (
 type amqpJob struct {
 	conn            *amqp.Connection
 	stateUpdateChan *amqp.Channel
-	logWriterChan	*amqp.Channel
+	logWriterChan   *amqp.Channel
 	delivery        amqp.Delivery
 	payload         *JobPayload
 	rawPayload      *simplejson.Json

--- a/amqp_job.go
+++ b/amqp_job.go
@@ -17,6 +17,8 @@ import (
 
 type amqpJob struct {
 	conn            *amqp.Connection
+	stateUpdateChan *amqp.Channel
+	logWriterChan	*amqp.Channel
 	delivery        amqp.Delivery
 	payload         *JobPayload
 	rawPayload      *simplejson.Json
@@ -121,7 +123,7 @@ func (j *amqpJob) LogWriter(ctx gocontext.Context, defaultLogTimeout time.Durati
 		logTimeout = defaultLogTimeout
 	}
 
-	return newAMQPLogWriter(ctx, j.conn, j.payload.Job.ID, logTimeout)
+	return newAMQPLogWriter(ctx, j.logWriterChan, j.payload.Job.ID, logTimeout)
 }
 
 func (j *amqpJob) createStateUpdateBody(ctx gocontext.Context, state string) map[string]interface{} {
@@ -160,12 +162,6 @@ func (j *amqpJob) sendStateUpdate(ctx gocontext.Context, event, state string) er
 	default:
 	}
 
-	amqpChan, err := j.conn.Channel()
-	if err != nil {
-		return err
-	}
-	defer amqpChan.Close()
-
 	j.stateCount++
 	body := j.createStateUpdateBody(ctx, state)
 
@@ -174,12 +170,7 @@ func (j *amqpJob) sendStateUpdate(ctx gocontext.Context, event, state string) er
 		return err
 	}
 
-	_, err = amqpChan.QueueDeclare("reporting.jobs.builds", true, false, false, false, nil)
-	if err != nil {
-		return err
-	}
-
-	return amqpChan.Publish("", "reporting.jobs.builds", false, false, amqp.Publishing{
+	return j.stateUpdateChan.Publish("", "reporting.jobs.builds", false, false, amqp.Publishing{
 		ContentType:  "application/json",
 		DeliveryMode: amqp.Persistent,
 		Timestamp:    time.Now().UTC(),

--- a/amqp_job_queue.go
+++ b/amqp_job_queue.go
@@ -38,6 +38,26 @@ func NewAMQPJobQueue(conn *amqp.Connection, queue string) (*AMQPJobQueue, error)
 		return nil, err
 	}
 
+	_, err = channel.QueueDeclare("reporting.jobs.builds", true, false, false, false, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	err = channel.ExchangeDeclare("reporting", "topic", true, false, false, false, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = channel.QueueDeclare("reporting.jobs.logs", true, false, false, false, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	err = channel.QueueBind("reporting.jobs.logs", "reporting.jobs.logs", "reporting", false, nil)
+	if err != nil {
+		return nil, err
+	}
+
 	err = channel.Close()
 	if err != nil {
 		return nil, err
@@ -53,17 +73,27 @@ func NewAMQPJobQueue(conn *amqp.Connection, queue string) (*AMQPJobQueue, error)
 // first channel gets sent every BuildJob that we receive from AMQP. The
 // stopChan is a channel that can be closed in order to stop the consumer.
 func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err error) {
-	channel, err := q.conn.Channel()
+	jobsChannel, err := q.conn.Channel()
 	if err != nil {
 		return
 	}
 
-	err = channel.Qos(1, 0, false)
+	err = jobsChannel.Qos(1, 0, false)
 	if err != nil {
 		return
 	}
 
-	deliveries, err := channel.Consume(q.queue, "build-job-consumer", false, false, false, false, nil)
+	deliveries, err := jobsChannel.Consume(q.queue, "build-job-consumer", false, false, false, false, nil)
+	if err != nil {
+		return
+	}
+
+	stateUpdateChannel, err := q.conn.Channel()
+	if err != nil {
+		return
+	}
+
+	logWriterChannel, err := q.conn.Channel()
 	if err != nil {
 		return
 	}
@@ -72,7 +102,9 @@ func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 	outChan = buildJobChan
 
 	go func() {
-		defer channel.Close()
+		defer jobsChannel.Close()
+		defer stateUpdateChannel.Close()
+		defer logWriterChannel.Close()
 		defer close(buildJobChan)
 
 		logger := context.LoggerFromContext(ctx).WithFields(logrus.Fields{
@@ -138,6 +170,8 @@ func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 				buildJob.startAttributes.VMType = buildJob.payload.VMType
 				buildJob.startAttributes.SetDefaults(q.DefaultLanguage, q.DefaultDist, q.DefaultGroup, q.DefaultOS, VMTypeDefault)
 				buildJob.conn = q.conn
+				buildJob.stateUpdateChan = stateUpdateChannel
+				buildJob.logWriterChan = logWriterChannel
 				buildJob.delivery = delivery
 				buildJob.stateCount = buildJob.payload.Meta.StateUpdateCount
 

--- a/amqp_job_test.go
+++ b/amqp_job_test.go
@@ -44,7 +44,15 @@ func (a *fakeAMQPAcknowledger) Reject(tag uint64, req bool) error {
 }
 
 func newTestAMQPJob(t *testing.T) *amqpJob {
-	amqpConn, _ := setupAMQPConn(t)
+	amqpConn, err := setupAMQPConn(t)
+	if err != nil {
+		t.Error(err)
+	}
+	amqpChan, err := amqpConn.Channel()
+	if err != nil {
+		t.Error(err)
+	}
+
 	payload := &JobPayload{
 		Type: "job:test",
 		Job: JobJobPayload{
@@ -85,6 +93,7 @@ func newTestAMQPJob(t *testing.T) *amqpJob {
 
 	return &amqpJob{
 		conn:            amqpConn,
+		logWriterChan	 amqpChan,
 		delivery:        delivery,
 		payload:         payload,
 		rawPayload:      rawPayload,

--- a/amqp_job_test.go
+++ b/amqp_job_test.go
@@ -44,10 +44,8 @@ func (a *fakeAMQPAcknowledger) Reject(tag uint64, req bool) error {
 }
 
 func newTestAMQPJob(t *testing.T) *amqpJob {
-	amqpConn, err := setupAMQPConn(t)
-	if err != nil {
-		t.Error(err)
-	}
+	amqpConn, _ := setupAMQPConn(t)
+
 	logChan, err := amqpConn.Channel()
 	if err != nil {
 		t.Error(err)

--- a/amqp_job_test.go
+++ b/amqp_job_test.go
@@ -44,16 +44,8 @@ func (a *fakeAMQPAcknowledger) Reject(tag uint64, req bool) error {
 }
 
 func newTestAMQPJob(t *testing.T) *amqpJob {
-	amqpConn, _ := setupAMQPConn(t)
+	amqpConn, logChan := setupAMQPConn(t)
 
-	logChan, err := amqpConn.Channel()
-	if err != nil {
-		t.Error(err)
-	}
-	stateChan, err := amqpConn.Channel()
-	if err != nil {
-		t.Error(err)
-	}
 	payload := &JobPayload{
 		Type: "job:test",
 		Job: JobJobPayload{
@@ -95,7 +87,6 @@ func newTestAMQPJob(t *testing.T) *amqpJob {
 	return &amqpJob{
 		conn:            amqpConn,
 		logWriterChan:   logChan,
-		stateUpdateChan: stateChan,
 		delivery:        delivery,
 		payload:         payload,
 		rawPayload:      rawPayload,

--- a/amqp_job_test.go
+++ b/amqp_job_test.go
@@ -44,7 +44,7 @@ func (a *fakeAMQPAcknowledger) Reject(tag uint64, req bool) error {
 }
 
 func newTestAMQPJob(t *testing.T) *amqpJob {
-	amqpConn, logChan := setupAMQPConn(t)
+	amqpConn, logChan, stateChan := setupAMQPConn(t)
 
 	payload := &JobPayload{
 		Type: "job:test",
@@ -87,6 +87,7 @@ func newTestAMQPJob(t *testing.T) *amqpJob {
 	return &amqpJob{
 		conn:            amqpConn,
 		logWriterChan:   logChan,
+		stateUpdateChan: stateChan,
 		delivery:        delivery,
 		payload:         payload,
 		rawPayload:      rawPayload,

--- a/amqp_job_test.go
+++ b/amqp_job_test.go
@@ -96,8 +96,8 @@ func newTestAMQPJob(t *testing.T) *amqpJob {
 
 	return &amqpJob{
 		conn:            amqpConn,
-		logWriterChan	 logChan,
-		stateUpdateChan  stateChan,
+		logWriterChan:   logChan,
+		stateUpdateChan: stateChan,
 		delivery:        delivery,
 		payload:         payload,
 		rawPayload:      rawPayload,

--- a/amqp_job_test.go
+++ b/amqp_job_test.go
@@ -48,11 +48,14 @@ func newTestAMQPJob(t *testing.T) *amqpJob {
 	if err != nil {
 		t.Error(err)
 	}
-	amqpChan, err := amqpConn.Channel()
+	logChan, err := amqpConn.Channel()
 	if err != nil {
 		t.Error(err)
 	}
-
+	stateChan, err := amqpConn.Channel()
+	if err != nil {
+		t.Error(err)
+	}
 	payload := &JobPayload{
 		Type: "job:test",
 		Job: JobJobPayload{
@@ -93,7 +96,8 @@ func newTestAMQPJob(t *testing.T) *amqpJob {
 
 	return &amqpJob{
 		conn:            amqpConn,
-		logWriterChan	 amqpChan,
+		logWriterChan	 logChan,
+		stateUpdateChan  stateChan,
 		delivery:        delivery,
 		payload:         payload,
 		rawPayload:      rawPayload,

--- a/amqp_log_writer.go
+++ b/amqp_log_writer.go
@@ -43,31 +43,12 @@ type amqpLogWriter struct {
 	timeout time.Duration
 }
 
-func newAMQPLogWriter(ctx gocontext.Context, conn *amqp.Connection, jobID uint64, timeout time.Duration) (*amqpLogWriter, error) {
-	channel, err := conn.Channel()
-	if err != nil {
-		return nil, err
-	}
-
-	err = channel.ExchangeDeclare("reporting", "topic", true, false, false, false, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = channel.QueueDeclare("reporting.jobs.logs", true, false, false, false, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	err = channel.QueueBind("reporting.jobs.logs", "reporting.jobs.logs", "reporting", false, nil)
-	if err != nil {
-		return nil, err
-	}
+func newAMQPLogWriter(ctx gocontext.Context, logWriterChan *amqp.Channel, jobID uint64, timeout time.Duration) (*amqpLogWriter, error) {
 
 	writer := &amqpLogWriter{
 		ctx:       context.FromComponent(ctx, "log_writer"),
 		amqpConn:  conn,
-		amqpChan:  channel,
+		amqpChan:  logWriterChan,
 		jobID:     jobID,
 		closeChan: make(chan struct{}),
 		buffer:    new(bytes.Buffer),

--- a/amqp_log_writer.go
+++ b/amqp_log_writer.go
@@ -113,7 +113,6 @@ func (w *amqpLogWriter) Close() error {
 	w.logPartNumber++
 
 	err := w.publishLogPart(part)
-	_ = w.amqpChan.Close()
 	return err
 }
 
@@ -153,7 +152,6 @@ func (w *amqpLogWriter) WriteAndClose(p []byte) (int, error) {
 	w.logPartNumber++
 
 	err = w.publishLogPart(part)
-	_ = w.amqpChan.Close()
 	return n, err
 }
 

--- a/amqp_log_writer_test.go
+++ b/amqp_log_writer_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAMQPLogWriterWrite(t *testing.T) {
-	amqpConn, amqpChan := setupAMQPConn(t)
+	amqpConn, amqpChan, _ := setupAMQPConn(t)
 	defer amqpConn.Close()
 	defer amqpChan.Close()
 
@@ -69,7 +69,7 @@ func TestAMQPLogWriterWrite(t *testing.T) {
 }
 
 func TestAMQPLogWriterClose(t *testing.T) {
-	amqpConn, amqpChan := setupAMQPConn(t)
+	amqpConn, amqpChan, _ := setupAMQPConn(t)
 	defer amqpConn.Close()
 	defer amqpChan.Close()
 
@@ -117,7 +117,7 @@ func TestAMQPLogWriterClose(t *testing.T) {
 }
 
 func TestAMQPMaxLogLength(t *testing.T) {
-	amqpConn, amqpChan := setupAMQPConn(t)
+	amqpConn, amqpChan, _ := setupAMQPConn(t)
 	defer amqpConn.Close()
 	defer amqpChan.Close()
 

--- a/amqp_log_writer_test.go
+++ b/amqp_log_writer_test.go
@@ -19,7 +19,7 @@ func TestAMQPLogWriterWrite(t *testing.T) {
 	uuid := uuid.NewRandom()
 	ctx := workerctx.FromUUID(context.TODO(), uuid.String())
 
-	logWriter, err := newAMQPLogWriter(ctx, amqpConn, 4, time.Hour)
+	logWriter, err := newAMQPLogWriter(ctx, amqpChan, 4, time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +76,7 @@ func TestAMQPLogWriterClose(t *testing.T) {
 	uuid := uuid.NewRandom()
 	ctx := workerctx.FromUUID(context.TODO(), uuid.String())
 
-	logWriter, err := newAMQPLogWriter(ctx, amqpConn, 4, time.Hour)
+	logWriter, err := newAMQPLogWriter(ctx, amqpChan, 4, time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestAMQPMaxLogLength(t *testing.T) {
 	uuid := uuid.NewRandom()
 	ctx := workerctx.FromUUID(context.TODO(), uuid.String())
 
-	logWriter, err := newAMQPLogWriter(ctx, amqpConn, 4, time.Hour)
+	logWriter, err := newAMQPLogWriter(ctx, amqpChan, 4, time.Hour)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/amqp_test.go
+++ b/amqp_test.go
@@ -24,7 +24,7 @@ func setupAMQPConn(t *testing.T) (*amqp.Connection, *amqp.Channel, *amqp.Channel
 
 	err = logChan.ExchangeDeclare("reporting", "topic", true, false, false, false, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, nil
 	}
 	_, err = logChan.QueueDeclare("reporting.jobs.logs", true, false, false, false, nil)
 	if err != nil {
@@ -33,7 +33,7 @@ func setupAMQPConn(t *testing.T) (*amqp.Connection, *amqp.Channel, *amqp.Channel
 
 	err = logChan.QueueBind("reporting.jobs.logs", "reporting.jobs.logs", "reporting", false, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, nil
 	}
 
 	_, err = logChan.QueuePurge("reporting.jobs.logs", false)

--- a/amqp_test.go
+++ b/amqp_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/streadway/amqp"
 )
 
-func setupAMQPConn(t *testing.T) (*amqp.Connection, *amqp.Channel) {
+func setupAMQPConn(t *testing.T) (*amqp.Connection, *amqp.Channel, *amqp.Channel) {
 	if os.Getenv("AMQP_URI") == "" {
 		t.Skip("skipping amqp test since there is no AMQP_URI")
 	}
@@ -32,5 +32,15 @@ func setupAMQPConn(t *testing.T) (*amqp.Connection, *amqp.Channel) {
 		t.Error(err)
 	}
 
-	return amqpConn, logChan
+	stateChan, err := amqpConn.Channel()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = stateChan.QueueDeclare("reporting.jobs.builds", true, false, false, false, nil)
+	if err != nil {
+		return nil, nil, nil
+	}
+
+	return amqpConn, logChan, stateChan
 }

--- a/amqp_test.go
+++ b/amqp_test.go
@@ -17,20 +17,20 @@ func setupAMQPConn(t *testing.T) (*amqp.Connection, *amqp.Channel) {
 		t.Fatal(err)
 	}
 
-	amqpChan, err := amqpConn.Channel()
+	logChan, err := amqpConn.Channel()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = amqpChan.QueueDeclare("reporting.jobs.logs", true, false, false, false, nil)
+	_, err = logChan.QueueDeclare("reporting.jobs.logs", true, false, false, false, nil)
 	if err != nil {
 		t.Error(err)
 	}
 
-	_, err = amqpChan.QueuePurge("reporting.jobs.logs", false)
+	_, err = logChan.QueuePurge("reporting.jobs.logs", false)
 	if err != nil {
 		t.Error(err)
 	}
 
-	return amqpConn, amqpChan
+	return amqpConn, logChan
 }

--- a/amqp_test.go
+++ b/amqp_test.go
@@ -22,9 +22,18 @@ func setupAMQPConn(t *testing.T) (*amqp.Connection, *amqp.Channel, *amqp.Channel
 		t.Fatal(err)
 	}
 
+	err = logChan.ExchangeDeclare("reporting", "topic", true, false, false, false, nil)
+	if err != nil {
+		return nil, err
+	}
 	_, err = logChan.QueueDeclare("reporting.jobs.logs", true, false, false, false, nil)
 	if err != nil {
 		t.Error(err)
+	}
+
+	err = logChan.QueueBind("reporting.jobs.logs", "reporting.jobs.logs", "reporting", false, nil)
+	if err != nil {
+		return nil, err
 	}
 
 	_, err = logChan.QueuePurge("reporting.jobs.logs", false)


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
We have had high CPU alerts for our CloudAMQP Rabbit cluster daily for the last week, and our CPU use has been quite high for over a month. 
CloudAMQP support suggested that this might be due to channel churn and after some investigation, it turned out that we were creating/closing a channel for each job state update message and one channel per job to send the logs. 

## What approach did you choose and why?
We've decided to take the same approach to channel-use as we already had for the build job queue, which implies having the amqp_job_queue create one channel for each queue and have it reused by the processor. 

⚠️ **This is currently running in production in GCE for `production-1-worker-org-c-3-gce` `(IP: 104.197.196.167)`.**

## How can you test this?
Deploy it and check the AMQP logs for channel created/closed events?!
This has behaved well on EC2 staging, so we'll probably try it for a few workers in production later today.

