### PR TITLE
Build on go 1.9.4 with latest dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.9.2
+go: 1.9.4
 sudo: required
 dist: trusty
 group: edge

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -320,6 +320,15 @@
 			"notests": true
 		},
 		{
+			"importpath": "golang.org/x/crypto/poly1305",
+			"repository": "https://go.googlesource.com/crypto",
+			"vcs": "git",
+			"revision": "650f4a345ab4e5b245a3034b110ebc7299e68186",
+			"branch": "master",
+			"path": "/poly1305",
+			"notests": true
+		},
+		{
 			"importpath": "golang.org/x/crypto/ssh",
 			"repository": "https://go.googlesource.com/crypto",
 			"vcs": "git",

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -5,7 +5,7 @@
 			"importpath": "cloud.google.com/go/compute/metadata",
 			"repository": "https://code.googlesource.com/gocloud",
 			"vcs": "git",
-			"revision": "28b507a1143b9134490384bc95088187dde1b96a",
+			"revision": "ec59366efe06569bd5f37eb4511c996cf220963d",
 			"branch": "master",
 			"path": "/compute/metadata",
 			"notests": true
@@ -22,7 +22,7 @@
 			"importpath": "github.com/Microsoft/go-winio",
 			"repository": "https://github.com/Microsoft/go-winio",
 			"vcs": "git",
-			"revision": "78439966b38d69bf38227fbf57ac8a6fee70f69a",
+			"revision": "7da180ee92d8bd8bb8c37fc560e673e6557c392f",
 			"branch": "master",
 			"notests": true
 		},
@@ -38,7 +38,7 @@
 			"importpath": "github.com/cenk/backoff",
 			"repository": "https://github.com/cenk/backoff",
 			"vcs": "git",
-			"revision": "309aa717adbf351e92864cbedf9cca0b769a4b5a",
+			"revision": "2ea60e5f094469f9e65adb9cd103795b73ae743e",
 			"branch": "master",
 			"notests": true
 		},
@@ -46,7 +46,7 @@
 			"importpath": "github.com/certifi/gocertifi",
 			"repository": "https://github.com/certifi/gocertifi",
 			"vcs": "git",
-			"revision": "a4ab0227d360091084658029ec8ae45f989fba3e",
+			"revision": "deb3ae2ef2610fde3330947281941c562861188b",
 			"branch": "master",
 			"notests": true
 		},
@@ -54,7 +54,7 @@
 			"importpath": "github.com/docker/docker",
 			"repository": "https://github.com/docker/docker",
 			"vcs": "git",
-			"revision": "72e45fd54e13256c813fdb39b18e26a0de980733",
+			"revision": "68c3201626439d5be5c24d14d4fe7e27fe93954d",
 			"branch": "master",
 			"notests": true,
 			"allfiles": true
@@ -63,7 +63,7 @@
 			"importpath": "github.com/docker/go-connections/tlsconfig",
 			"repository": "https://github.com/docker/go-connections",
 			"vcs": "git",
-			"revision": "3ede32e2033de7505e6500d6c868c2b9ed9f169d",
+			"revision": "7beb39f0b969b075d1325fecb092faf27fd357b6",
 			"branch": "master",
 			"path": "/tlsconfig",
 			"notests": true
@@ -72,7 +72,7 @@
 			"importpath": "github.com/docker/go-units",
 			"repository": "https://github.com/docker/go-units",
 			"vcs": "git",
-			"revision": "0dadbb0345b35ec7ef35e228dabb8de89a65bf52",
+			"revision": "47565b4f722fb6ceae66b95f853feed578a4a51c",
 			"branch": "master",
 			"notests": true
 		},
@@ -88,7 +88,7 @@
 			"importpath": "github.com/garyburd/redigo/internal",
 			"repository": "https://github.com/garyburd/redigo",
 			"vcs": "git",
-			"revision": "b389d5392e340092642eec4e36754e0280ad1f8e",
+			"revision": "d1ed5c67e5794de818ea85e6b522fda02623a484",
 			"branch": "master",
 			"path": "internal",
 			"notests": true
@@ -97,7 +97,7 @@
 			"importpath": "github.com/garyburd/redigo/redis",
 			"repository": "https://github.com/garyburd/redigo",
 			"vcs": "git",
-			"revision": "b389d5392e340092642eec4e36754e0280ad1f8e",
+			"revision": "d1ed5c67e5794de818ea85e6b522fda02623a484",
 			"branch": "master",
 			"path": "/redis",
 			"notests": true
@@ -106,7 +106,7 @@
 			"importpath": "github.com/getsentry/raven-go",
 			"repository": "https://github.com/getsentry/raven-go",
 			"vcs": "git",
-			"revision": "c9de0b92586aaba092c2a231cb7384354b178544",
+			"revision": "563b81fc02b75d664e54da31f787c2cc2186780b",
 			"branch": "master",
 			"notests": true
 		},
@@ -114,7 +114,7 @@
 			"importpath": "github.com/golang/protobuf/proto",
 			"repository": "https://github.com/golang/protobuf",
 			"vcs": "git",
-			"revision": "1e59b77b52bf8e4b449a57e6f79f21226d571845",
+			"revision": "bbd03ef6da3a115852eaf24c8a1c46aeb39aa175",
 			"branch": "master",
 			"path": "/proto",
 			"notests": true
@@ -123,7 +123,7 @@
 			"importpath": "github.com/golang/protobuf/ptypes/any",
 			"repository": "https://github.com/golang/protobuf",
 			"vcs": "git",
-			"revision": "1e59b77b52bf8e4b449a57e6f79f21226d571845",
+			"revision": "bbd03ef6da3a115852eaf24c8a1c46aeb39aa175",
 			"branch": "master",
 			"path": "ptypes/any",
 			"notests": true
@@ -140,7 +140,7 @@
 			"importpath": "github.com/gorilla/mux",
 			"repository": "https://github.com/gorilla/mux",
 			"vcs": "git",
-			"revision": "65ec7248c53f499f6b480655e019e0b9d7a6ce11",
+			"revision": "c0091a029979286890368b4c7b301261e448e242",
 			"branch": "master",
 			"notests": true
 		},
@@ -148,7 +148,7 @@
 			"importpath": "github.com/hashicorp/go-cleanhttp",
 			"repository": "https://github.com/hashicorp/go-cleanhttp",
 			"vcs": "git",
-			"revision": "3573b8b52aa7b37b9358d966a898feb387f62437",
+			"revision": "d5fe4b57a186c716b0e00b8c301cbd9b4182694d",
 			"branch": "master",
 			"notests": true
 		},
@@ -172,7 +172,7 @@
 			"importpath": "github.com/mihasya/go-metrics-librato",
 			"repository": "https://github.com/mihasya/go-metrics-librato",
 			"vcs": "git",
-			"revision": "0ec8d5e8bf04a48fc5c96792bfd016b08afdabad",
+			"revision": "c2a1624c7a80c6ad27067d6757b074c867e0b444",
 			"branch": "master",
 			"notests": true
 		},
@@ -180,7 +180,7 @@
 			"importpath": "github.com/mitchellh/mapstructure",
 			"repository": "https://github.com/mitchellh/mapstructure",
 			"vcs": "git",
-			"revision": "06020f85339e21b2478f756a78e295255ffa4d6a",
+			"revision": "a4e142e9c047c904fa2f1e144d9a84e6133024bc",
 			"branch": "master",
 			"notests": true
 		},
@@ -196,7 +196,7 @@
 			"importpath": "github.com/pborman/uuid",
 			"repository": "https://github.com/pborman/uuid",
 			"vcs": "git",
-			"revision": "e533369306653d193b93dae055f6083cbf8ba54f",
+			"revision": "c65b2f87fee37d1c7854c9164a450713c28d50cd",
 			"branch": "master",
 			"notests": true
 		},
@@ -204,7 +204,7 @@
 			"importpath": "github.com/pkg/errors",
 			"repository": "https://github.com/pkg/errors",
 			"vcs": "git",
-			"revision": "f15c970de5b76fac0b59abb32d62c17cc7bed265",
+			"revision": "30136e27e2ac8d167177e8a583aa4c3fea5be833",
 			"branch": "master",
 			"notests": true
 		},
@@ -212,7 +212,7 @@
 			"importpath": "github.com/pkg/sftp",
 			"repository": "https://github.com/pkg/sftp",
 			"vcs": "git",
-			"revision": "f6ec992e480925807f691a585c4c36841357ef89",
+			"revision": "22e9c1ccc02fc1b9fa3264572e49109b68a86947",
 			"branch": "master",
 			"notests": true
 		},
@@ -228,7 +228,7 @@
 			"importpath": "github.com/rcrowley/go-metrics",
 			"repository": "https://github.com/rcrowley/go-metrics",
 			"vcs": "git",
-			"revision": "e181e095bae94582363434144c61a9653aff6e50",
+			"revision": "8732c616f52954686704c8645fe1a9d59e9df7c1",
 			"branch": "master",
 			"notests": true
 		},
@@ -236,7 +236,7 @@
 			"importpath": "github.com/sirupsen/logrus",
 			"repository": "https://github.com/sirupsen/logrus",
 			"vcs": "git",
-			"revision": "95cd2b9c79aa5e72ab0bc69b7ccc2be15bf850f6",
+			"revision": "8c0189d9f6bbf301e5d055d34268156b317016af",
 			"branch": "master",
 			"notests": true
 		},
@@ -252,7 +252,7 @@
 			"importpath": "github.com/streadway/amqp",
 			"repository": "https://github.com/streadway/amqp",
 			"vcs": "git",
-			"revision": "ff791c2d22d3f1588b4e2cc71a9fba5e1da90654",
+			"revision": "fc7fda2371f5327ad39211e09482845b8734cc72",
 			"branch": "master",
 			"notests": true
 		},
@@ -260,7 +260,7 @@
 			"importpath": "github.com/stretchr/testify/assert",
 			"repository": "https://github.com/stretchr/testify",
 			"vcs": "git",
-			"revision": "2aa2c176b9dab406a6970f6a55f513e8a8c8b18f",
+			"revision": "be8372ae8ec5c6daaed3cc28ebf73c54b737c240",
 			"branch": "master",
 			"path": "/assert",
 			"notests": true
@@ -269,7 +269,7 @@
 			"importpath": "github.com/stretchr/testify/require",
 			"repository": "https://github.com/stretchr/testify",
 			"vcs": "git",
-			"revision": "2aa2c176b9dab406a6970f6a55f513e8a8c8b18f",
+			"revision": "be8372ae8ec5c6daaed3cc28ebf73c54b737c240",
 			"branch": "master",
 			"path": "/require",
 			"notests": true
@@ -278,7 +278,7 @@
 			"importpath": "github.com/stretchr/testify/vendor/github.com/davecgh/go-spew/spew",
 			"repository": "https://github.com/stretchr/testify",
 			"vcs": "git",
-			"revision": "2aa2c176b9dab406a6970f6a55f513e8a8c8b18f",
+			"revision": "be8372ae8ec5c6daaed3cc28ebf73c54b737c240",
 			"branch": "master",
 			"path": "vendor/github.com/davecgh/go-spew/spew",
 			"notests": true
@@ -287,7 +287,7 @@
 			"importpath": "github.com/stretchr/testify/vendor/github.com/pmezard/go-difflib/difflib",
 			"repository": "https://github.com/stretchr/testify",
 			"vcs": "git",
-			"revision": "2aa2c176b9dab406a6970f6a55f513e8a8c8b18f",
+			"revision": "be8372ae8ec5c6daaed3cc28ebf73c54b737c240",
 			"branch": "master",
 			"path": "vendor/github.com/pmezard/go-difflib/difflib",
 			"notests": true
@@ -296,7 +296,7 @@
 			"importpath": "golang.org/x/crypto/curve25519",
 			"repository": "https://go.googlesource.com/crypto",
 			"vcs": "git",
-			"revision": "94eea52f7b742c7cbe0b03b22f0c4c8631ece122",
+			"revision": "650f4a345ab4e5b245a3034b110ebc7299e68186",
 			"branch": "master",
 			"path": "curve25519",
 			"notests": true
@@ -305,16 +305,25 @@
 			"importpath": "golang.org/x/crypto/ed25519",
 			"repository": "https://go.googlesource.com/crypto",
 			"vcs": "git",
-			"revision": "94eea52f7b742c7cbe0b03b22f0c4c8631ece122",
+			"revision": "650f4a345ab4e5b245a3034b110ebc7299e68186",
 			"branch": "master",
 			"path": "ed25519",
+			"notests": true
+		},
+		{
+			"importpath": "golang.org/x/crypto/internal/chacha20",
+			"repository": "https://go.googlesource.com/crypto",
+			"vcs": "git",
+			"revision": "650f4a345ab4e5b245a3034b110ebc7299e68186",
+			"branch": "master",
+			"path": "/internal/chacha20",
 			"notests": true
 		},
 		{
 			"importpath": "golang.org/x/crypto/ssh",
 			"repository": "https://go.googlesource.com/crypto",
 			"vcs": "git",
-			"revision": "94eea52f7b742c7cbe0b03b22f0c4c8631ece122",
+			"revision": "650f4a345ab4e5b245a3034b110ebc7299e68186",
 			"branch": "master",
 			"path": "ssh",
 			"notests": true
@@ -323,7 +332,7 @@
 			"importpath": "golang.org/x/net/context",
 			"repository": "https://go.googlesource.com/net",
 			"vcs": "git",
-			"revision": "a8b9294777976932365dabb6640cf1468d95c70f",
+			"revision": "f5dfe339be1d06f81b22525fe34671ee7d2c8904",
 			"branch": "master",
 			"path": "/context",
 			"notests": true
@@ -332,7 +341,7 @@
 			"importpath": "golang.org/x/oauth2",
 			"repository": "https://go.googlesource.com/oauth2",
 			"vcs": "git",
-			"revision": "f95fa95eaa936d9d87489b15d1d18b97c1ba9c28",
+			"revision": "543e37812f10c46c622c9575afd7ad22f22a12ba",
 			"branch": "master",
 			"notests": true
 		},
@@ -340,7 +349,7 @@
 			"importpath": "golang.org/x/sys/unix",
 			"repository": "https://go.googlesource.com/sys",
 			"vcs": "git",
-			"revision": "8b4580aae2a0dd0c231a45d3ccb8434ff533b840",
+			"revision": "37707fdb30a5b38865cfb95e5aab41707daec7fd",
 			"branch": "master",
 			"path": "/unix",
 			"notests": true
@@ -349,7 +358,7 @@
 			"importpath": "golang.org/x/sys/windows",
 			"repository": "https://go.googlesource.com/sys",
 			"vcs": "git",
-			"revision": "8b4580aae2a0dd0c231a45d3ccb8434ff533b840",
+			"revision": "37707fdb30a5b38865cfb95e5aab41707daec7fd",
 			"branch": "master",
 			"path": "/windows",
 			"notests": true
@@ -358,7 +367,7 @@
 			"importpath": "google.golang.org/api/compute/v1",
 			"repository": "https://code.googlesource.com/google-api-go-client",
 			"vcs": "git",
-			"revision": "88d8826ad7655f8bdc7328b1ec3774f3851c3a44",
+			"revision": "b0284fdf28b5e4d7c9aa5c26e67035437f711304",
 			"branch": "master",
 			"path": "/compute/v1",
 			"notests": true
@@ -367,7 +376,7 @@
 			"importpath": "google.golang.org/api/gensupport",
 			"repository": "https://code.googlesource.com/google-api-go-client",
 			"vcs": "git",
-			"revision": "88d8826ad7655f8bdc7328b1ec3774f3851c3a44",
+			"revision": "b0284fdf28b5e4d7c9aa5c26e67035437f711304",
 			"branch": "master",
 			"path": "gensupport",
 			"notests": true
@@ -376,7 +385,7 @@
 			"importpath": "google.golang.org/api/googleapi",
 			"repository": "https://code.googlesource.com/google-api-go-client",
 			"vcs": "git",
-			"revision": "88d8826ad7655f8bdc7328b1ec3774f3851c3a44",
+			"revision": "b0284fdf28b5e4d7c9aa5c26e67035437f711304",
 			"branch": "master",
 			"path": "googleapi",
 			"notests": true
@@ -385,7 +394,7 @@
 			"importpath": "google.golang.org/appengine",
 			"repository": "https://github.com/golang/appengine",
 			"vcs": "git",
-			"revision": "9d8544a6b2c7df9cff240fcf92d7b2f59bc13416",
+			"revision": "5bee14b453b4c71be47ec1781b0fa61c2ea182db",
 			"branch": "master",
 			"notests": true
 		},
@@ -417,7 +426,7 @@
 			"importpath": "gopkg.in/yaml.v2",
 			"repository": "https://gopkg.in/yaml.v2",
 			"vcs": "git",
-			"revision": "287cf08546ab5e7e37d55a84f7ed3fd1db036de5",
+			"revision": "d670f9405373e636a5a2765eea47fac0c9bc91a4",
 			"branch": "v2",
 			"notests": true
 		}


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The current release is built on go 1.9.2 with dependencies last updated Nov 30, 2017.

## What approach did you choose and why?

Build against go 1.9.4 (latest stable) and update dependencies via `gvt update -all`.

## How can you test this?

- [x] Staging deployment(s)