### PR TITLE
Waiting before running createdb fixes flaky integration test

### DIFF
--- a/script/http-job-test
+++ b/script/http-job-test
@@ -22,7 +22,7 @@ main() {
 
   docker exec \
     --user postgres \
-    job-board-postgres bash -c 'while ! pg_isready; do sleep 1; done'
+    job-board-postgres bash -c 'while ! pg_isready -d template1; do sleep 1; done'
 
   docker exec \
     --user postgres \

--- a/script/http-job-test
+++ b/script/http-job-test
@@ -12,6 +12,10 @@ main() {
     "${JOB_BOARD_CLONE_URL}" "${JOB_BOARD_CLONE_DIR}"
 
   docker run -d \
+    --name job-board-redis \
+    redis
+
+  docker run -d \
     --name job-board-postgres \
     -e POSTGRES_PASSWORD=yay \
     postgres
@@ -27,11 +31,7 @@ main() {
   docker exec \
     --user postgres \
     job-board-postgres psql -l
-
-  docker run -d \
-    --name job-board-redis \
-    redis
-
+  
   docker run \
     --rm \
     --name travis-worker-http-job-test \

--- a/script/http-job-test
+++ b/script/http-job-test
@@ -22,7 +22,7 @@ main() {
 
   docker exec \
     --user postgres \
-    job-board-postgres bash -c 'while ! psql -l; do sleep 1; done'
+    job-board-postgres bash -c 'while ! pg_isready; do sleep 1; done'
 
   docker exec \
     --user postgres \

--- a/script/http-job-test
+++ b/script/http-job-test
@@ -22,7 +22,9 @@ main() {
 
   docker exec \
     --user postgres \
-    job-board-postgres bash -c 'while ! pg_isready -d template1; do sleep 1; done'
+    job-board-postgres bash -c 'while ! pg_isready; do sleep 1; done'
+
+  sleep 1
 
   docker exec \
     --user postgres \

--- a/script/http-job-test
+++ b/script/http-job-test
@@ -31,7 +31,7 @@ main() {
   docker exec \
     --user postgres \
     job-board-postgres psql -l
-  
+
   docker run \
     --rm \
     --name travis-worker-http-job-test \

--- a/script/http-job-test
+++ b/script/http-job-test
@@ -24,6 +24,8 @@ main() {
     --user postgres \
     job-board-postgres bash -c 'while ! pg_isready; do sleep 1; done'
 
+  # despite pg_isready reporting the server as up, we still have to wait a bit
+  # for createdb to be able to successfully connect
   sleep 1
 
   docker exec \


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
http-job-test is still failing quite often at the stage where it's trying to create the new db, but can't connect to postgres (example: https://travis-ci.org/travis-ci/worker/builds/342690250)

## What approach did you choose and why?
I thought using pg_isready would be a better way to check for postgres' status, but it seems we're still trying to connect a bit too fast (result: https://travis-ci.org/travis-ci/worker/builds/342718822).
I've decided to keep using it for the check (instead of the previous `psql -l`) since I feel it communicates the intention better.
Adding an extra sleep (as ugly as it is) between the check and the createdb call seems to improve things (haven't had any failures yet, but we can also considering increasing the duration if they start occurring again)

## How can you test this?
Check the builds for intermittent failures.