### PR TITLE
More docker container labels (ipv4, instance id)

### DIFF
--- a/backend/docker.go
+++ b/backend/docker.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -385,6 +386,20 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 	jid, ok := context.JobIDFromContext(ctx)
 	if ok {
 		labels["travis.job_id"] = strconv.FormatUint(jid, 10)
+	}
+
+	ipv4, err := ioutil.ReadFile("/var/tmp/travis-run.d/instance-ipv4")
+	if err != nil {
+		logger.WithField("err", err).Error("couldn't read instance IP from /var/tmp/travis-run.d/instance-ipv4")
+	} else {
+		labels["travis.ipv4"] = ipv4
+	}
+
+	iid, err := ioutil.ReadFile("/var/tmp/travis-run.d/instance-id")
+	if err != nil {
+		logger.WithField("err", err).Error("couldn't read instance ID from /var/tmp/travis-run.d/instance-id")
+	} else {
+		labels["travis.instance_id"] = iid
 	}
 
 	dockerConfig := &dockercontainer.Config{

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -392,14 +392,14 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 	if err != nil {
 		logger.WithField("err", err).Error("couldn't read instance IP from /var/tmp/travis-run.d/instance-ipv4")
 	} else {
-		labels["travis.ipv4"] = ipv4
+		labels["travis.ipv4"] = string(ipv4)
 	}
 
 	iid, err := ioutil.ReadFile("/var/tmp/travis-run.d/instance-id")
 	if err != nil {
 		logger.WithField("err", err).Error("couldn't read instance ID from /var/tmp/travis-run.d/instance-id")
 	} else {
-		labels["travis.instance_id"] = iid
+		labels["travis.instance_id"] = string(iid)
 	}
 
 	dockerConfig := &dockercontainer.Config{


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Docker containers are currently labeled with the repo and job ID. When viewing a list of all containers, it would be easier to associate a container with a specific instance if it were also labeled with its IP and instance ID.

## What approach did you choose and why?

This PR makes travis-worker add these two new labels to job containers.

## How can you test this?

Run on staging with `travisci/worker:v3.5.0-9-g4e46c72` as the docker worker image.

Before:

```
aj@bastion-shared-1:~$ ./all-jobs.sh 
travis-job-soulshake-autoscale-test-713036  4 minutes ago       soulshake/autoscale-tester
travis-job-soulshake-autoscale-test-713040  4 minutes ago       soulshake/autoscale-tester
travis-job-soulshake-autoscale-test-713041  4 minutes ago       soulshake/autoscale-tester
```

After:

```
aj@bastion-shared-1:~$ ./all-jobs.sh 
travis-job-soulshake-autoscale-test-713037  4 minutes ago       soulshake/autoscale-tester  10.10.2.53  i-07d7ae4bab00364d2
travis-job-soulshake-autoscale-test-713038  4 minutes ago       soulshake/autoscale-tester  10.10.2.53  i-07d7ae4bab00364d2
travis-job-soulshake-autoscale-test-713039  4 minutes ago       soulshake/autoscale-tester  10.10.2.53  i-07d7ae4bab00364d2
```