### PR TITLE
Rework Docker container labeling to allow for arbitrary input via config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- backend/docker: include arbitrary container labels from config
 
 ### Changed
 - backend/gce: add a `no-ip` tag when allocating instance without public IP


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The current labels assigned for ip address and instance ID depend on the existence of the "Travis run dir", which is a concept that doesn't appear elsewhere in the worker source code.

## What approach did you choose and why?

Assign container labels via a configurable map instead so that we can add this metadata explicitly into the worker config and aren't coupled to file paths that happen to be used in the hosted infrastructure.  This will mean that we can alter the labels without altering source code, and Enterprise customers can make use of the extra labels without adding files in specific locations.

## How can you test this?

Tests passing + probably some staging deployments.