### PR TITLE
Prep for v3.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 - backend/gce: add a `no-ip` tag when allocating instance without public IP
+- build: support and build using Go 1.9.4
 
 ## [3.5.0] - 2018-02-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
-- backend/docker: include arbitrary container labels from config
 
 ### Changed
-- backend/gce: add a `no-ip` tag when allocating instance without public IP
 
 ### Deprecated
 
@@ -17,6 +15,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
 
 ### Security
+
+## [3.6.0] - 2018-03-02
+
+### Added
+- backend/docker: include arbitrary container labels from config
+
+### Changed
+- backend/gce: add a `no-ip` tag when allocating instance without public IP
 
 ## [3.5.0] - 2018-02-12
 
@@ -648,8 +654,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/travis-ci/worker/compare/v3.5.0...HEAD
-[3.4.0]: https://github.com/travis-ci/worker/compare/v3.4.0...v3.5.0
+[Unreleased]: https://github.com/travis-ci/worker/compare/v3.6.0...HEAD
+[3.6.0]: https://github.com/travis-ci/worker/compare/v3.5.0...v3.6.0
+[3.5.0]: https://github.com/travis-ci/worker/compare/v3.4.0...v3.5.0
 [3.4.0]: https://github.com/travis-ci/worker/compare/v3.3.1...v3.4.0
 [3.3.1]: https://github.com/travis-ci/worker/compare/v3.3.0...v3.3.1
 [3.3.0]: https://github.com/travis-ci/worker/compare/v3.2.2...v3.3.0


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

[Delta size of "Unreleased"](https://github.com/travis-ci/worker/compare/v3.5.0...meat-v3.6.0-prep).

## What approach did you choose and why?

Bump to v3.6.0 given non-breaking additions since v3.5.0.

## How can you test this?

Staging deployments, and maybe production canary deployments:
- [x] docker (ec2)
- [x] gce
- [x] macstadium