### PR TITLE
Improve worker logs

### DIFF
--- a/amqp_job.go
+++ b/amqp_job.go
@@ -61,7 +61,12 @@ func (j *amqpJob) Error(ctx gocontext.Context, errMessage string) error {
 }
 
 func (j *amqpJob) Requeue(ctx gocontext.Context) error {
-	context.LoggerFromContext(ctx).WithField("self", "amqp_job").Info("requeueing job")
+	context.LoggerFromContext(ctx).WithFields(
+		logrus.Fields{
+			"self":       "amqp_job",
+			"job_id":     j.Payload().Job.ID,
+			"repository": j.Payload().Repository.Slug,
+		}).Info("requeueing job")
 
 	metrics.Mark("worker.job.requeue")
 
@@ -93,8 +98,10 @@ func (j *amqpJob) Started(ctx gocontext.Context) error {
 
 func (j *amqpJob) Finish(ctx gocontext.Context, state FinishState) error {
 	context.LoggerFromContext(ctx).WithFields(logrus.Fields{
-		"state": state,
-		"self":  "amqp_job",
+		"state":      state,
+		"self":       "amqp_job",
+		"job_id":     j.Payload().Job.ID,
+		"repository": j.Payload().Repository.Slug,
 	}).Info("finishing job")
 
 	j.finished = time.Now()

--- a/amqp_job_queue.go
+++ b/amqp_job_queue.go
@@ -180,8 +180,8 @@ func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 				case buildJobChan <- buildJob:
 					metrics.TimeSince("travis.worker.job_queue.amqp.blocking_time", jobSendBegin)
 					logger.WithFields(logrus.Fields{
-						"source": "amqp",
-						"dur":    time.Since(jobSendBegin),
+						"source":           "amqp",
+						"send_duration_ms": time.Since(jobSendBegin).Seconds() * 1e3,
 					}).Info("sent job to output channel")
 				case <-ctx.Done():
 					delivery.Nack(false, true)

--- a/cli.go
+++ b/cli.go
@@ -531,7 +531,7 @@ func (i *CLI) logProcessorInfo(msg string) {
 		"revision":        RevisionString,
 		"generated":       GeneratedString,
 		"boot_time":       i.bootTime.String(),
-		"uptime":          time.Since(i.bootTime),
+		"uptime_min":      time.Since(i.bootTime).Minutes(),
 		"pool_size":       i.ProcessorPool.Size(),
 		"total_processed": i.ProcessorPool.TotalProcessed(),
 	}).Info(msg)

--- a/http_job_queue.go
+++ b/http_job_queue.go
@@ -149,8 +149,8 @@ func (q *HTTPJobQueue) pollForJob(ctx gocontext.Context, buildJobChan chan Job) 
 	case buildJobChan <- buildJob:
 		metrics.TimeSince("travis.worker.job_queue.http.blocking_time", jobSendBegin)
 		logger.WithFields(logrus.Fields{
-			"source": "http",
-			"dur":    time.Since(jobSendBegin),
+			"source":           "http",
+			"send_duration_ms": time.Since(jobSendBegin).Seconds() * 1e3,
 		}).Info("sent job to output channel")
 		return pollInterval, true, readyChan
 	case <-ctx.Done():

--- a/multi_source_job_queue.go
+++ b/multi_source_job_queue.go
@@ -69,9 +69,9 @@ func (msjq *MultiSourceJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job
 
 					metrics.TimeSince("travis.worker.job_queue.multi.blocking_time", jobSendBegin)
 					logger.WithFields(logrus.Fields{
-						"job_id": jobID,
-						"source": queueName,
-						"dur":    time.Since(jobSendBegin),
+						"job_id":           jobID,
+						"source":           queueName,
+						"send_duration_ms": time.Since(jobSendBegin).Seconds() * 1e3,
 					}).Info("sent job to multi source output channel")
 				case <-ctx.Done():
 					return

--- a/processor.go
+++ b/processor.go
@@ -31,8 +31,9 @@ type Processor struct {
 	generator               BuildScriptGenerator
 	cancellationBroadcaster *CancellationBroadcaster
 
-	graceful  chan struct{}
-	terminate gocontext.CancelFunc
+	graceful    chan struct{}
+	terminate   gocontext.CancelFunc
+	shutdown_at time.Time
 
 	// ProcessedCount contains the number of jobs that has been processed
 	// by this Processor. This value should not be modified outside of the
@@ -117,7 +118,7 @@ func (p *Processor) Run() {
 			logger.Info("processor is done, terminating")
 			return
 		case <-p.graceful:
-			logger.Info("processor is done, terminating")
+			logger.WithField("shutdown_duration_s", time.Since(p.shutdown_at).Seconds()).Info("processor is done, terminating")
 			p.terminate()
 			return
 		default:
@@ -128,7 +129,7 @@ func (p *Processor) Run() {
 			logger.Info("processor is done, terminating")
 			return
 		case <-p.graceful:
-			logger.Info("processor is done, terminating")
+			logger.WithField("shutdown_duration_s", time.Since(p.shutdown_at).Seconds()).Info("processor is done, terminating")
 			p.terminate()
 			return
 		case buildJob, ok := <-p.buildJobsChan:
@@ -193,6 +194,7 @@ func (p *Processor) GracefulShutdown() {
 		}
 	}()
 	logger.Info("processor initiating graceful shutdown")
+	p.shutdown_at = time.Now()
 	tryClose(p.graceful)
 }
 

--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -61,10 +61,10 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	logger.WithFields(logrus.Fields{
-		"boot_time":   time.Since(startTime).Seconds() * 1e3,
-		"instance_id": instance.ID(),
-		"image_name":  instance.ImageName(),
-		"version":     VersionString,
+		"boot_duration_ms": time.Since(startTime).Seconds() * 1e3,
+		"instance_id":      instance.ID(),
+		"image_name":       instance.ImageName(),
+		"version":          VersionString,
 	}).Info("started instance")
 
 	state.Put("instance", instance)

--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -61,9 +61,11 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	logger.WithFields(logrus.Fields{
-		"boot_time":   time.Since(startTime),
+		"boot_time":   time.Since(startTime).Seconds() * 1e3,
 		"instance_id": instance.ID(),
 		"image_name":  instance.ImageName(),
+		"job_id":      buildJob.Payload().Job.ID,
+		"version":     VersionString,
 	}).Info("started instance")
 
 	state.Put("instance", instance)

--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -64,7 +64,6 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 		"boot_time":   time.Since(startTime).Seconds() * 1e3,
 		"instance_id": instance.ID(),
 		"image_name":  instance.ImageName(),
-		"job_id":      buildJob.Payload().Job.ID,
 		"version":     VersionString,
 	}).Info("started instance")
 


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
https://github.com/travis-ci/reliability/issues/6
Since we now have a [honeycomb dataset for worker](https://ui.honeycomb.io/travis-ci/datasets/worker), which is based on the logs, we should keep the information in the logs easily searchable and filterable. 

## What approach did you choose and why?
As described in the [issue](https://github.com/travis-ci/reliability/issues/6), this is meant to:
- report instance boot time in seconds (so it's easier to parse by honeycomb, which currently treats it as a string)
- adds the  job id and repository slug to some events that are logged using the processors context (like canceling and requeueing)
- tracks how long it takes for a processor to perform a graceful shutdown

## How can you test this?
- [x] deploy to staging and check the [worker-staging dataset](https://ui.honeycomb.io/travis-ci/datasets/worker-staging)
