### PR TITLE
Fill in tfw-ized app compat bits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,12 @@ RUN make deps
 ENV CGO_ENABLED 0
 RUN make build
 
-#################################
-### linux/amd64/travis-worker ###
-#################################
-
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates curl bash
 
 COPY --from=builder /go/bin/travis-worker /usr/local/bin/travis-worker
+COPY --from=builder /go/src/github.com/travis-ci/worker/systemd.service /app/systemd.service
+COPY --from=builder /go/src/github.com/travis-ci/worker/systemd-wrapper /app/systemd-wrapper
 COPY --from=builder /go/src/github.com/travis-ci/worker/.docker-entrypoint.sh /docker-entrypoint.sh
 
 VOLUME ["/var/tmp"]

--- a/systemd-wrapper
+++ b/systemd-wrapper
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -o errexit
+
+main() {
+  local name="${1:-travis-worker}"
+
+  docker stop "${name}" &>/dev/null || true
+  docker rm -f "${name}" &>/dev/null || true
+
+  local env_file
+  env_file="$(tfw writeenv travis-worker)"
+
+  set -o allexport
+  # shellcheck source=/dev/null
+  source "${env_file}"
+
+  if [[ "${TRAVIS_WORKER_PROVIDER_NAME}" == gce ]]; then
+    local gce_zone
+    gce_zone="$(__fetch_gce_zone)"
+    if [ -z "${gce_zone}" ]; then
+      gce_zone=us-central1-b
+    fi
+    echo "TRAVIS_WORKER_GCE_ZONE=${gce_zone}" >>"${env_file}"
+  fi
+
+  if [[ ! "${TRAVIS_WORKER_LIBRATO_SOURCE}" ]]; then
+    local librato_source
+    librato_source="$(__build_librato_source "$(hostname)" "${name}")"
+    echo "TRAVIS_WORKER_LIBRATO_SOURCE=${librato_source}" >>"${env_file}"
+  fi
+
+  if [ -f "${TRAVIS_WORKER_PRESTART_HOOK}" ]; then
+    "${TRAVIS_WORKER_PRESTART_HOOK}"
+  fi
+
+  exec docker run \
+    --rm \
+    --name "${name}" \
+    --hostname "$(hostname)" \
+    --userns host \
+    -v /var/tmp:/var/tmp \
+    -v /var/run:/var/run \
+    --env-file "${env_file}" \
+    "${TRAVIS_WORKER_SELF_IMAGE}" travis-worker
+}
+
+__fetch_gce_zone() {
+  curl -sSL \
+    "http://metadata.google.internal/computeMetadata/v1/instance/zone" \
+    -H "Metadata-Flavor: Google" |
+    awk -F/ '{ print $NF }'
+}
+
+__build_librato_source() {
+  local host_name="${1}"
+  local name="${2}"
+
+  if [[ "${name}" == "travis-worker" ]]; then
+    echo "${host_name}"
+    return
+  fi
+
+  echo "${host_name}-${name/travis-worker-/}"
+}
+
+main "$@"

--- a/systemd.service
+++ b/systemd.service
@@ -1,0 +1,13 @@
+# Service definition to be installed somewhere in the systemd load path
+[Unit]
+Description=Travis Worker
+
+[Service]
+ExecStart=___SYSTEMD_WRAPPER___
+ExecStopPost=/bin/sleep 5
+Restart=always
+WorkingDirectory=/
+User=travis
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The current docker image does not include files that are used by [`tfw extract`](https://github.com/travis-ci/tfw/blob/3722ebb1edee7dce3958f1fc83917329188cf364/tfw#L302-L356).

## What approach did you choose and why?

Create the necessary files or copy from elsewhere, and ensure they are copied into the final docker image at the expected path.

## How can you test this?

- [x] image builds
- [x] may be deployed via `tfw extract`