### PR TITLE
Add a convenience uninstaller script

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ instructions](https://packagecloud.io/travisci/worker/install).
 1. install [shellcheck](https://github.com/koalaman/shellcheck)
 1. `make`
 
+
+## Uninstalling
+
+In the case where Travis Worker has been installed via a deb package, there is a
+convenience script available which may be executed like so:
+
+``` bash
+curl -sSL https://raw.githubusercontent.com/travis-ci/worker/master/bin/travis-worker-uninstall |
+  sudo bash -
+```
+
 ## Configuring Travis Worker
 
 Travis Worker is configured with environment variables or command line flags via

--- a/bin/travis-worker-uninstall
+++ b/bin/travis-worker-uninstall
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -o errexit
+
+main() {
+  local prog
+  prog="$(basename "${0}")"
+
+  local halp='-h|--help|help'
+  if [[ "${*}" =~ $halp ]]; then
+    cat <<EOUSAGE
+Usage: ${prog} [-h|--help|help]
+
+Remove travis-worker and its APT source from the current system, which is
+intended to be a Debian/Ubuntu system, most likely Ubuntu 14.04 (Trusty).
+EOUSAGE
+    exit 0
+  fi
+
+  if [[ "$(id -u)" != 0 ]]; then
+    echo "${prog}:ERROR: this script is intended to be run as root" >&2
+    exit 1
+  fi
+
+  if ! apt-get --version &>/dev/null; then
+    echo "${prog}:ERROR: this script is intended for debian/ubuntu systems" >&2
+    exit 2
+  fi
+
+  export DEBIAN_FRONTEND=noninteractive
+
+  apt-get remove -yqq travis-worker || true
+  apt-get purge -yqq travis-worker || true
+
+  rm -vf \
+    /etc/apt/sources.list.d/travisci_worker.list \
+    /etc/default/travis-enterprise \
+    /etc/default/travis-worker \
+    /etc/init.d/travis-worker \
+    /etc/init/travis-worker.conf \
+    /usr/local/bin/travis-worker \
+    /usr/share/doc/travis-worker/changelog.gz
+
+  apt-get update -yqq || true
+}
+
+main "${@}"


### PR DESCRIPTION
for use with Trusty systems that previously installed travis-worker via deb.