### PR TITLE
backend/gce: disable automatic restart

### DIFF
--- a/backend/gce.go
+++ b/backend/gce.go
@@ -932,7 +932,8 @@ func (p *gceProvider) buildInstance(ctx gocontext.Context, startAttributes *Star
 			},
 		},
 		Scheduling: &compute.Scheduling{
-			Preemptible: p.ic.Preemptible,
+			Preemptible:      p.ic.Preemptible,
+			AutomaticRestart: googleapi.Bool(false),
 		},
 		MachineType: machineType.SelfLink,
 		Name:        hostname,


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Prevent a VM from being restarted and accumulating cost if Compute Engine wants to restart it (this is for Compute Engine-initiated restarts, not user-initiated ones). This also prevents any startup script code from being run, I can't quite remember what all is in there.

See [the Compute Engine docs](https://cloud.google.com/compute/docs/reference/rest/v1/instances/insert#body.request_body.FIELDS.inlinedField_66) for more info about this flag (link may get out of date in the future, search for `resource.scheduling.automaticRestart` on that page if it doesn't go there automatically).

## What approach did you choose and why?

I set the supported API flag, since this is a built-in feature in Compute Engine it seems good to use that.

## How can you test this?

Unsure if there's a good way to test this, or if it's needed. It's a very small change adding a documented flag to the API request, the main risk I can think of is if I typoed something, and the compiler will take care of that.

The main issue I can think of is if this causes leaked VMs to be powered off instead of powered on, but if I recall correctly, gcloud-cleaner (…if that's what that was called? gcloud-janitor?) handles powered off VMs now, so that shouldn't be an issue?

## What feedback would you like, if any?