### PR TITLE
make send-docker-hub-trigger friendly to third-party pull requests

### DIFF
--- a/script/send-docker-hub-trigger
+++ b/script/send-docker-hub-trigger
@@ -2,7 +2,7 @@
 
 # This script will trigger a multi-stage Docker build at the Docker hub repo referenced by $DOCKER_HUB_TRIGGER_URL.
 
-if [[ "$TRAVIS_PULL_REQUEST" != 'false' ]]; then
+if [[ -n "$TRAVIS_PULL_REQUEST" && "$TRAVIS_PULL_REQUEST" != 'false' ]]; then
   echo "This is a pull request (${TRAVIS_PULL_REQUEST}); not triggering Docker hub build"
   exit 0
 fi

--- a/script/send-docker-hub-trigger
+++ b/script/send-docker-hub-trigger
@@ -2,15 +2,16 @@
 
 # This script will trigger a multi-stage Docker build at the Docker hub repo referenced by $DOCKER_HUB_TRIGGER_URL.
 
+if [[ "$TRAVIS_PULL_REQUEST" != 'false' ]]; then
+  echo "This is a pull request (${TRAVIS_PULL_REQUEST}); not triggering Docker hub build"
+  exit 0
+fi
+
 [ -z "$TRAVIS_PULL_REQUEST" ] && echo "No TRAVIS_PULL_REQUEST env var found. Aborting." && exit 1
 [ -z "$DOCKER_HUB_TRIGGER_URL" ] && echo "No DOCKER_HUB_TRIGGER_URL env var found. Aborting." && exit 1
 [ -z "$TRAVIS_BRANCH" ] && echo "No TRAVIS_BRANCH env var found. Aborting." && exit 1
 
-if [[ "$TRAVIS_PULL_REQUEST" == 'false' ]]; then
-  echo "Triggering Docker Hub build on branch ${TRAVIS_BRANCH}"
-  curl -H "Content-Type: application/json" \
-    --data '{"source_type":"Branch","source_name":"'${TRAVIS_BRANCH}'"}' \
-    -X POST "$DOCKER_HUB_TRIGGER_URL"
-else
-  echo "This is a pull request (${TRAVIS_PULL_REQUEST}); not triggering Docker hub build"
-fi
+echo "Triggering Docker Hub build on branch ${TRAVIS_BRANCH}"
+curl -H "Content-Type: application/json" \
+  --data '{"source_type":"Branch","source_name":"'${TRAVIS_BRANCH}'"}' \
+  -X POST "$DOCKER_HUB_TRIGGER_URL"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

When someone who does not have push access to the repo submits a pull request, the secret env vars are not set (specifically `DOCKER_HUB_TRIGGER_URL`). Thus this script exits with an exit code `1`, failing the build. We saw this in travis-ci/worker#452.

## What approach did you choose and why?

Since the trigger does not even run for pull requests, that check can be moved further up, before the check for the existence of the secret env var.

## How can you test this?

## What feedback would you like, if any?
