### PR TITLE
Fix worker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ jobs:
     - chmod +x ~/bin/shfmt
     - shfmt -version
     script:
-    - make lintall
     - go get github.com/FiloSottile/gvt
     - travis_retry make deps
+    - make lintall
     - make test
     - make crossbuild
     - make smoke

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ CROSSBUILD_BINARIES := \
 
 %-coverage.coverprofile:
 	$(GO) test -covermode=count -coverprofile=$@ \
-		-tags netgo -x -ldflags "$(GOBUILD_LDFLAGS)" \
+		-tags netgo -ldflags "$(GOBUILD_LDFLAGS)" \
 		$(PACKAGE)/$(subst -,/,$(subst root,,$(subst -coverage.coverprofile,,$@)))
 
 .PHONY: %

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ CROSSBUILD_BINARIES := \
 	build/linux/amd64/travis-worker
 
 %-coverage.coverprofile:
-	$(GO) test -v -covermode=count -coverprofile=$@ \
+	$(GO) test -covermode=count -coverprofile=$@ \
 		-tags netgo -x -ldflags "$(GOBUILD_LDFLAGS)" \
 		$(PACKAGE)/$(subst -,/,$(subst root,,$(subst -coverage.coverprofile,,$@)))
 
@@ -56,7 +56,7 @@ test: deps lintall build fmtpolice test-no-cover coverage.html
 
 .PHONY: test-no-cover
 test-no-cover:
-	$(GO) test -v -race -tags netgo -x -ldflags "$(GOBUILD_LDFLAGS)" $(ALL_PACKAGES)
+	$(GO) test -race -tags netgo -ldflags "$(GOBUILD_LDFLAGS)" $(ALL_PACKAGES)
 
 coverage.html: coverage.coverprofile
 	$(GO) tool cover -html=$^ -o $@
@@ -67,7 +67,7 @@ coverage.coverprofile: $(COVERPROFILES)
 
 .PHONY: build
 build: deps
-	$(GO) install -tags netgo -x -ldflags "$(GOBUILD_LDFLAGS)" $(ALL_PACKAGES)
+	$(GO) install -tags netgo -ldflags "$(GOBUILD_LDFLAGS)" $(ALL_PACKAGES)
 
 .PHONY: crossbuild
 crossbuild: deps $(CROSSBUILD_BINARIES)

--- a/backend/docker_test.go
+++ b/backend/docker_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"io"
 	"archive/tar"
 	"bytes"
 	gocontext "context"
@@ -428,7 +429,7 @@ func TestDockerInstance_UploadScript_WithNative(t *testing.T) {
 
 				buf := make([]byte, hdr.Size)
 				_, err = tr.Read(buf)
-				assert.Nil(t, err)
+				assert.Equal(t, err, io.EOF)
 				assert.Equal(t, buf, script)
 
 				scriptUploaded = true

--- a/backend/docker_test.go
+++ b/backend/docker_test.go
@@ -1,12 +1,12 @@
 package backend
 
 import (
-	"io"
 	"archive/tar"
 	"bytes"
 	gocontext "context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
The travis build was failing for worker.

## What approach did you choose and why?
 * Run the linter after the dependencies were fetched, since it was complaining about them missing
 * Check for `EOF` instead of `nil` for archive/tar errors (as suggested by the [doc](https://golang.org/pkg/archive/tar/#Reader.Read))
 * Make the build and test output less verbose, since it was very hard to figure out what's going on when the log was 7500 lines.

