### PR TITLE
Add the concept of a separate LogsQueue 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ jobs:
     - chmod +x ~/bin/shfmt
     - shfmt -version
     script:
-    - make lintall
     - go get github.com/FiloSottile/gvt
     - travis_retry make deps
+    - make lintall
     - make test
     - make crossbuild
     - make smoke

--- a/cli.go
+++ b/cli.go
@@ -211,8 +211,8 @@ func (i *CLI) Run() {
 	go i.signalHandler()
 
 	i.logger.WithFields(logrus.Fields{
-		"pool_size": i.Config.PoolSize,
-		"queue":     i.JobQueue,
+		"pool_size":  i.Config.PoolSize,
+		"queue":      i.JobQueue,
 		"logs_queue": i.LogsQueue,
 	}).Debug("running pool")
 

--- a/cli.go
+++ b/cli.go
@@ -213,7 +213,7 @@ func (i *CLI) Run() {
 	i.logger.WithFields(logrus.Fields{
 		"pool_size": i.Config.PoolSize,
 		"queue":     i.JobQueue,
-		"log_queue": i.LogsQueue,
+		"logs_queue": i.LogsQueue,
 	}).Debug("running pool")
 
 	i.ProcessorPool.Run(i.Config.PoolSize, i.JobQueue)

--- a/cli.go
+++ b/cli.go
@@ -184,6 +184,12 @@ func (i *CLI) Setup() (bool, error) {
 		return false, err
 	}
 
+	err = i.setupLogsQueue()
+	if err != nil {
+		logger.WithField("err", err).Error("couldn't create logs queue")
+		return false, err
+	}
+
 	return true, nil
 }
 
@@ -686,19 +692,19 @@ func (i *CLI) buildFileJobQueue() (*FileJobQueue, error) {
 	return jobQueue, nil
 }
 
-func (i *CLI) setupLogQueue() error {
+func (i *CLI) setupLogsQueue() error {
 	if i.Config.LogsAmqpURI == "" {
 		// No separate AMQP logs cluster is set. Use the JobsQueue to send log parts
 		return nil
 	}
-	err := i.buildAMQPLogQueue()
+	err := i.buildAMQPLogsQueue()
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func (i *CLI) buildAMQPLogQueue() error {
+func (i *CLI) buildAMQPLogsQueue() error {
 	var amqpConn *amqp.Connection
 	var err error
 

--- a/cli.go
+++ b/cli.go
@@ -694,14 +694,11 @@ func (i *CLI) buildFileJobQueue() (*FileJobQueue, error) {
 
 func (i *CLI) setupLogsQueue() error {
 	if i.Config.LogsAmqpURI == "" {
-		// No separate AMQP logs cluster is set. Use the JobsQueue to send log parts
+		// If no separate URI is set for LogsAMQP, use the JobsQueue to send log parts
 		return nil
 	}
 	err := i.buildAMQPLogsQueue()
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func (i *CLI) buildAMQPLogsQueue() error {

--- a/cli.go
+++ b/cli.go
@@ -56,6 +56,7 @@ type CLI struct {
 	ProcessorPool           *ProcessorPool
 	CancellationBroadcaster *CancellationBroadcaster
 	JobQueue                JobQueue
+	LogsQueue				LogsQueue
 
 	heartbeatErrSleep time.Duration
 	heartbeatSleep    time.Duration
@@ -206,6 +207,7 @@ func (i *CLI) Run() {
 	i.logger.WithFields(logrus.Fields{
 		"pool_size": i.Config.PoolSize,
 		"queue":     i.JobQueue,
+		"log_queue": i.LogsQueue,
 	}).Debug("running pool")
 
 	i.ProcessorPool.Run(i.Config.PoolSize, i.JobQueue)
@@ -213,6 +215,13 @@ func (i *CLI) Run() {
 	err := i.JobQueue.Cleanup()
 	if err != nil {
 		i.logger.WithField("err", err).Error("couldn't clean up job queue")
+	}
+
+	if i.LogsQueue != nil {
+		err := i.LogsQueue.Cleanup()
+		if err != nil {
+			i.logger.WithField("err", err).Error("couldn't clean up logs queue")
+		}
 	}
 }
 

--- a/cli.go
+++ b/cli.go
@@ -56,7 +56,7 @@ type CLI struct {
 	ProcessorPool           *ProcessorPool
 	CancellationBroadcaster *CancellationBroadcaster
 	JobQueue                JobQueue
-	LogsQueue				LogsQueue
+	LogsQueue               LogsQueue
 
 	heartbeatErrSleep time.Duration
 	heartbeatSleep    time.Duration

--- a/config/config.go
+++ b/config/config.go
@@ -54,14 +54,23 @@ var (
 			Value: defaultAmqpURI,
 			Usage: `The URI to the AMQP server to connect to (only valid for "amqp" queue type)`,
 		}),
+		NewConfigDef("LogsAmqpURI", &cli.StringFlag{
+			Usage: `The URI to the Logs AMQP server to connect to (only valid for "amqp" queue type)`,
+		}),
 		NewConfigDef("AmqpInsecure", &cli.BoolFlag{
 			Usage: `Whether to connect to the AMQP server without verifying TLS certificates (only valid for "amqp" queue type)`,
 		}),
 		NewConfigDef("AmqpTlsCert", &cli.StringFlag{
-			Usage: `The TLS certificate used to connet to the AMQP server`,
+			Usage: `The TLS certificate used to connet to the jobs AMQP server`,
 		}),
 		NewConfigDef("AmqpTlsCertPath", &cli.StringFlag{
-			Usage: `Path to the TLS certificate used to connet to the AMQP server`,
+			Usage: `Path to the TLS certificate used to connet to the jobs AMQP server`,
+		}),
+		NewConfigDef("LogsAmqpTlsCert", &cli.StringFlag{
+			Usage: `The TLS certificate used to connet to the logs AMQP server`,
+		}),
+		NewConfigDef("LogsAmqpTlsCertPath", &cli.StringFlag{
+			Usage: `Path to the TLS certificate used to connet to the logs AMQP server`,
 		}),
 		NewConfigDef("BaseDir", &cli.StringFlag{
 			Value: defaultBaseDir,
@@ -157,6 +166,10 @@ var (
 		}),
 		NewConfigDef("StateUpdatePoolSize", &cli.IntFlag{
 			Usage: "The pool size for state update workers",
+			Value: 3,
+		}),
+		NewConfigDef("LogPoolSize", &cli.IntFlag{
+			Usage: "The pool size for log workers",
 			Value: 3,
 		}),
 
@@ -309,29 +322,33 @@ func NewConfigDef(fieldName string, flag cli.Flag) *ConfigDef {
 
 // Config contains all the configuration needed to run the worker.
 type Config struct {
-	ProviderName    string `config:"provider-name"`
-	QueueType       string `config:"queue-type"`
-	AmqpURI         string `config:"amqp-uri"`
-	AmqpInsecure    bool   `config:"amqp-insecure"`
-	AmqpTlsCert     string `config:"amqp-tls-cert"`
-	AmqpTlsCertPath string `config:"amqp-tls-cert-path"`
-	BaseDir         string `config:"base-dir"`
-	PoolSize        int    `config:"pool-size"`
-	BuildAPIURI     string `config:"build-api-uri"`
-	QueueName       string `config:"queue-name"`
-	LibratoEmail    string `config:"librato-email"`
-	LibratoToken    string `config:"librato-token"`
-	LibratoSource   string `config:"librato-source"`
-	SentryDSN       string `config:"sentry-dsn"`
-	Hostname        string `config:"hostname"`
-	DefaultLanguage string `config:"default-language"`
-	DefaultDist     string `config:"default-dist"`
-	DefaultGroup    string `config:"default-group"`
-	DefaultOS       string `config:"default-os"`
-	JobBoardURL     string `config:"job-board-url"`
-	TravisSite      string `config:"travis-site"`
+	ProviderName        string `config:"provider-name"`
+	QueueType           string `config:"queue-type"`
+	AmqpURI             string `config:"amqp-uri"`
+	AmqpInsecure        bool   `config:"amqp-insecure"`
+	AmqpTlsCert         string `config:"amqp-tls-cert"`
+	AmqpTlsCertPath     string `config:"amqp-tls-cert-path"`
+	BaseDir             string `config:"base-dir"`
+	PoolSize            int    `config:"pool-size"`
+	BuildAPIURI         string `config:"build-api-uri"`
+	QueueName           string `config:"queue-name"`
+	LibratoEmail        string `config:"librato-email"`
+	LibratoToken        string `config:"librato-token"`
+	LibratoSource       string `config:"librato-source"`
+	LogsAmqpURI         string `config:"logs-amqp-uri"`
+	LogsAmqpTlsCert     string `config:"amqp-tls-cert"`
+	LogsAmqpTlsCertPath string `config:"amqp-tls-cert-path"`
+	SentryDSN           string `config:"sentry-dsn"`
+	Hostname            string `config:"hostname"`
+	DefaultLanguage     string `config:"default-language"`
+	DefaultDist         string `config:"default-dist"`
+	DefaultGroup        string `config:"default-group"`
+	DefaultOS           string `config:"default-os"`
+	JobBoardURL         string `config:"job-board-url"`
+	TravisSite          string `config:"travis-site"`
 
 	StateUpdatePoolSize int `config:"state-update-pool-size"`
+	LogPoolSize         int `config:"log-pool-size"`
 
 	FilePollingInterval      time.Duration `config:"file-polling-interval"`
 	HTTPPollingInterval      time.Duration `config:"http-polling-interval"`

--- a/config/config.go
+++ b/config/config.go
@@ -336,8 +336,8 @@ type Config struct {
 	LibratoToken        string `config:"librato-token"`
 	LibratoSource       string `config:"librato-source"`
 	LogsAmqpURI         string `config:"logs-amqp-uri"`
-	LogsAmqpTlsCert     string `config:"amqp-tls-cert"`
-	LogsAmqpTlsCertPath string `config:"amqp-tls-cert-path"`
+	LogsAmqpTlsCert     string `config:"logs-amqp-tls-cert"`
+	LogsAmqpTlsCertPath string `config:"logs-amqp-tls-cert-path"`
 	SentryDSN           string `config:"sentry-dsn"`
 	Hostname            string `config:"hostname"`
 	DefaultLanguage     string `config:"default-language"`

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -71,6 +71,7 @@ func TestFromCLIContext_SetsStringFlags(t *testing.T) {
 		"--librato-email=email",
 		"--librato-source=source",
 		"--librato-token=token",
+		"--logs-amqp-uri=amqp://logs",
 		"--provider-name=provider",
 		"--queue-name=name",
 		"--queue-type=type",
@@ -97,6 +98,7 @@ func TestFromCLIContext_SetsStringFlags(t *testing.T) {
 		assert.Equal(t, "email", cfg.LibratoEmail, "LibratoEmail")
 		assert.Equal(t, "source", cfg.LibratoSource, "LibratoSource")
 		assert.Equal(t, "token", cfg.LibratoToken, "LibratoToken")
+		assert.Equal(t, "amqp://logs", cfg.LogsAmqpURI, "LogsAmqpURI")
 		assert.Equal(t, "provider", cfg.ProviderName, "ProviderName")
 		assert.Equal(t, "name", cfg.QueueName, "QueueName")
 		assert.Equal(t, "type", cfg.QueueType, "QueueType")

--- a/logs_queue.go
+++ b/logs_queue.go
@@ -1,0 +1,10 @@
+package worker
+
+import (
+	gocontext "context"
+)
+
+type LogsQueue interface {
+	LogWriter(gocontext.Context) (LogWriter, error)
+	Cleanup() error
+}


### PR DESCRIPTION
Reference issue: https://github.com/travis-ci/reliability/issues/90
This is the first step in separating the logs behaviour in general and allowing worker to use a separate RabbitMQ cluster for build log processing. 
For now, the worker just connects to a new AMQP server if given the option. 

I intentionally chose to create a new interface instead of reusing the LogWriter one in order to keep the current behaviour and transition the responsibility gradually. 
For now, this only applies to AMQP queues (and not the HTTP or file types), but in the future it should be easy to switch between queue types separately for jobs and logs.