### PR TITLE
Make heartbeat configurable for AMQP connections

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -627,7 +627,11 @@ func (i *CLI) buildAMQPJobQueueAndCanceller() (*AMQPJobQueue, *AMQPCanceller, er
 			&tls.Config{InsecureSkipVerify: true},
 		)
 	} else {
-		amqpConn, err = amqp.Dial(i.Config.AmqpURI)
+		amqpConfig := amqp.Config{
+			Heartbeat: 0 * time.Second,
+			Locale:    "en_US",
+		}
+		amqpConn, err = amqp.DialConfig(i.Config.AmqpURI, amqpConfig)
 	}
 	if err != nil {
 		i.logger.WithField("err", err).Error("couldn't connect to AMQP")

--- a/cli.go
+++ b/cli.go
@@ -620,18 +620,26 @@ func (i *CLI) buildAMQPJobQueueAndCanceller() (*AMQPJobQueue, *AMQPCanceller, er
 			}
 			cfg.RootCAs.AppendCertsFromPEM(cert)
 		}
-		amqpConn, err = amqp.DialTLS(i.Config.AmqpURI, cfg)
+		amqpConn, err = amqp.DialConfig(i.Config.AmqpURI,
+			amqp.Config{
+				Heartbeat:       i.Config.AmqpHeartbeat,
+				Locale:          "en_US",
+				TLSClientConfig: cfg,
+			})
 	} else if i.Config.AmqpInsecure {
-		amqpConn, err = amqp.DialTLS(
+		amqpConn, err = amqp.DialConfig(
 			i.Config.AmqpURI,
-			&tls.Config{InsecureSkipVerify: true},
-		)
+			amqp.Config{
+				Heartbeat:       i.Config.AmqpHeartbeat,
+				Locale:          "en_US",
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			})
 	} else {
-		amqpConfig := amqp.Config{
-			Heartbeat: 0 * time.Second,
-			Locale:    "en_US",
-		}
-		amqpConn, err = amqp.DialConfig(i.Config.AmqpURI, amqpConfig)
+		amqpConn, err = amqp.DialConfig(i.Config.AmqpURI,
+			amqp.Config{
+				Heartbeat: i.Config.AmqpHeartbeat,
+				Locale:    "en_US",
+			})
 	}
 	if err != nil {
 		i.logger.WithField("err", err).Error("couldn't connect to AMQP")
@@ -722,14 +730,26 @@ func (i *CLI) buildAMQPLogsQueue() error {
 			}
 			cfg.RootCAs.AppendCertsFromPEM(cert)
 		}
-		amqpConn, err = amqp.DialTLS(i.Config.LogsAmqpURI, cfg)
+		amqpConn, err = amqp.DialConfig(i.Config.AmqpURI,
+			amqp.Config{
+				Heartbeat:       i.Config.AmqpHeartbeat,
+				Locale:          "en_US",
+				TLSClientConfig: cfg,
+			})
 	} else if i.Config.AmqpInsecure {
-		amqpConn, err = amqp.DialTLS(
-			i.Config.LogsAmqpURI,
-			&tls.Config{InsecureSkipVerify: true},
-		)
+		amqpConn, err = amqp.DialConfig(
+			i.Config.AmqpURI,
+			amqp.Config{
+				Heartbeat:       i.Config.AmqpHeartbeat,
+				Locale:          "en_US",
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			})
 	} else {
-		amqpConn, err = amqp.Dial(i.Config.LogsAmqpURI)
+		amqpConn, err = amqp.DialConfig(i.Config.AmqpURI,
+			amqp.Config{
+				Heartbeat: i.Config.AmqpHeartbeat,
+				Locale:    "en_US",
+			})
 	}
 	if err != nil {
 		i.logger.WithField("err", err).Error("couldn't connect to the logs AMQP server")

--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,10 @@ var (
 			Value: defaultQueueType,
 			Usage: `The name of the queue type to use ("amqp", "http", or "file")`,
 		}),
+		NewConfigDef("AmqpHeartbeat", &cli.DurationFlag{
+			Value: 10 * time.Second,
+			Usage: "The heartbeat timeout value defines after what time the peer TCP connection should be considered unreachable",
+		}),
 		NewConfigDef("AmqpURI", &cli.StringFlag{
 			Value: defaultAmqpURI,
 			Usage: `The URI to the AMQP server to connect to (only valid for "amqp" queue type)`,
@@ -322,30 +326,31 @@ func NewConfigDef(fieldName string, flag cli.Flag) *ConfigDef {
 
 // Config contains all the configuration needed to run the worker.
 type Config struct {
-	ProviderName        string `config:"provider-name"`
-	QueueType           string `config:"queue-type"`
-	AmqpURI             string `config:"amqp-uri"`
-	AmqpInsecure        bool   `config:"amqp-insecure"`
-	AmqpTlsCert         string `config:"amqp-tls-cert"`
-	AmqpTlsCertPath     string `config:"amqp-tls-cert-path"`
-	BaseDir             string `config:"base-dir"`
-	PoolSize            int    `config:"pool-size"`
-	BuildAPIURI         string `config:"build-api-uri"`
-	QueueName           string `config:"queue-name"`
-	LibratoEmail        string `config:"librato-email"`
-	LibratoToken        string `config:"librato-token"`
-	LibratoSource       string `config:"librato-source"`
-	LogsAmqpURI         string `config:"logs-amqp-uri"`
-	LogsAmqpTlsCert     string `config:"logs-amqp-tls-cert"`
-	LogsAmqpTlsCertPath string `config:"logs-amqp-tls-cert-path"`
-	SentryDSN           string `config:"sentry-dsn"`
-	Hostname            string `config:"hostname"`
-	DefaultLanguage     string `config:"default-language"`
-	DefaultDist         string `config:"default-dist"`
-	DefaultGroup        string `config:"default-group"`
-	DefaultOS           string `config:"default-os"`
-	JobBoardURL         string `config:"job-board-url"`
-	TravisSite          string `config:"travis-site"`
+	ProviderName        string        `config:"provider-name"`
+	QueueType           string        `config:"queue-type"`
+	AmqpURI             string        `config:"amqp-uri"`
+	AmqpInsecure        bool          `config:"amqp-insecure"`
+	AmqpTlsCert         string        `config:"amqp-tls-cert"`
+	AmqpTlsCertPath     string        `config:"amqp-tls-cert-path"`
+	AmqpHeartbeat       time.Duration `config:"amqp-heartbeat"`
+	BaseDir             string        `config:"base-dir"`
+	PoolSize            int           `config:"pool-size"`
+	BuildAPIURI         string        `config:"build-api-uri"`
+	QueueName           string        `config:"queue-name"`
+	LibratoEmail        string        `config:"librato-email"`
+	LibratoToken        string        `config:"librato-token"`
+	LibratoSource       string        `config:"librato-source"`
+	LogsAmqpURI         string        `config:"logs-amqp-uri"`
+	LogsAmqpTlsCert     string        `config:"logs-amqp-tls-cert"`
+	LogsAmqpTlsCertPath string        `config:"logs-amqp-tls-cert-path"`
+	SentryDSN           string        `config:"sentry-dsn"`
+	Hostname            string        `config:"hostname"`
+	DefaultLanguage     string        `config:"default-language"`
+	DefaultDist         string        `config:"default-dist"`
+	DefaultGroup        string        `config:"default-group"`
+	DefaultOS           string        `config:"default-os"`
+	JobBoardURL         string        `config:"job-board-url"`
+	TravisSite          string        `config:"travis-site"`
 
 	StateUpdatePoolSize int `config:"state-update-pool-size"`
 	LogPoolSize         int `config:"log-pool-size"`


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
https://github.com/travis-ci/reliability/issues/114

## What approach did you choose and why?
Set hearbeats to 0 in order to disable them (just for the insecure connections, for testing purposes - if this works, will add the same for the amqp tls connection as well).

## How can you test this?
Check for normal behaviour on staging.
Deploy to a few instances and see if errors like `[ERROR] closing AMQP connection <0.22954.214> (35.188.132.197:38448 -> 10.50.94.192:5671): missed heartbeats from client, timeout: 10s
` stops appearing in the cloud amqp logs

## What feedback would you like, if any?
