### PR TITLE
Enable the use of the RabbitMQ sharding plugin for travis-logs

### DIFF
--- a/amqp_job.go
+++ b/amqp_job.go
@@ -28,6 +28,7 @@ type amqpJob struct {
 	started         time.Time
 	finished        time.Time
 	stateCount      uint
+	withLogSharding bool
 }
 
 func (j *amqpJob) GoString() string {
@@ -131,7 +132,7 @@ func (j *amqpJob) LogWriter(ctx gocontext.Context, defaultLogTimeout time.Durati
 		logTimeout = defaultLogTimeout
 	}
 
-	return newAMQPLogWriter(ctx, j.logWriterChan, j.payload.Job.ID, logTimeout)
+	return newAMQPLogWriter(ctx, j.logWriterChan, j.payload.Job.ID, logTimeout, j.withLogSharding)
 }
 
 func (j *amqpJob) createStateUpdateBody(ctx gocontext.Context, state string) map[string]interface{} {

--- a/amqp_job_queue.go
+++ b/amqp_job_queue.go
@@ -18,8 +18,9 @@ import (
 
 // AMQPJobQueue is a JobQueue that uses AMQP
 type AMQPJobQueue struct {
-	conn  *amqp.Connection
-	queue string
+	conn            *amqp.Connection
+	queue           string
+	withLogSharding bool
 
 	stateUpdatePool *tunny.Pool
 
@@ -79,8 +80,9 @@ func NewAMQPJobQueue(conn *amqp.Connection, queue string, stateUpdatePoolSize in
 	go reportPoolMetrics("state_update_pool", stateUpdatePool)
 
 	return &AMQPJobQueue{
-		conn:  conn,
-		queue: queue,
+		conn:            conn,
+		queue:           queue,
+		withLogSharding: sharded,
 
 		stateUpdatePool: stateUpdatePool,
 	}, nil
@@ -163,6 +165,7 @@ func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 					payload:         &JobPayload{},
 					startAttributes: &backend.StartAttributes{},
 					stateUpdatePool: q.stateUpdatePool,
+					withLogSharding: q.withLogSharding,
 				}
 				startAttrs := &jobPayloadStartAttrs{Config: &backend.StartAttributes{}}
 

--- a/amqp_job_queue.go
+++ b/amqp_job_queue.go
@@ -55,7 +55,7 @@ func NewAMQPJobQueue(conn *amqp.Connection, queue string, stateUpdatePoolSize in
 
 	if sharded {
 		// This exchange should be declared as sharded using a policy that matches its name.
-		err = channel.ExchangeDeclare("reporting.jobs.logs_sharded", "direct", true, false, false, false, nil)
+		err = channel.ExchangeDeclare("reporting.jobs.logs_sharded", "x-modulus-hash", true, false, false, false, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/amqp_log_writer.go
+++ b/amqp_log_writer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -228,12 +229,15 @@ func (w *amqpLogWriter) publishLogPart(part amqpLogPart) error {
 
 	w.amqpChanMutex.RLock()
 	var exchange string
+	var routingKey string
 	if w.sharded {
 		exchange = "reporting.jobs.logs_sharded"
+		routingKey = strconv.FormatUint(w.jobID, 10)
 	} else {
 		exchange = "reporting"
+		routingKey = "reporting.jobs.logs"
 	}
-	err = w.amqpChan.Publish(exchange, "reporting.jobs.logs", false, false, amqp.Publishing{
+	err = w.amqpChan.Publish(exchange, routingKey, false, false, amqp.Publishing{
 		ContentType:  "application/json",
 		DeliveryMode: amqp.Persistent,
 		Timestamp:    time.Now(),

--- a/amqp_log_writer_test.go
+++ b/amqp_log_writer_test.go
@@ -19,7 +19,7 @@ func TestAMQPLogWriterWrite(t *testing.T) {
 	uuid := uuid.NewRandom()
 	ctx := workerctx.FromUUID(context.TODO(), uuid.String())
 
-	logWriter, err := newAMQPLogWriter(ctx, amqpChan, 4, time.Hour)
+	logWriter, err := newAMQPLogWriter(ctx, amqpChan, 4, time.Hour, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,7 +76,7 @@ func TestAMQPLogWriterClose(t *testing.T) {
 	uuid := uuid.NewRandom()
 	ctx := workerctx.FromUUID(context.TODO(), uuid.String())
 
-	logWriter, err := newAMQPLogWriter(ctx, amqpChan, 4, time.Hour)
+	logWriter, err := newAMQPLogWriter(ctx, amqpChan, 4, time.Hour, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +124,7 @@ func TestAMQPMaxLogLength(t *testing.T) {
 	uuid := uuid.NewRandom()
 	ctx := workerctx.FromUUID(context.TODO(), uuid.String())
 
-	logWriter, err := newAMQPLogWriter(ctx, amqpChan, 4, time.Hour)
+	logWriter, err := newAMQPLogWriter(ctx, amqpChan, 4, time.Hour, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli.go
+++ b/cli.go
@@ -653,7 +653,7 @@ func (i *CLI) buildAMQPJobQueueAndCanceller() (*AMQPJobQueue, *AMQPCanceller, er
 	canceller := NewAMQPCanceller(i.ctx, amqpConn, i.CancellationBroadcaster)
 	i.logger.WithField("canceller", fmt.Sprintf("%#v", canceller)).Debug("built")
 
-	jobQueue, err := NewAMQPJobQueue(amqpConn, i.Config.QueueName, i.Config.StateUpdatePoolSize)
+	jobQueue, err := NewAMQPJobQueue(amqpConn, i.Config.QueueName, i.Config.StateUpdatePoolSize, i.Config.RabbitMQSharding)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -176,6 +176,9 @@ var (
 			Usage: "The pool size for log workers",
 			Value: 3,
 		}),
+		NewConfigDef("RabbitMQSharding", &cli.BoolFlag{
+			Usage: "Enable sharding for the logs AMQP queue",
+		}),
 
 		// build script generator flags
 		NewConfigDef("BuildCacheFetchTimeout", &cli.DurationFlag{
@@ -351,6 +354,7 @@ type Config struct {
 	DefaultOS           string        `config:"default-os"`
 	JobBoardURL         string        `config:"job-board-url"`
 	TravisSite          string        `config:"travis-site"`
+	RabbitMQSharding    bool          `config:"rabbitmq-sharding"`
 
 	StateUpdatePoolSize int `config:"state-update-pool-size"`
 	LogPoolSize         int `config:"log-pool-size"`


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
https://github.com/travis-ci/reliability/issues/125

## What approach did you choose and why?
I tried to follow the instructions from the [README of the plugin](https://github.com/rabbitmq/rabbitmq-sharding).
I've declared a new exchange (`reporting.jobs.logs_sharded`, to match what the [changes in the logs app](https://github.com/travis-ci/travis-logs/pull/181) expected and made sure the `LogWriter` routes to the correct exchange based on whether the new config option `TRAVIS_WORKER_RABBITMQ_SHARDING` is set or not.
In terms of manual changes, I had to enable the RabbitMQ sharding plugin in the CloudAMQP Plugins tab and create a new policy (`logs-sharding`) for the sharded exchage, as specified in the README that's linked above.

(Naming could probably be improved, since I was mostly interested in getting this in a state where I could test it before leaving for the weekend 😅)

## How can you test this?
This was successfully tested on org-staging. The CloudAMQP addon has been configured as described above (with the plugin enabled and exchange policy created) and all org workers are currently running in sharded mode (the changes were made locally on the instances and not through a `terraform apply`)
I've also tested with just half of the workers running in sharded mode and without the logs drain_sharded to see the messages piling up in the sharded queues. 
Everything looked good! ✅ 

