### PR TITLE
Add log entries measuring since processed

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -210,7 +210,7 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 	state.Put("buildJob", buildJob)
 	state.Put("procCtx", buildJob.SetupContext(p.ctx))
 	state.Put("ctx", buildJob.SetupContext(ctx))
-	state.Put("receivedAt", time.Now().UTC())
+	state.Put("processedAt", time.Now().UTC())
 
 	logger := context.LoggerFromContext(ctx).WithFields(logrus.Fields{
 		"job_id": buildJob.Payload().Job.ID,

--- a/processor.go
+++ b/processor.go
@@ -210,6 +210,7 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 	state.Put("buildJob", buildJob)
 	state.Put("procCtx", buildJob.SetupContext(p.ctx))
 	state.Put("ctx", buildJob.SetupContext(ctx))
+	state.Put("receivedAt", time.Now().UTC())
 
 	logger := context.LoggerFromContext(ctx).WithFields(logrus.Fields{
 		"job_id": buildJob.Payload().Job.ID,

--- a/step_update_state.go
+++ b/step_update_state.go
@@ -2,6 +2,7 @@ package worker
 
 import (
 	gocontext "context"
+	"time"
 
 	"github.com/mitchellh/multistep"
 	"github.com/sirupsen/logrus"
@@ -15,6 +16,9 @@ func (s *stepUpdateState) Run(state multistep.StateBag) multistep.StepAction {
 	ctx := state.Get("ctx").(gocontext.Context)
 	buildJob := state.Get("buildJob").(Job)
 	instance := state.Get("instance").(backend.Instance)
+	receivedAt := state.Get("receivedAt").(time.Time)
+
+	logger := context.LoggerFromContext(ctx).WithField("self", "step_update_state")
 
 	instanceID := instance.ID()
 	if instanceID != "" {
@@ -31,6 +35,11 @@ func (s *stepUpdateState) Run(state multistep.StateBag) multistep.StepAction {
 		}).Error("couldn't mark job as started")
 	}
 
+	logger.WithFields(logrus.Fields{
+		"since_received_ms": time.Since(receivedAt).Seconds() * 1e3,
+		"action":            "run",
+	}).Info("marked job as started")
+
 	return multistep.ActionContinue
 }
 
@@ -38,6 +47,7 @@ func (s *stepUpdateState) Cleanup(state multistep.StateBag) {
 	buildJob := state.Get("buildJob").(Job)
 	procCtx := state.Get("procCtx").(gocontext.Context)
 	ctx := state.Get("ctx").(gocontext.Context)
+	receivedAt := state.Get("receivedAt").(time.Time)
 
 	instance := state.Get("instance").(backend.Instance)
 	instanceID := instance.ID()
@@ -45,6 +55,12 @@ func (s *stepUpdateState) Cleanup(state multistep.StateBag) {
 		ctx = context.FromInstanceID(ctx, instanceID)
 		state.Put("ctx", ctx)
 	}
+
+	logger := context.LoggerFromContext(ctx).WithField("self", "step_update_state")
+	logger.WithFields(logrus.Fields{
+		"since_received_ms": time.Since(receivedAt).Seconds() * 1e3,
+		"action":            "cleanup",
+	}).Info("cleaning up")
 
 	mresult, ok := state.GetOk("scriptResult")
 

--- a/step_update_state.go
+++ b/step_update_state.go
@@ -16,7 +16,7 @@ func (s *stepUpdateState) Run(state multistep.StateBag) multistep.StepAction {
 	ctx := state.Get("ctx").(gocontext.Context)
 	buildJob := state.Get("buildJob").(Job)
 	instance := state.Get("instance").(backend.Instance)
-	receivedAt := state.Get("receivedAt").(time.Time)
+	processedAt := state.Get("processedAt").(time.Time)
 
 	logger := context.LoggerFromContext(ctx).WithField("self", "step_update_state")
 
@@ -36,8 +36,8 @@ func (s *stepUpdateState) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	logger.WithFields(logrus.Fields{
-		"since_received_ms": time.Since(receivedAt).Seconds() * 1e3,
-		"action":            "run",
+		"since_processed_ms": time.Since(processedAt).Seconds() * 1e3,
+		"action":             "run",
 	}).Info("marked job as started")
 
 	return multistep.ActionContinue
@@ -47,7 +47,7 @@ func (s *stepUpdateState) Cleanup(state multistep.StateBag) {
 	buildJob := state.Get("buildJob").(Job)
 	procCtx := state.Get("procCtx").(gocontext.Context)
 	ctx := state.Get("ctx").(gocontext.Context)
-	receivedAt := state.Get("receivedAt").(time.Time)
+	processedAt := state.Get("processedAt").(time.Time)
 
 	instance := state.Get("instance").(backend.Instance)
 	instanceID := instance.ID()
@@ -58,8 +58,8 @@ func (s *stepUpdateState) Cleanup(state multistep.StateBag) {
 
 	logger := context.LoggerFromContext(ctx).WithField("self", "step_update_state")
 	logger.WithFields(logrus.Fields{
-		"since_received_ms": time.Since(receivedAt).Seconds() * 1e3,
-		"action":            "cleanup",
+		"since_processed_ms": time.Since(processedAt).Seconds() * 1e3,
+		"action":             "cleanup",
 	}).Info("cleaning up")
 
 	mresult, ok := state.GetOk("scriptResult")

--- a/step_upload_script.go
+++ b/step_upload_script.go
@@ -22,6 +22,7 @@ func (s *stepUploadScript) Run(state multistep.StateBag) multistep.StepAction {
 	ctx := state.Get("ctx").(gocontext.Context)
 	buildJob := state.Get("buildJob").(Job)
 	logWriter := state.Get("logWriter").(LogWriter)
+	receivedAt := state.Get("receivedAt").(time.Time)
 
 	instance := state.Get("instance").(backend.Instance)
 	script := state.Get("script").([]byte)
@@ -58,7 +59,9 @@ func (s *stepUploadScript) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 
-	logger.Info("uploaded script")
+	logger.WithFields(logrus.Fields{
+		"since_received_ms": time.Since(receivedAt).Seconds() * 1e3,
+	}).Info("uploaded script")
 
 	return multistep.ActionContinue
 }

--- a/step_upload_script.go
+++ b/step_upload_script.go
@@ -22,7 +22,7 @@ func (s *stepUploadScript) Run(state multistep.StateBag) multistep.StepAction {
 	ctx := state.Get("ctx").(gocontext.Context)
 	buildJob := state.Get("buildJob").(Job)
 	logWriter := state.Get("logWriter").(LogWriter)
-	receivedAt := state.Get("receivedAt").(time.Time)
+	processedAt := state.Get("processedAt").(time.Time)
 
 	instance := state.Get("instance").(backend.Instance)
 	script := state.Get("script").([]byte)
@@ -60,7 +60,7 @@ func (s *stepUploadScript) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	logger.WithFields(logrus.Fields{
-		"since_received_ms": time.Since(receivedAt).Seconds() * 1e3,
+		"since_processed_ms": time.Since(processedAt).Seconds() * 1e3,
 	}).Info("uploaded script")
 
 	return multistep.ActionContinue


### PR DESCRIPTION
so that we can query for these intervals and see if/how they change based on various load(s).  AFAIK these intervals are not currently directly recorded anywhere, and instead we have to derive the values from multiple metrics/records.  My intent here is to remove that indirection so that exploratory querying in tools like Honeycomb is more accessible to everyone, such as by filtering on `self = step_upload_script` with `P90(since_processed_ms)` (??)