### PR TITLE
Only terminate on host maintenance when GPUs are involved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 - backend/gce: build.sh trace persisting
+- backend/gce: make migration behavior on host maintenance events conditional on GPU usage
 
 ### Changed
 

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -1069,10 +1069,14 @@ func (p *gceProvider) buildInstance(ctx gocontext.Context, startAttributes *Star
 		hostname = fmt.Sprintf("travis-job-%s", uuid.NewRandom())
 	}
 
+	var onHostMaintenance string
+	onHostMaintenance = "MIGRATE"
+
 	acceleratorConfigs := []*compute.AcceleratorConfig{}
 	if acceleratorConfig.AcceleratorCount > 0 {
 		logger.Debug("GPU requested, setting acceleratorConfig")
 		acceleratorConfigs = append(acceleratorConfigs, acceleratorConfig)
+		onHostMaintenance = "TERMINATE"
 	}
 
 	return &compute.Instance{
@@ -1094,7 +1098,7 @@ func (p *gceProvider) buildInstance(ctx gocontext.Context, startAttributes *Star
 		Scheduling: &compute.Scheduling{
 			Preemptible:       p.ic.Preemptible,
 			AutomaticRestart:  googleapi.Bool(false),
-			OnHostMaintenance: "TERMINATE",
+			OnHostMaintenance: onHostMaintenance,
 		},
 		MachineType: machineType.SelfLink,
 		Name:        hostname,


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Sudo-enabled job VMs are shutting down unexpectedly due to host maintenance events. (https://github.com/travis-ci/travis-ci/issues/4924#issuecomment-408327917)

## What approach did you choose and why?

According to https://github.com/travis-ci/worker/commit/811106032d78b3bff03434ed431e3ac90542781d, migrating on host maintenance is problematic when GPUs are involved.
This PR sets host maintenance action based on the presence of at least one GPU.

## What feedback would you like, if any?

What's the actual problem caused by migrating when GPUs are present? Is there a way we can make migration work?