### PR TITLE
only run trace code when trace flag is set on job

### DIFF
--- a/job.go
+++ b/job.go
@@ -37,6 +37,7 @@ type JobPayload struct {
 	VMType     string                 `json:"vm_type"`
 	VMConfig   backend.VmConfig       `json:"vm_config"`
 	Meta       JobMetaPayload         `json:"meta"`
+    Trace      bool                   `json:"trace"`
 }
 
 // JobMetaPayload contains meta information about the job.

--- a/job.go
+++ b/job.go
@@ -37,7 +37,7 @@ type JobPayload struct {
 	VMType     string                 `json:"vm_type"`
 	VMConfig   backend.VmConfig       `json:"vm_config"`
 	Meta       JobMetaPayload         `json:"meta"`
-    Trace      bool                   `json:"trace"`
+	Trace      bool                   `json:"trace"`
 }
 
 // JobMetaPayload contains meta information about the job.

--- a/step_download_trace.go
+++ b/step_download_trace.go
@@ -36,9 +36,9 @@ func (s *stepDownloadTrace) Run(state multistep.StateBag) multistep.StepAction {
 
 	// downloading the trace is best-effort, so we continue in any case
 
-    if !buildJob.Payload().Trace {
+	if !buildJob.Payload().Trace {
 		return multistep.ActionContinue
-    }
+	}
 
 	buf, err := instance.DownloadTrace(ctx)
 	if err != nil {

--- a/step_download_trace.go
+++ b/step_download_trace.go
@@ -36,6 +36,10 @@ func (s *stepDownloadTrace) Run(state multistep.StateBag) multistep.StepAction {
 
 	// downloading the trace is best-effort, so we continue in any case
 
+    if !buildJob.Payload().Trace {
+		return multistep.ActionContinue
+    }
+
 	buf, err := instance.DownloadTrace(ctx)
 	if err != nil {
 		if err == backend.ErrDownloadTraceNotImplemented || os.IsNotExist(errors.Cause(err)) {


### PR DESCRIPTION
This ensures a much stricter opt-in and should allow us to turn off tracing at the scheduler-level completely. That will enable us to perform a safer rollout of this feature.

https://github.com/travis-ci/reliability/issues/152