### PR TITLE
propagate trace flag to hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 
+- trace: guard trace download step on the trace flag from the payload
+- trace: propagate the trace flag in state update message
+
 ### Deprecated
 
 ### Removed

--- a/amqp_job.go
+++ b/amqp_job.go
@@ -161,6 +161,10 @@ func (j *amqpJob) createStateUpdateBody(ctx gocontext.Context, state string) map
 		body["finished_at"] = j.finished.UTC().Format(time.RFC3339)
 	}
 
+	if j.Payload().Trace {
+		body["trace"] = true
+	}
+
 	return body
 }
 

--- a/http_job.go
+++ b/http_job.go
@@ -184,6 +184,10 @@ func (j *httpJob) createStateUpdateBody(curState, newState string) map[string]in
 		body["finished_at"] = j.finished.UTC().Format(time.RFC3339)
 	}
 
+	if j.Payload().Trace {
+		body["trace"] = true
+	}
+
 	return body
 }
 


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

When a downstream app such as hub gets the state update, it may want to initiate trace processing only if the job actually had tracing enabled.

We don't currently store that data anywhere, it exists transiently in the job payload generated by scheduler. That is why it needs to be propagated through -- there is no place to look it up.

## What approach did you choose and why?

The trace flag is passed through as part of the state update message.

## How can you test this?

End-to-end test, ideally with [build-trace-processor](https://github.com/travis-ci/build-trace-processor).

## What feedback would you like, if any?

refs https://github.com/travis-ci/reliability/issues/153