### PR TITLE
Collapse travis jobs, remove packaging step, report golang version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.10.3
+go: 1.10.x
 sudo: required
 dist: trusty
 group: edge
@@ -18,54 +18,27 @@ env:
   - GO15VENDOREXPERIMENT='1'
   - REDIS_URL="redis://"
 
-
-# TODO: re-add the skips once travis-yml is fixed
-#install: skip
-#script: skip
-
-jobs:
-  include:
-  - stage: Build and Test
-    script:
-    - travis_retry make deps
-    - make lintall
-    - make test
-    - make crossbuild
-    - make smoke
-    addons:
-      artifacts:
-        paths:
-        - ./build/linux/amd64/travis-worker
-        - ./build/darwin/amd64/travis-worker
-        target_paths:
-        - travis-ci/worker/$TRAVIS_BUILD_NUMBER/$TRAVIS_JOB_NUMBER
-        - travis-ci/worker/$(git describe --always --dirty --tags)
-        - travis-ci/worker/$TRAVIS_BRANCH
-  - stage: Job Board Integration Tests
-    script:
-    - travis_retry make deps
-    - make crossbuild
-    - make http-job-test
-  - stage: Build and Push Docker Image
-    script:
-    - if [[ $TRAVIS_PULL_REQUEST = 'false' && $DOCKER_LOGIN_PASSWORD && $DOCKER_LOGIN_USERNAME ]]; then
-        travis_retry make deps;
-        make crossbuild;
-        sudo apt-get update;
-        sudo apt-get -y install docker-ce;
-        make docker-build smoke-docker docker-push;
-      fi
-    - echo "TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST}"
-    - echo "TRAVIS_BRANCH=${TRAVIS_BRANCH}"
-    - make send-docker-hub-trigger
-  - stage: Build and Test Packages
-    script:
-    - if [[ $TRAVIS_PULL_REQUEST = 'false' && $PACKAGECLOUD_TOKEN ]]; then
-        travis_retry make deps;
-        make crossbuild;
-        gem install package_cloud --no-ri --no-rdoc;
-        make package smoke-package;
-      fi
-    notifications:
-      slack:
-        secure: IyWrJhruYYHEIvi4YsN3vV2rycctnRiIolzUMwgiDo275AK6O4h58+fu1EXFjMZmCqdOan98MsF709yW3S9zDaZo2s233dKWzQ95S8+n2RS+pGsxBZacCiEvOh0u1K3f19hpf8zj0ybtpcox+a6yrxK+F3er9WveO39yPZjzwCA=
+script:
+- travis_retry make deps
+- make lintall
+- make test
+- make crossbuild
+- make http-job-test
+- make smoke
+- if [[ $TRAVIS_PULL_REQUEST = 'false' && $DOCKER_LOGIN_PASSWORD && $DOCKER_LOGIN_USERNAME ]]; then
+    sudo apt-get update;
+    sudo apt-get -y install docker-ce;
+    make docker-build smoke-docker docker-push;
+  fi
+- echo "TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST}"
+- echo "TRAVIS_BRANCH=${TRAVIS_BRANCH}"
+- make send-docker-hub-trigger
+addons:
+  artifacts:
+    paths:
+    - ./build/linux/amd64/travis-worker
+    - ./build/darwin/amd64/travis-worker
+    target_paths:
+    - travis-ci/worker/$TRAVIS_BUILD_NUMBER/$TRAVIS_JOB_NUMBER
+    - travis-ci/worker/$(git describe --always --dirty --tags)
+    - travis-ci/worker/$TRAVIS_BRANCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.3 as builder
+FROM golang:1.10 as builder
 MAINTAINER Travis CI GmbH <support+travis-worker-docker-image@travis-ci.org>
 
 RUN go get -u github.com/FiloSottile/gvt

--- a/version.go
+++ b/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"gopkg.in/urfave/cli.v1"
 )
@@ -29,6 +30,6 @@ func init() {
 }
 
 func customVersionPrinter(c *cli.Context) {
-	fmt.Printf("%v v=%v rev=%v d=%v\n", filepath.Base(c.App.Name),
-		VersionString, RevisionString, GeneratedString)
+	fmt.Printf("%v v=%v rev=%v d=%v go=%v\n", filepath.Base(c.App.Name),
+		VersionString, RevisionString, GeneratedString, runtime.Version())
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

- The output of the deb and rpm packaging steps *should not* be in use anymore.
- Each job step is under ~10m and a significant portion of that is repeated per job and cannot be reasonably cached.

## What approach did you choose and why?

- Remove the package building, verification, and publishing steps.
- Collapse remaining jobs into a single job.