### PR TITLE
Take into account custom job timeouts when running script

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -256,7 +256,7 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 		&stepCheckCancellation{},
 		&stepRunScript{
 			logTimeout:               logTimeout,
-			hardTimeout:              p.hardTimeout,
+			hardTimeout:              buildJob.StartAttributes().HardTimeout,
 			skipShutdownOnLogTimeout: p.SkipShutdownOnLogTimeout,
 		},
 		&stepDownloadTrace{


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Custom job timeouts are being ignored after the changes introduced in https://github.com/travis-ci/worker/pull/492

## What approach did you choose and why?
Use the hardtimeout in the jobs start attributes instead of the processor one (which just relies on config)

## How can you test this?
✅ tested on staging

## What feedback would you like, if any?
