### PR TITLE
metrics: replace meter with counter

### DIFF
--- a/metrics/package.go
+++ b/metrics/package.go
@@ -9,7 +9,7 @@ import (
 
 // Mark increases the meter metric with the given name by 1
 func Mark(name string) {
-	metrics.GetOrRegisterMeter(name, metrics.DefaultRegistry).Mark(1)
+	metrics.GetOrRegisterCounter(name, metrics.DefaultRegistry).Inc(1)
 }
 
 // TimeSince increases the timer metric with the given name by the time since the given time


### PR DESCRIPTION
Meters behave strangely on librato, as they implicitly perform a derivative and produce unreliable charts.

The hope is that counters can be added together nicely. Affected metrics:

* worker.job.requeue
* travis.worker.job.finish
* travis.worker.job.finish.*
* worker.vm.provider.cloudbrain.boot.timeout
* worker.vm.provider.cloudbrain.boot.poll
* worker.vm.provider.cloudbrain.delete.timeout
* worker.vm.provider.docker.boot.timeout
* worker.vm.provider.gce.boot.timeout
* worker.vm.provider.gce.boot.poll
* travis.worker.gce.preempted-instances
* worker.vm.provider.gce.delete.timeout
* worker.vm.provider.jupiterbrain.boot.timeout
* worker.vm.provider.jupiterbrain.boot.timeout
* worker.job.trace.download.error
* worker.job.trace.persist.error
* worker.job.upload.error
* worker.job.upload.error.stalevm

## What is the problem that this PR is trying to fix?

## What approach did you choose and why?

## How can you test this?

## What feedback would you like, if any?
