### PR TITLE
introduce log-metrics flag, change log metrics to opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 ### Changed
+- config: replace `silence-metrics` option with `log-metrics`, changing log metrics from opt-out to opt-in
 
 ### Deprecated
 
@@ -111,7 +112,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - Makefile: log output from building or running the tests is now less verbose
 
 ### Fixed
-- backend/docker_test: check for EOF instead of Nil for archive/tar errors 
+- backend/docker_test: check for EOF instead of Nil for archive/tar errors
 
 ## [3.8.0] - 2018-05-31
 

--- a/cli.go
+++ b/cli.go
@@ -338,7 +338,9 @@ func (i *CLI) setupMetrics() {
 		go librato.Librato(metrics.DefaultRegistry, time.Minute,
 			i.Config.LibratoEmail, i.Config.LibratoToken, i.Config.LibratoSource,
 			[]float64{0.50, 0.75, 0.90, 0.95, 0.99, 0.999, 1.0}, time.Millisecond)
-	} else if !i.c.Bool("silence-metrics") {
+	}
+
+	if i.c.Bool("log-metrics") {
 		i.logger.Info("starting logger metrics reporter")
 
 		go metrics.Log(metrics.DefaultRegistry, time.Minute,

--- a/config/config.go
+++ b/config/config.go
@@ -233,7 +233,7 @@ var (
 			Usage: "deprecated flag",
 		}),
 		NewConfigDef("log-metrics", &cli.BoolFlag{
-			Usage: "periodically write metrics to the logs",
+			Usage: "periodically print metrics to the stdout",
 		}),
 		NewConfigDef("echo-config", &cli.BoolFlag{
 			Usage: "echo parsed config and exit",

--- a/config/config.go
+++ b/config/config.go
@@ -230,7 +230,10 @@ var (
 			Usage: "username:password for http api basic auth",
 		}),
 		NewConfigDef("silence-metrics", &cli.BoolFlag{
-			Usage: "silence metrics logging in case no Librato creds have been provided",
+			Usage: "deprecated flag",
+		}),
+		NewConfigDef("log-metrics", &cli.BoolFlag{
+			Usage: "periodically write metrics to the logs",
 		}),
 		NewConfigDef("echo-config", &cli.BoolFlag{
 			Usage: "echo parsed config and exit",


### PR DESCRIPTION
When running worker without librato configured, e.g. locally or on enterprise, we will print some metrics to the console once per minute. This output tends to be quite spammy, and doesn't make for a very nice out-of-the-box experience.

It's possible to opt-out of that behaviour by specifying:

```
TRAVIS_WORKER_SILENCE_METRICS=true
```

This patch is intended to make the default experience more user friendly by changing the behaviour to an opt-in `TRAVIS_WORKER_LOG_METRICS` flag.

This came out of a conversation with @schultyy about how these defaults have caused some issues on enterprise.