### PR TITLE
Allow for process-level progress type config

### DIFF
--- a/backend/progresser.go
+++ b/backend/progresser.go
@@ -32,3 +32,7 @@ type ProgressEntry struct {
 type Progresser interface {
 	Progress(*ProgressEntry)
 }
+
+type NullProgresser struct{}
+
+func (np *NullProgresser) Progress(_ *ProgressEntry) {}

--- a/backend/start_attributes.go
+++ b/backend/start_attributes.go
@@ -31,6 +31,10 @@ type StartAttributes struct {
 	// HardTimeout isn't stored in the config directly, but is injected
 	// from the processor
 	HardTimeout time.Duration `json:"-"`
+
+	// ProgressType isn't stored in the config directly, but is injected from
+	// the processor
+	ProgressType string `json:"-"`
 }
 
 // SetDefaults sets any missing required attributes to the default values provided

--- a/cli.go
+++ b/cli.go
@@ -175,6 +175,7 @@ func (i *CLI) Setup() (bool, error) {
 		ScriptUploadTimeout:     i.Config.ScriptUploadTimeout,
 		StartupTimeout:          i.Config.StartupTimeout,
 		PayloadFilterExecutable: i.Config.PayloadFilterExecutable,
+		ProgressType:            i.Config.ProgressType,
 	}
 
 	pool := NewProcessorPool(ppc, i.BackendProvider, i.BuildScriptGenerator, i.BuildTracePersister, i.CancellationBroadcaster)

--- a/config/config.go
+++ b/config/config.go
@@ -220,6 +220,9 @@ var (
 		NewConfigDef("BuildAPIInsecureSkipVerify", &cli.BoolFlag{
 			Usage: "Skip build API TLS verification (useful for Enterprise and testing)",
 		}),
+		NewConfigDef("ProgressType", &cli.StringFlag{
+			Usage: "Report progress for supported backends (valid values \"text\" or unset)",
+		}),
 		NewConfigDef("pprof-port", &cli.StringFlag{
 			Usage: "enable pprof http endpoint (and internal http api) at port",
 		}),
@@ -412,6 +415,7 @@ type Config struct {
 	BuildCacheS3SecretAccessKey string `config:"build-cache-s3-secret-access-key"`
 
 	PayloadFilterExecutable string `config:"payload-filter-executable"`
+	ProgressType            string `config:"progress-type"`
 
 	ProviderConfig *ProviderConfig
 }

--- a/processor.go
+++ b/processor.go
@@ -24,6 +24,7 @@ type Processor struct {
 	scriptUploadTimeout     time.Duration
 	startupTimeout          time.Duration
 	payloadFilterExecutable string
+	progressType            string
 
 	ctx                     gocontext.Context
 	buildJobsChan           <-chan Job
@@ -60,6 +61,7 @@ type ProcessorConfig struct {
 	ScriptUploadTimeout     time.Duration
 	StartupTimeout          time.Duration
 	PayloadFilterExecutable string
+	ProgressType            string
 
 	BuildTraceEnabled     bool
 	BuildTraceS3Bucket    string
@@ -96,6 +98,7 @@ func NewProcessor(ctx gocontext.Context, hostname string, queue JobQueue,
 		startupTimeout:          config.StartupTimeout,
 		maxLogLength:            config.MaxLogLength,
 		payloadFilterExecutable: config.PayloadFilterExecutable,
+		progressType:            config.ProgressType,
 
 		ctx:                     ctx,
 		buildJobsChan:           buildJobsChan,
@@ -146,6 +149,8 @@ func (p *Processor) Run() {
 				p.terminate()
 				return
 			}
+
+			buildJob.StartAttributes().ProgressType = p.progressType
 
 			jobID := buildJob.Payload().Job.ID
 

--- a/processor_pool.go
+++ b/processor_pool.go
@@ -28,7 +28,7 @@ type ProcessorPool struct {
 	HardTimeout, InitialSleep, LogTimeout, ScriptUploadTimeout, StartupTimeout time.Duration
 	MaxLogLength                                                               int
 
-	PayloadFilterExecutable string
+	PayloadFilterExecutable, ProgressType string
 
 	SkipShutdownOnLogTimeout bool
 
@@ -48,7 +48,7 @@ type ProcessorPoolConfig struct {
 	HardTimeout, InitialSleep, LogTimeout, ScriptUploadTimeout, StartupTimeout time.Duration
 	MaxLogLength                                                               int
 
-	PayloadFilterExecutable string
+	PayloadFilterExecutable, ProgressType string
 }
 
 // NewProcessorPool creates a new processor pool using the given arguments.
@@ -72,6 +72,7 @@ func NewProcessorPool(ppc *ProcessorPoolConfig,
 		Persister:               persister,
 		CancellationBroadcaster: cancellationBroadcaster,
 		PayloadFilterExecutable: ppc.PayloadFilterExecutable,
+		ProgressType:            ppc.ProgressType,
 	}
 }
 
@@ -197,6 +198,7 @@ func (p *ProcessorPool) runProcessor(queue JobQueue, logWriterFactory LogWriterF
 			ScriptUploadTimeout:     p.ScriptUploadTimeout,
 			StartupTimeout:          p.StartupTimeout,
 			PayloadFilterExecutable: p.PayloadFilterExecutable,
+			ProgressType:            p.ProgressType,
 		})
 
 	if err != nil {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The reporting of text-based progress is not something that's generally wanted by product-focused humans at Travis.

## What approach did you choose and why?

Allow for opt-in configuration of text progress, defaulting to no progress.