### PR TITLE
Implement downloading traces for Jupiter Brain

### DIFF
--- a/backend/jupiterbrain.go
+++ b/backend/jupiterbrain.go
@@ -469,7 +469,18 @@ func (i *jupiterBrainInstance) RunScript(ctx gocontext.Context, output io.Writer
 }
 
 func (i *jupiterBrainInstance) DownloadTrace(ctx gocontext.Context) ([]byte, error) {
-	return nil, ErrDownloadTraceNotImplemented
+	conn, err := i.sshConnection()
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't connect to SSH server")
+	}
+	defer conn.Close()
+
+	buf, err := conn.DownloadFile("/tmp/build.trace")
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't download trace")
+	}
+
+	return buf, nil
 }
 
 func (i *jupiterBrainInstance) Stop(ctx gocontext.Context) error {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

We want to be able to use build tracing on the Mac infra, just like the other infras.

## What approach did you choose and why?

I copied the code from GCE, since both infras just use an SSH connection.

## How can you test this?

We could deploy it to staging and run a job with tracing enabled.

## What feedback would you like, if any?

Did I miss anything?
