### PR TITLE
propagate job-specific metadata on first log line event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 ### Changed
+- amqp_log_writer: propagate more job metadata with "time to first log line" event
 
 ### Deprecated
 

--- a/amqp_job.go
+++ b/amqp_job.go
@@ -134,7 +134,7 @@ func (j *amqpJob) LogWriter(ctx gocontext.Context, defaultLogTimeout time.Durati
 		logTimeout = defaultLogTimeout
 	}
 
-	return newAMQPLogWriter(ctx, j.logWriterChan, j.payload.Job.ID, j.Payload().Job.QueuedAt, logTimeout, j.withLogSharding)
+	return newAMQPLogWriter(ctx, j.logWriterChan, j.payload.Job.ID, logTimeout, j.withLogSharding)
 }
 
 func (j *amqpJob) createStateUpdateBody(ctx gocontext.Context, state string) map[string]interface{} {

--- a/amqp_log_writer_factory.go
+++ b/amqp_log_writer_factory.go
@@ -50,7 +50,7 @@ func (l *AMQPLogWriterFactory) LogWriter(ctx gocontext.Context, defaultLogTimeou
 		logTimeout = defaultLogTimeout
 	}
 
-	return newAMQPLogWriter(ctx, l.logWriterChan, job.Payload().Job.ID, job.Payload().Job.QueuedAt, logTimeout, l.withLogSharding)
+	return newAMQPLogWriter(ctx, l.logWriterChan, job.Payload().Job.ID, logTimeout, l.withLogSharding)
 }
 
 func (l *AMQPLogWriterFactory) Cleanup() error {

--- a/amqp_log_writer_test.go
+++ b/amqp_log_writer_test.go
@@ -17,10 +17,9 @@ func TestAMQPLogWriterWrite(t *testing.T) {
 	defer amqpChan.Close()
 
 	uuid := uuid.NewRandom()
-	queuedAt := time.Now()
 	ctx := workerctx.FromUUID(context.TODO(), uuid.String())
 
-	logWriter, err := newAMQPLogWriter(ctx, amqpChan, 4, &queuedAt, time.Hour, false)
+	logWriter, err := newAMQPLogWriter(ctx, amqpChan, 4, time.Hour, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,10 +74,9 @@ func TestAMQPLogWriterClose(t *testing.T) {
 	defer amqpChan.Close()
 
 	uuid := uuid.NewRandom()
-	queuedAt := time.Now()
 	ctx := workerctx.FromUUID(context.TODO(), uuid.String())
 
-	logWriter, err := newAMQPLogWriter(ctx, amqpChan, 4, &queuedAt, time.Hour, false)
+	logWriter, err := newAMQPLogWriter(ctx, amqpChan, 4, time.Hour, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,10 +124,9 @@ func TestAMQPMaxLogLength(t *testing.T) {
 	defer amqpChan.Close()
 
 	uuid := uuid.NewRandom()
-	queuedAt := time.Now()
 	ctx := workerctx.FromUUID(context.TODO(), uuid.String())
 
-	logWriter, err := newAMQPLogWriter(ctx, amqpChan, 4, &queuedAt, time.Hour, false)
+	logWriter, err := newAMQPLogWriter(ctx, amqpChan, 4, time.Hour, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli.go
+++ b/cli.go
@@ -176,6 +176,7 @@ func (i *CLI) Setup() (bool, error) {
 		StartupTimeout:          i.Config.StartupTimeout,
 		PayloadFilterExecutable: i.Config.PayloadFilterExecutable,
 		ProgressType:            i.Config.ProgressType,
+		Infra:                   i.Config.Infra,
 	}
 
 	pool := NewProcessorPool(ppc, i.BackendProvider, i.BuildScriptGenerator, i.BuildTracePersister, i.CancellationBroadcaster)

--- a/config/config.go
+++ b/config/config.go
@@ -259,6 +259,9 @@ var (
 		NewConfigDef("heartbeat-url-auth-token", &cli.StringFlag{
 			Usage: "auth token for health check and/or supervisor check URL (may be \"file://path/to/file\")",
 		}),
+		NewConfigDef("infra", &cli.StringFlag{
+			Usage: "infra tag, e.g. gce or ec2",
+		}),
 	}
 
 	// Flags is the list of all CLI flags accepted by travis-worker
@@ -416,6 +419,7 @@ type Config struct {
 
 	PayloadFilterExecutable string `config:"payload-filter-executable"`
 	ProgressType            string `config:"progress-type"`
+	Infra                   string `config:"infra"`
 
 	ProviderConfig *ProviderConfig
 }

--- a/config/config.go
+++ b/config/config.go
@@ -259,7 +259,7 @@ var (
 		NewConfigDef("heartbeat-url-auth-token", &cli.StringFlag{
 			Usage: "auth token for health check and/or supervisor check URL (may be \"file://path/to/file\")",
 		}),
-		NewConfigDef("infra", &cli.StringFlag{
+		NewConfigDef("Infra", &cli.StringFlag{
 			Usage: "infra tag, e.g. gce or ec2",
 		}),
 	}

--- a/file_log_writer.go
+++ b/file_log_writer.go
@@ -44,7 +44,7 @@ func (w *fileLogWriter) SetMaxLogLength(n int) {
 	return
 }
 
-func (w *fileLogWriter) SetJobStarted() {}
+func (w *fileLogWriter) SetJobStarted(meta *JobStartedMeta) {}
 
 func (w *fileLogWriter) SetCancelFunc(cancel gocontext.CancelFunc) {}
 

--- a/http_log_writer.go
+++ b/http_log_writer.go
@@ -135,7 +135,7 @@ func (w *httpLogWriter) SetMaxLogLength(bytes int) {
 	w.maxLength = bytes
 }
 
-func (w *httpLogWriter) SetJobStarted() {}
+func (w *httpLogWriter) SetJobStarted(meta *JobStartedMeta) {}
 
 func (w *httpLogWriter) SetCancelFunc(cancel gocontext.CancelFunc) {
 	w.cancel = cancel

--- a/job.go
+++ b/job.go
@@ -37,6 +37,7 @@ type JobPayload struct {
 	VMType     string                 `json:"vm_type"`
 	VMConfig   backend.VmConfig       `json:"vm_config"`
 	Meta       JobMetaPayload         `json:"meta"`
+	Queue      string                 `json:"queue"`
 	Trace      bool                   `json:"trace"`
 }
 

--- a/log_writer.go
+++ b/log_writer.go
@@ -33,6 +33,14 @@ var (
 	LogChunkSize = 1653
 )
 
+// JobStartedMeta is metadata that is useful for computing time to first
+// log line downstream, and breaking it down into further dimensions.
+type JobStartedMeta struct {
+	QueuedAt *time.Time
+	Repo     string
+	Infra    string
+}
+
 // LogWriter is primarily an io.Writer that will send all bytes to travis-logs
 // for processing, and also has some utility methods for timeouts and log length
 // limiting. Each LogWriter is tied to a given job, and can be gotten by calling
@@ -42,7 +50,7 @@ type LogWriter interface {
 	WriteAndClose([]byte) (int, error)
 	Timeout() <-chan time.Time
 	SetMaxLogLength(int)
-	SetJobStarted()
+	SetJobStarted(meta *JobStartedMeta)
 	SetCancelFunc(gocontext.CancelFunc)
 	MaxLengthReached() bool
 }

--- a/log_writer.go
+++ b/log_writer.go
@@ -36,9 +36,9 @@ var (
 // JobStartedMeta is metadata that is useful for computing time to first
 // log line downstream, and breaking it down into further dimensions.
 type JobStartedMeta struct {
-	QueuedAt *time.Time
-	Repo     string
-	Infra    string
+	QueuedAt *time.Time `json:"queued_at"`
+	Repo     string     `json:"repo"`
+	Infra    string     `json:"infra"`
 }
 
 // LogWriter is primarily an io.Writer that will send all bytes to travis-logs

--- a/log_writer.go
+++ b/log_writer.go
@@ -38,6 +38,7 @@ var (
 type JobStartedMeta struct {
 	QueuedAt *time.Time `json:"queued_at"`
 	Repo     string     `json:"repo"`
+	Queue    string     `json:"queue"`
 	Infra    string     `json:"infra"`
 }
 

--- a/package_test.go
+++ b/package_test.go
@@ -147,7 +147,7 @@ func (flw *fakeLogWriter) Timeout() <-chan time.Time {
 
 func (flw *fakeLogWriter) SetMaxLogLength(_ int) {}
 
-func (flw *fakeLogWriter) SetJobStarted() {}
+func (flw *fakeLogWriter) SetJobStarted(meta *JobStartedMeta) {}
 
 func (flw *fakeLogWriter) SetCancelFunc(_ gocontext.CancelFunc) {}
 

--- a/processor.go
+++ b/processor.go
@@ -25,6 +25,7 @@ type Processor struct {
 	startupTimeout          time.Duration
 	payloadFilterExecutable string
 	progressType            string
+	infra                   string
 
 	ctx                     gocontext.Context
 	buildJobsChan           <-chan Job
@@ -62,6 +63,7 @@ type ProcessorConfig struct {
 	StartupTimeout          time.Duration
 	PayloadFilterExecutable string
 	ProgressType            string
+	Infra                   string
 
 	BuildTraceEnabled     bool
 	BuildTraceS3Bucket    string
@@ -99,6 +101,7 @@ func NewProcessor(ctx gocontext.Context, hostname string, queue JobQueue,
 		maxLogLength:            config.MaxLogLength,
 		payloadFilterExecutable: config.PayloadFilterExecutable,
 		progressType:            config.ProgressType,
+		infra:                   config.Infra,
 
 		ctx:                     ctx,
 		buildJobsChan:           buildJobsChan,
@@ -218,6 +221,7 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 	state.Put("procCtx", buildJob.SetupContext(p.ctx))
 	state.Put("ctx", buildJob.SetupContext(ctx))
 	state.Put("processedAt", time.Now().UTC())
+	state.Put("infra", p.infra)
 
 	logger := context.LoggerFromContext(ctx).WithFields(logrus.Fields{
 		"job_id": buildJob.Payload().Job.ID,

--- a/processor_pool.go
+++ b/processor_pool.go
@@ -29,6 +29,7 @@ type ProcessorPool struct {
 	MaxLogLength                                                               int
 
 	PayloadFilterExecutable, ProgressType string
+	Infra                                 string
 
 	SkipShutdownOnLogTimeout bool
 
@@ -49,6 +50,7 @@ type ProcessorPoolConfig struct {
 	MaxLogLength                                                               int
 
 	PayloadFilterExecutable, ProgressType string
+	Infra                                 string
 }
 
 // NewProcessorPool creates a new processor pool using the given arguments.
@@ -73,6 +75,7 @@ func NewProcessorPool(ppc *ProcessorPoolConfig,
 		CancellationBroadcaster: cancellationBroadcaster,
 		PayloadFilterExecutable: ppc.PayloadFilterExecutable,
 		ProgressType:            ppc.ProgressType,
+		Infra:                   ppc.Infra,
 	}
 }
 
@@ -199,6 +202,7 @@ func (p *ProcessorPool) runProcessor(queue JobQueue, logWriterFactory LogWriterF
 			StartupTimeout:          p.StartupTimeout,
 			PayloadFilterExecutable: p.PayloadFilterExecutable,
 			ProgressType:            p.ProgressType,
+			Infra:                   p.Infra,
 		})
 
 	if err != nil {

--- a/step_update_state.go
+++ b/step_update_state.go
@@ -30,6 +30,7 @@ func (s *stepUpdateState) Run(state multistep.StateBag) multistep.StepAction {
 	logWriter.SetJobStarted(&JobStartedMeta{
 		QueuedAt: buildJob.Payload().Job.QueuedAt,
 		Repo:     buildJob.Payload().Repository.Slug,
+		Queue:    buildJob.Payload().Queue,
 		Infra:    state.Get("infra").(string),
 	})
 

--- a/step_update_state.go
+++ b/step_update_state.go
@@ -27,7 +27,11 @@ func (s *stepUpdateState) Run(state multistep.StateBag) multistep.StepAction {
 		state.Put("ctx", ctx)
 	}
 
-	logWriter.SetJobStarted()
+	logWriter.SetJobStarted(&JobStartedMeta{
+		QueuedAt: buildJob.Payload().Job.QueuedAt,
+		Repo:     buildJob.Payload().Repository.Slug,
+		Infra:    state.Get("infra").(string),
+	})
 
 	err := buildJob.Started(ctx)
 	if err != nil {

--- a/step_write_worker_info_test.go
+++ b/step_write_worker_info_test.go
@@ -32,7 +32,7 @@ func (w *byteBufferLogWriter) Timeout() <-chan time.Time {
 func (w *byteBufferLogWriter) SetMaxLogLength(m int) {
 }
 
-func (w *byteBufferLogWriter) SetJobStarted() {
+func (w *byteBufferLogWriter) SetJobStarted(meta *JobStartedMeta) {
 }
 
 func (w *byteBufferLogWriter) SetCancelFunc(_ gocontext.CancelFunc) {


### PR DESCRIPTION
Passing the infra config through got quite messy unfortunately. I have a feeling that the job config stuff could be simplified a great deal. Instead of Config => ProcessorPoolConfig => ProcessorPool => ProcessorConfig => Processor, we could just pass the original config all the way through.

In any case, the main goal of this is to be able to get per-infra "time to first log line" metrics. To do that, we need to pass metadata to travis-logs. I'm also passing the repo slug, since it might be nice to do more high-cardinality analysis in honeycomb.

refs https://github.com/travis-ci/reliability/issues/190