### PR TITLE
pass-through config instead of duplicating the keys all over the place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 - amqp_log_writer: propagate more job metadata with "time to first log line" event
+- config: refactor config propagation to pass config struct directly
 
 ### Deprecated
 

--- a/cli.go
+++ b/cli.go
@@ -167,21 +167,11 @@ func (i *CLI) Setup() (bool, error) {
 	ppc := &ProcessorPoolConfig{
 		Hostname: i.Config.Hostname,
 		Context:  ctx,
-
-		HardTimeout:             i.Config.HardTimeout,
-		InitialSleep:            i.Config.InitialSleep,
-		LogTimeout:              i.Config.LogTimeout,
-		MaxLogLength:            i.Config.MaxLogLength,
-		ScriptUploadTimeout:     i.Config.ScriptUploadTimeout,
-		StartupTimeout:          i.Config.StartupTimeout,
-		PayloadFilterExecutable: i.Config.PayloadFilterExecutable,
-		ProgressType:            i.Config.ProgressType,
-		Infra:                   i.Config.Infra,
+		Config:   i.Config,
 	}
 
 	pool := NewProcessorPool(ppc, i.BackendProvider, i.BuildScriptGenerator, i.BuildTracePersister, i.CancellationBroadcaster)
 
-	pool.SkipShutdownOnLogTimeout = i.Config.SkipShutdownOnLogTimeout
 	logger.WithField("pool", pool).Debug("built")
 
 	i.ProcessorPool = pool

--- a/processor_pool.go
+++ b/processor_pool.go
@@ -5,13 +5,13 @@ import (
 	"os"
 	"sort"
 	"sync"
-	"time"
 
 	gocontext "context"
 
 	"github.com/pborman/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/travis-ci/worker/backend"
+	"github.com/travis-ci/worker/config"
 	"github.com/travis-ci/worker/context"
 )
 
@@ -24,14 +24,7 @@ type ProcessorPool struct {
 	Persister               BuildTracePersister
 	CancellationBroadcaster *CancellationBroadcaster
 	Hostname                string
-
-	HardTimeout, InitialSleep, LogTimeout, ScriptUploadTimeout, StartupTimeout time.Duration
-	MaxLogLength                                                               int
-
-	PayloadFilterExecutable, ProgressType string
-	Infra                                 string
-
-	SkipShutdownOnLogTimeout bool
+	Config                  *config.Config
 
 	queue            JobQueue
 	logWriterFactory LogWriterFactory
@@ -45,12 +38,7 @@ type ProcessorPool struct {
 type ProcessorPoolConfig struct {
 	Hostname string
 	Context  gocontext.Context
-
-	HardTimeout, InitialSleep, LogTimeout, ScriptUploadTimeout, StartupTimeout time.Duration
-	MaxLogLength                                                               int
-
-	PayloadFilterExecutable, ProgressType string
-	Infra                                 string
+	Config   *config.Config
 }
 
 // NewProcessorPool creates a new processor pool using the given arguments.
@@ -61,21 +49,12 @@ func NewProcessorPool(ppc *ProcessorPoolConfig,
 	return &ProcessorPool{
 		Hostname: ppc.Hostname,
 		Context:  ppc.Context,
-
-		HardTimeout:         ppc.HardTimeout,
-		InitialSleep:        ppc.InitialSleep,
-		LogTimeout:          ppc.LogTimeout,
-		ScriptUploadTimeout: ppc.ScriptUploadTimeout,
-		StartupTimeout:      ppc.StartupTimeout,
-		MaxLogLength:        ppc.MaxLogLength,
+		Config:   ppc.Config,
 
 		Provider:                provider,
 		Generator:               generator,
 		Persister:               persister,
 		CancellationBroadcaster: cancellationBroadcaster,
-		PayloadFilterExecutable: ppc.PayloadFilterExecutable,
-		ProgressType:            ppc.ProgressType,
-		Infra:                   ppc.Infra,
 	}
 }
 
@@ -194,15 +173,7 @@ func (p *ProcessorPool) runProcessor(queue JobQueue, logWriterFactory LogWriterF
 	proc, err := NewProcessor(ctx, p.Hostname,
 		queue, logWriterFactory, p.Provider, p.Generator, p.Persister, p.CancellationBroadcaster,
 		ProcessorConfig{
-			HardTimeout:             p.HardTimeout,
-			InitialSleep:            p.InitialSleep,
-			LogTimeout:              p.LogTimeout,
-			MaxLogLength:            p.MaxLogLength,
-			ScriptUploadTimeout:     p.ScriptUploadTimeout,
-			StartupTimeout:          p.StartupTimeout,
-			PayloadFilterExecutable: p.PayloadFilterExecutable,
-			ProgressType:            p.ProgressType,
-			Infra:                   p.Infra,
+			Config: p.Config,
 		})
 
 	if err != nil {
@@ -212,8 +183,6 @@ func (p *ProcessorPool) runProcessor(queue JobQueue, logWriterFactory LogWriterF
 		}).Error("couldn't create processor")
 		return err
 	}
-
-	proc.SkipShutdownOnLogTimeout = p.SkipShutdownOnLogTimeout
 
 	p.processorsLock.Lock()
 	p.processors = append(p.processors, proc)

--- a/processor_test.go
+++ b/processor_test.go
@@ -73,12 +73,14 @@ func TestProcessor(t *testing.T) {
 		cancellationBroadcaster := NewCancellationBroadcaster()
 
 		processor, err := NewProcessor(ctx, "test-hostname", jobQueue, nil, provider, generator, nil, cancellationBroadcaster, ProcessorConfig{
-			HardTimeout:             tc.hardTimeout,
-			LogTimeout:              time.Second,
-			ScriptUploadTimeout:     3 * time.Second,
-			StartupTimeout:          4 * time.Second,
-			MaxLogLength:            4500000,
-			PayloadFilterExecutable: "filter.py",
+			Config: &config.Config{
+				HardTimeout:             tc.hardTimeout,
+				LogTimeout:              time.Second,
+				ScriptUploadTimeout:     3 * time.Second,
+				StartupTimeout:          4 * time.Second,
+				MaxLogLength:            4500000,
+				PayloadFilterExecutable: "filter.py",
+			},
 		})
 		if err != nil {
 			t.Error(err)


### PR DESCRIPTION
This has been kind of a long-standing issue for adding config values, as they always need to be added in many places. Most recently encountered as part of https://github.com/travis-ci/worker/pull/508. This patch tries to simplify things by passing the config struct directly.

vaguely refs travis-ci/reliability#190