### PR TITLE
Worker Trace - Opencensus and Stackdriver 

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -353,8 +353,8 @@ func (i *CLI) setupMetrics() {
 	}
 }
 
-func loadStackdriverTraceJSON(ctx gocontext.Context, StackdriverTraceAccountJSON string) (*google.Credentials, error) {
-	credBytes, err := loadBytes(StackdriverTraceAccountJSON)
+func loadStackdriverTraceJSON(ctx gocontext.Context, stackdriverTraceAccountJSON string) (*google.Credentials, error) {
+	credBytes, err := loadBytes(stackdriverTraceAccountJSON)
 	if err != nil {
 		return nil, err
 	}
@@ -384,8 +384,8 @@ func loadBytes(filenameOrJSON string) ([]byte, error) {
 	return bytes, nil
 }
 
-func (i *CLI) setupOpenCensus(StackdriverTraceAccountJSON string) error {
-	creds, err := loadStackdriverTraceJSON(gocontext.TODO(), StackdriverTraceAccountJSON)
+func (i *CLI) setupOpenCensus(stackdriverTraceAccountJSON string) error {
+	creds, err := loadStackdriverTraceJSON(gocontext.TODO(), stackdriverTraceAccountJSON)
 	if err != nil {
 		return err
 	}

--- a/cli.go
+++ b/cli.go
@@ -398,7 +398,7 @@ func (i *CLI) setupOpenCensus(stackdriverTraceAccountJSON string) error {
 	}
 
 	sd, err := stackdriver.NewExporter(stackdriver.Options{
-		ProjectID: os.Getenv("TRAVIS_WORKER_GCE_PROJECT_ID"),
+		ProjectID: i.Config.StackdriverProjectID,
 		TraceClientOptions: []option.ClientOption{
 			option.WithCredentials(creds),
 		},

--- a/cli.go
+++ b/cli.go
@@ -385,7 +385,6 @@ func loadBytes(filenameOrJSON string) ([]byte, error) {
 }
 
 func (i *CLI) setupOpenCensus(stackdriverTraceAccountJSON string) error {
-
 	opencensusEnabled := i.Config.OpencensusTracingEnabled
 
 	if !opencensusEnabled {

--- a/cli.go
+++ b/cli.go
@@ -139,7 +139,12 @@ func (i *CLI) Setup() (bool, error) {
 
 	i.setupSentry()
 	i.setupMetrics()
-	i.setupOpenCensus("stackdriver-trace-account-json")
+	err := i.setupOpenCensus("stackdriver-trace-account-json")
+
+	if err != nil {
+		logger.WithField("err", err).Error("failed to set up opencensus")
+		return false, err
+	}
 
 	generator := NewBuildScriptGenerator(i.Config)
 	logger.WithField("build_script_generator", fmt.Sprintf("%#v", generator)).Debug("built")

--- a/cli.go
+++ b/cli.go
@@ -139,7 +139,8 @@ func (i *CLI) Setup() (bool, error) {
 
 	i.setupSentry()
 	i.setupMetrics()
-	err := i.setupOpenCensus("stackdriver-trace-account-json")
+
+	err := i.setupOpenCensus(i.Config.StackdriverTraceAccountJSON)
 
 	if err != nil {
 		logger.WithField("err", err).Error("failed to set up opencensus")
@@ -357,6 +358,7 @@ func loadStackdriverTraceJSON(ctx gocontext.Context, StackdriverTraceAccountJSON
 	if err != nil {
 		return nil, err
 	}
+
 	creds, err := google.CredentialsFromJSON(ctx, credBytes, googlecloudtrace.ScopeTraceAppend)
 	if err != nil {
 		return nil, err
@@ -383,13 +385,12 @@ func loadBytes(filenameOrJSON string) ([]byte, error) {
 }
 
 func (i *CLI) setupOpenCensus(StackdriverTraceAccountJSON string) error {
-
 	creds, err := loadStackdriverTraceJSON(gocontext.TODO(), StackdriverTraceAccountJSON)
 	if err != nil {
 		return err
 	}
 	sd, err := stackdriver.NewExporter(stackdriver.Options{
-		ProjectID: os.Getenv("GCLOUD_PROJECT"),
+		ProjectID: os.Getenv("TRAVIS_WORKER_GCE_PROJECT_ID"),
 		TraceClientOptions: []option.ClientOption{
 			option.WithCredentials(creds),
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -265,6 +265,9 @@ var (
 		NewConfigDef("StackdriverTraceAccountJSON", &cli.StringFlag{
 			Usage: "file path or JSON to stackdriver trace on Google Cloud",
 		}),
+		NewConfigDef("StackdriverProjectID", &cli.StringFlag{
+			Usage: "google cloud project ID where where traces are exported and viewed",
+		}),
 		NewConfigDef("OpencensusTracingEnabled", &cli.BoolFlag{
 			Usage: "enable tracing for worker with google stackdriver client",
 		}),
@@ -431,6 +434,7 @@ type Config struct {
 	ProgressType                string `config:"progress-type"`
 	Infra                       string `config:"infra"`
 	StackdriverTraceAccountJSON string `config:"stackdriver-trace-account-json"`
+	StackdriverProjectID        string `config:"stackdriver-project-ID"`
 	OpencensusTracingEnabled    bool   `config:"opencensus-tracing-enabled"`
 	OpencensusSamplingRate      int    `config:"opencensus-sampling-rate"`
 

--- a/config/config.go
+++ b/config/config.go
@@ -434,7 +434,7 @@ type Config struct {
 	ProgressType                string `config:"progress-type"`
 	Infra                       string `config:"infra"`
 	StackdriverTraceAccountJSON string `config:"stackdriver-trace-account-json"`
-	StackdriverProjectID        string `config:"stackdriver-project-ID"`
+	StackdriverProjectID        string `config:"stackdriver-project-id"`
 	OpencensusTracingEnabled    bool   `config:"opencensus-tracing-enabled"`
 	OpencensusSamplingRate      int    `config:"opencensus-sampling-rate"`
 

--- a/config/config.go
+++ b/config/config.go
@@ -265,6 +265,9 @@ var (
 		NewConfigDef("StackdriverTraceAccountJSON", &cli.StringFlag{
 			Usage: "file path or JSON to stackdriver trace on Google Cloud",
 		}),
+		NewConfigDef("opencensus-tracing-enabled", &cli.StringFlag{
+			Usage: "enable tracing for worker with google stackdriver client",
+		}),
 	}
 
 	// Flags is the list of all CLI flags accepted by travis-worker
@@ -424,6 +427,7 @@ type Config struct {
 	ProgressType                string `config:"progress-type"`
 	Infra                       string `config:"infra"`
 	StackdriverTraceAccountJSON string `config:"stackdriver-trace-account-json"`
+	OpencensusTracingEnabled    bool   `config:"opencensus-tracing-enabled"`
 
 	ProviderConfig *ProviderConfig
 }

--- a/config/config.go
+++ b/config/config.go
@@ -262,6 +262,9 @@ var (
 		NewConfigDef("Infra", &cli.StringFlag{
 			Usage: "infra tag, e.g. gce or ec2",
 		}),
+		NewConfigDef("stackdriver-trace-account-json", &cli.StringFlag{
+			Usage: "file path or JSON to stackdriver trace on Google Cloud  ",
+		}),
 	}
 
 	// Flags is the list of all CLI flags accepted by travis-worker
@@ -417,9 +420,10 @@ type Config struct {
 	BuildCacheS3AccessKeyID     string `config:"build-cache-s3-access-key-id"`
 	BuildCacheS3SecretAccessKey string `config:"build-cache-s3-secret-access-key"`
 
-	PayloadFilterExecutable string `config:"payload-filter-executable"`
-	ProgressType            string `config:"progress-type"`
-	Infra                   string `config:"infra"`
+	PayloadFilterExecutable     string `config:"payload-filter-executable"`
+	ProgressType                string `config:"progress-type"`
+	Infra                       string `config:"infra"`
+	StackdriverTraceAccountJSON string `config:"stackdriver-trace-account-json"`
 
 	ProviderConfig *ProviderConfig
 }

--- a/config/config.go
+++ b/config/config.go
@@ -262,8 +262,8 @@ var (
 		NewConfigDef("Infra", &cli.StringFlag{
 			Usage: "infra tag, e.g. gce or ec2",
 		}),
-		NewConfigDef("stackdriver-trace-account-json", &cli.StringFlag{
-			Usage: "file path or JSON to stackdriver trace on Google Cloud  ",
+		NewConfigDef("StackdriverTraceAccountJSON", &cli.StringFlag{
+			Usage: "file path or JSON to stackdriver trace on Google Cloud",
 		}),
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -265,8 +265,12 @@ var (
 		NewConfigDef("StackdriverTraceAccountJSON", &cli.StringFlag{
 			Usage: "file path or JSON to stackdriver trace on Google Cloud",
 		}),
-		NewConfigDef("opencensus-tracing-enabled", &cli.StringFlag{
+		NewConfigDef("OpencensusTracingEnabled", &cli.BoolFlag{
 			Usage: "enable tracing for worker with google stackdriver client",
+		}),
+		NewConfigDef("OpencensusSamplingRate", &cli.IntFlag{
+			Usage: "sample rate for trace as an inverse fraction - for sample rate n, every nth event will be sampled",
+			Value: 1,
 		}),
 	}
 
@@ -428,6 +432,7 @@ type Config struct {
 	Infra                       string `config:"infra"`
 	StackdriverTraceAccountJSON string `config:"stackdriver-trace-account-json"`
 	OpencensusTracingEnabled    bool   `config:"opencensus-tracing-enabled"`
+	OpencensusSamplingRate      int    `config:"opencensus-sampling-rate"`
 
 	ProviderConfig *ProviderConfig
 }

--- a/processor.go
+++ b/processor.go
@@ -91,7 +91,6 @@ func NewProcessor(ctx gocontext.Context, hostname string, queue JobQueue,
 // terminated, either by calling the GracefulShutdown or Terminate methods, or
 // if the build jobs channel is closed.
 func (p *Processor) Run() {
-
 	logger := context.LoggerFromContext(p.ctx).WithField("self", "processor")
 	logger.Info("starting processor")
 	defer logger.Info("processor done")
@@ -184,7 +183,6 @@ func (p *Processor) Terminate() {
 }
 
 func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
-
 	ctx, span := trace.StartSpan(ctx, "ProcessorRun")
 	defer span.End()
 

--- a/processor.go
+++ b/processor.go
@@ -186,6 +186,10 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 	ctx, span := trace.StartSpan(ctx, "ProcessorRun")
 	defer span.End()
 
+	span.AddAttributes(
+		trace.StringAttribute("app", "worker"),
+	)
+
 	state := new(multistep.BasicStateBag)
 	state.Put("hostname", p.ID)
 	state.Put("buildJob", buildJob)

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -203,6 +203,15 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/aws/aws-sdk-go/internal/s3err",
+			"repository": "https://github.com/aws/aws-sdk-go",
+			"vcs": "git",
+			"revision": "111e32cc8572b4efc1e01cfc9a26313bf329d86e",
+			"branch": "master",
+			"path": "/internal/s3err",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/aws/aws-sdk-go/internal/sdkio",
 			"repository": "https://github.com/aws/aws-sdk-go",
 			"vcs": "git",

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -119,12 +119,11 @@
 			"notests": true
 		},
 		{
-			"importpath": "contrib.go.opencensus.io/exporter/stackdriver/propagation",
+			"importpath": "contrib.go.opencensus.io/exporter/stackdriver",
 			"repository": "https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver",
 			"vcs": "git",
 			"revision": "857ff689ec3b8d8ebb64827938f1ff602eee59a9",
 			"branch": "master",
-			"path": "/propagation",
 			"notests": true
 		},
 		{

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -110,12 +110,21 @@
 			"notests": true
 		},
 		{
-			"importpath": "cloud.google.com/go/trace/apiv2",
+			"importpath": "cloud.google.com/go/trace",
 			"repository": "https://code.googlesource.com/gocloud",
 			"vcs": "git",
-			"revision": "e0c17b1c932efccf9d30ca4beca8bcf215ea7762",
+			"revision": "9d56e3b4a0c5a8476fda83c058e458cc4748de00",
 			"branch": "master",
-			"path": "trace/apiv2",
+			"path": "/trace",
+			"notests": true
+		},
+		{
+			"importpath": "contrib.go.opencensus.io/exporter/stackdriver/propagation",
+			"repository": "https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver",
+			"vcs": "git",
+			"revision": "857ff689ec3b8d8ebb64827938f1ff602eee59a9",
+			"branch": "master",
+			"path": "/propagation",
 			"notests": true
 		},
 		{
@@ -1183,6 +1192,15 @@
 			"notests": true
 		},
 		{
+			"importpath": "google.golang.org/api/cloudtrace/v1",
+			"repository": "https://code.googlesource.com/google-api-go-client",
+			"vcs": "git",
+			"revision": "f5c49d98d21cc639f7ba8c7e4b127e88ee2af7ed",
+			"branch": "master",
+			"path": "/cloudtrace/v1",
+			"notests": true
+		},
+		{
 			"importpath": "google.golang.org/api/compute/v1",
 			"repository": "https://code.googlesource.com/google-api-go-client",
 			"vcs": "git",
@@ -1359,6 +1377,15 @@
 			"revision": "c3f76f3b92d1ffa4c58a9ff842a58b8877655e0f",
 			"branch": "master",
 			"path": "googleapis/datastore/v1",
+			"notests": true
+		},
+		{
+			"importpath": "google.golang.org/genproto/googleapis/devtools/cloudtrace/v1",
+			"repository": "https://github.com/google/go-genproto",
+			"vcs": "git",
+			"revision": "af9cb2a35e7f169ec875002c1829c9b315cddc04",
+			"branch": "master",
+			"path": "/googleapis/devtools/cloudtrace/v1",
 			"notests": true
 		},
 		{


### PR DESCRIPTION
refs https://github.com/travis-ci/reliability/issues/141

MVP worker trace with exporter and root span. 

## What is the problem that this PR is trying to fix?

Let's  do a first iteration on task/subtask execution & latency on our worker instances ⏲ 

## What approach did you choose and why?
We've already implemented trace in /gcloud-cleanup using opencensus go and the stackdriver exporter, so repeating here. 

## How can you test this?
Running worker locally.  

## What feedback would you like, if any?

We want to be backend agnostic, so:

Ok to put everything in global (rather than provider) config? 

#TODO
Link the associated PRs in terraform and config keychain. 


