### PR TITLE
Worker trace: child spans for all steps in ProcessorRun root span

### DIFF
--- a/step_check_cancellation.go
+++ b/step_check_cancellation.go
@@ -42,8 +42,7 @@ func (s *stepCheckCancellation) Run(state multistep.StateBag) multistep.StepActi
 func (s *stepCheckCancellation) Cleanup(state multistep.StateBag) {}
 
 func (s *stepCheckCancellation) writeLogAndFinishWithState(procCtx, ctx gocontext.Context, logWriter LogWriter, buildJob Job, state FinishState, logMessage string) {
-
-	ctx, span := trace.StartSpan(ctx, "writeLogAndFinishWithState")
+	ctx, span := trace.StartSpan(ctx, "WriteLogAndFinishWithState.CheckCancellation")
 	defer span.End()
 
 	_, err := logWriter.WriteAndClose([]byte(logMessage))

--- a/step_download_trace.go
+++ b/step_download_trace.go
@@ -26,7 +26,7 @@ func (s *stepDownloadTrace) Run(state multistep.StateBag) multistep.StepAction {
 
 	ctx := state.Get("ctx").(gocontext.Context)
 
-	ctx, span := trace.StartSpan(ctx, "stepDownloadTrace")
+	ctx, span := trace.StartSpan(ctx, "DownloadTrace.Run")
 	defer span.End()
 
 	buildJob := state.Get("buildJob").(Job)

--- a/step_download_trace.go
+++ b/step_download_trace.go
@@ -12,6 +12,7 @@ import (
 	"github.com/travis-ci/worker/backend"
 	"github.com/travis-ci/worker/context"
 	"github.com/travis-ci/worker/metrics"
+	"go.opencensus.io/trace"
 )
 
 type stepDownloadTrace struct {
@@ -24,6 +25,10 @@ func (s *stepDownloadTrace) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	ctx := state.Get("ctx").(gocontext.Context)
+
+	ctx, span := trace.StartSpan(ctx, "stepDownloadTrace")
+	defer span.End()
+
 	buildJob := state.Get("buildJob").(Job)
 	processedAt := state.Get("processedAt").(time.Time)
 

--- a/step_generate_script.go
+++ b/step_generate_script.go
@@ -20,7 +20,7 @@ func (s *stepGenerateScript) Run(state multistep.StateBag) multistep.StepAction 
 	buildJob := state.Get("buildJob").(Job)
 	ctx := state.Get("ctx").(gocontext.Context)
 
-	ctx, span := trace.StartSpan(ctx, "stepGenerateScript")
+	ctx, span := trace.StartSpan(ctx, "GenerateScript.Run")
 	defer span.End()
 
 	logger := context.LoggerFromContext(ctx).WithField("self", "step_generate_script")

--- a/step_generate_script.go
+++ b/step_generate_script.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cenk/backoff"
 	"github.com/mitchellh/multistep"
 	"github.com/travis-ci/worker/context"
+	"go.opencensus.io/trace"
 )
 
 type stepGenerateScript struct {
@@ -18,6 +19,9 @@ func (s *stepGenerateScript) Run(state multistep.StateBag) multistep.StepAction 
 	procCtx := state.Get("procCtx").(gocontext.Context)
 	buildJob := state.Get("buildJob").(Job)
 	ctx := state.Get("ctx").(gocontext.Context)
+
+	ctx, span := trace.StartSpan(ctx, "stepGenerateScript")
+	defer span.End()
 
 	logger := context.LoggerFromContext(ctx).WithField("self", "step_generate_script")
 

--- a/step_open_log_writer.go
+++ b/step_open_log_writer.go
@@ -23,7 +23,7 @@ func (s *stepOpenLogWriter) Run(state multistep.StateBag) multistep.StepAction {
 	logWriterFactory := state.Get("logWriterFactory")
 	logger := context.LoggerFromContext(ctx).WithField("self", "step_open_log_writer")
 
-	ctx, span := trace.StartSpan(ctx, "stepOpenLogWriter")
+	ctx, span := trace.StartSpan(ctx, "OpenLogWriter.Run")
 	defer span.End()
 
 	var logWriter LogWriter
@@ -57,7 +57,7 @@ func (s *stepOpenLogWriter) Run(state multistep.StateBag) multistep.StepAction {
 func (s *stepOpenLogWriter) Cleanup(state multistep.StateBag) {
 	ctx := state.Get("ctx").(gocontext.Context)
 
-	ctx, span := trace.StartSpan(ctx, "stepOpenLogWriterCleanup")
+	ctx, span := trace.StartSpan(ctx, "OpenLogWriter.Cleanup")
 	defer span.End()
 
 	logWriter, ok := state.Get("logWriter").(LogWriter)

--- a/step_run_script.go
+++ b/step_run_script.go
@@ -123,7 +123,6 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 }
 
 func (s *stepRunScript) writeLogAndFinishWithState(procCtx, ctx gocontext.Context, logWriter LogWriter, buildJob Job, state FinishState, logMessage string) {
-
 	ctx, span := trace.StartSpan(ctx, "stepWriteLogAndFinishWithState")
 	defer span.End()
 

--- a/step_run_script.go
+++ b/step_run_script.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/travis-ci/worker/backend"
 	"github.com/travis-ci/worker/context"
+	"go.opencensus.io/trace"
 )
 
 type runScriptReturn struct {
@@ -31,6 +32,9 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 	instance := state.Get("instance").(backend.Instance)
 	logWriter := state.Get("logWriter").(LogWriter)
 	cancelChan := state.Get("cancelChan").(<-chan struct{})
+
+	ctx, span := trace.StartSpan(ctx, "stepRunScript")
+	defer span.End()
 
 	logger := context.LoggerFromContext(ctx).WithField("self", "step_run_script")
 	ctx, cancel := gocontext.WithTimeout(ctx, s.hardTimeout)
@@ -119,6 +123,10 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 }
 
 func (s *stepRunScript) writeLogAndFinishWithState(procCtx, ctx gocontext.Context, logWriter LogWriter, buildJob Job, state FinishState, logMessage string) {
+
+	ctx, span := trace.StartSpan(ctx, "stepWriteLogAndFinishWithState")
+	defer span.End()
+
 	logger := context.LoggerFromContext(ctx).WithField("self", "step_run_script")
 	_, err := logWriter.WriteAndClose([]byte(logMessage))
 	if err != nil {

--- a/step_run_script.go
+++ b/step_run_script.go
@@ -33,7 +33,7 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 	logWriter := state.Get("logWriter").(LogWriter)
 	cancelChan := state.Get("cancelChan").(<-chan struct{})
 
-	ctx, span := trace.StartSpan(ctx, "stepRunScript")
+	ctx, span := trace.StartSpan(ctx, "RunScript.Run")
 	defer span.End()
 
 	logger := context.LoggerFromContext(ctx).WithField("self", "step_run_script")
@@ -123,7 +123,7 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 }
 
 func (s *stepRunScript) writeLogAndFinishWithState(procCtx, ctx gocontext.Context, logWriter LogWriter, buildJob Job, state FinishState, logMessage string) {
-	ctx, span := trace.StartSpan(ctx, "stepWriteLogAndFinishWithState")
+	ctx, span := trace.StartSpan(ctx, "WriteLogAndFinishWithState.RunScript")
 	defer span.End()
 
 	logger := context.LoggerFromContext(ctx).WithField("self", "step_run_script")

--- a/step_send_received.go
+++ b/step_send_received.go
@@ -6,6 +6,7 @@ import (
 	"github.com/mitchellh/multistep"
 	"github.com/sirupsen/logrus"
 	"github.com/travis-ci/worker/context"
+	"go.opencensus.io/trace"
 )
 
 type stepSendReceived struct{}
@@ -13,6 +14,9 @@ type stepSendReceived struct{}
 func (s *stepSendReceived) Run(state multistep.StateBag) multistep.StepAction {
 	buildJob := state.Get("buildJob").(Job)
 	ctx := state.Get("ctx").(gocontext.Context)
+
+	ctx, span := trace.StartSpan(ctx, "stepSendReceived")
+	defer span.End()
 
 	err := buildJob.Received(ctx)
 	if err != nil {
@@ -25,4 +29,9 @@ func (s *stepSendReceived) Run(state multistep.StateBag) multistep.StepAction {
 	return multistep.ActionContinue
 }
 
-func (s *stepSendReceived) Cleanup(state multistep.StateBag) {}
+func (s *stepSendReceived) Cleanup(state multistep.StateBag) {
+	ctx := state.Get("ctx").(gocontext.Context)
+
+	ctx, span := trace.StartSpan(ctx, "stepSendReceived_cleanup")
+	defer span.End()
+}

--- a/step_send_received.go
+++ b/step_send_received.go
@@ -29,9 +29,4 @@ func (s *stepSendReceived) Run(state multistep.StateBag) multistep.StepAction {
 	return multistep.ActionContinue
 }
 
-func (s *stepSendReceived) Cleanup(state multistep.StateBag) {
-	ctx := state.Get("ctx").(gocontext.Context)
-
-	ctx, span := trace.StartSpan(ctx, "stepSendReceived_cleanup")
-	defer span.End()
-}
+func (s *stepSendReceived) Cleanup(state multistep.StateBag) {}

--- a/step_send_received.go
+++ b/step_send_received.go
@@ -15,7 +15,7 @@ func (s *stepSendReceived) Run(state multistep.StateBag) multistep.StepAction {
 	buildJob := state.Get("buildJob").(Job)
 	ctx := state.Get("ctx").(gocontext.Context)
 
-	ctx, span := trace.StartSpan(ctx, "stepSendReceived")
+	ctx, span := trace.StartSpan(ctx, "SendReceived.Run")
 	defer span.End()
 
 	err := buildJob.Received(ctx)

--- a/step_sleep.go
+++ b/step_sleep.go
@@ -1,9 +1,11 @@
 package worker
 
 import (
+	gocontext "context"
 	"time"
 
 	"github.com/mitchellh/multistep"
+	"go.opencensus.io/trace"
 )
 
 type stepSleep struct {
@@ -11,6 +13,11 @@ type stepSleep struct {
 }
 
 func (s *stepSleep) Run(state multistep.StateBag) multistep.StepAction {
+	ctx := state.Get("ctx").(gocontext.Context)
+
+	ctx, span := trace.StartSpan(ctx, "stepSleep")
+	defer span.End()
+
 	time.Sleep(s.duration)
 
 	return multistep.ActionContinue

--- a/step_sleep.go
+++ b/step_sleep.go
@@ -15,7 +15,7 @@ type stepSleep struct {
 func (s *stepSleep) Run(state multistep.StateBag) multistep.StepAction {
 	ctx := state.Get("ctx").(gocontext.Context)
 
-	ctx, span := trace.StartSpan(ctx, "stepSleep")
+	ctx, span := trace.StartSpan(ctx, "Sleep.Run")
 	defer span.End()
 
 	time.Sleep(s.duration)

--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -11,6 +11,7 @@ import (
 	"github.com/travis-ci/worker/backend"
 	"github.com/travis-ci/worker/context"
 	workererrors "github.com/travis-ci/worker/errors"
+	"go.opencensus.io/trace"
 )
 
 type stepStartInstance struct {
@@ -24,6 +25,9 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 	ctx := state.Get("ctx").(gocontext.Context)
 	logger := context.LoggerFromContext(ctx).WithField("self", "step_start_instance")
 	logWriter := state.Get("logWriter").(LogWriter)
+
+	ctx, span := trace.StartSpan(ctx, "stepStartInstance")
+	defer span.End()
 
 	logger.Info("starting instance")
 
@@ -95,6 +99,10 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 
 func (s *stepStartInstance) Cleanup(state multistep.StateBag) {
 	ctx := state.Get("ctx").(gocontext.Context)
+
+	ctx, span := trace.StartSpan(ctx, "stepStartInstanceCleanup")
+	defer span.End()
+
 	instance, ok := state.Get("instance").(backend.Instance)
 	logger := context.LoggerFromContext(ctx).WithField("self", "step_start_instance")
 	if !ok {

--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -26,7 +26,7 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 	logger := context.LoggerFromContext(ctx).WithField("self", "step_start_instance")
 	logWriter := state.Get("logWriter").(LogWriter)
 
-	ctx, span := trace.StartSpan(ctx, "stepStartInstance")
+	ctx, span := trace.StartSpan(ctx, "StartInstance.Run")
 	defer span.End()
 
 	logger.Info("starting instance")
@@ -100,7 +100,7 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 func (s *stepStartInstance) Cleanup(state multistep.StateBag) {
 	ctx := state.Get("ctx").(gocontext.Context)
 
-	ctx, span := trace.StartSpan(ctx, "stepStartInstanceCleanup")
+	ctx, span := trace.StartSpan(ctx, "StartInstance.Cleanup")
 	defer span.End()
 
 	instance, ok := state.Get("instance").(backend.Instance)

--- a/step_subscribe_cancellation.go
+++ b/step_subscribe_cancellation.go
@@ -14,7 +14,7 @@ type stepSubscribeCancellation struct {
 func (s *stepSubscribeCancellation) Run(state multistep.StateBag) multistep.StepAction {
 	ctx := state.Get("ctx").(gocontext.Context)
 
-	ctx, span := trace.StartSpan(ctx, "SubscribeCancellation")
+	ctx, span := trace.StartSpan(ctx, "SubscribeCancellation.Run")
 	defer span.End()
 
 	if s.cancellationBroadcaster == nil {
@@ -37,7 +37,7 @@ func (s *stepSubscribeCancellation) Cleanup(state multistep.StateBag) {
 
 	ctx := state.Get("ctx").(gocontext.Context)
 
-	ctx, span := trace.StartSpan(ctx, "SubscribeCancellation_cleanup")
+	ctx, span := trace.StartSpan(ctx, "SubscribeCancellation.Cleanup")
 	defer span.End()
 
 	buildJob := state.Get("buildJob").(Job)

--- a/step_subscribe_cancellation.go
+++ b/step_subscribe_cancellation.go
@@ -1,12 +1,22 @@
 package worker
 
-import "github.com/mitchellh/multistep"
+import (
+	gocontext "context"
+
+	"github.com/mitchellh/multistep"
+	"go.opencensus.io/trace"
+)
 
 type stepSubscribeCancellation struct {
 	cancellationBroadcaster *CancellationBroadcaster
 }
 
 func (s *stepSubscribeCancellation) Run(state multistep.StateBag) multistep.StepAction {
+	ctx := state.Get("ctx").(gocontext.Context)
+
+	ctx, span := trace.StartSpan(ctx, "SubscribeCancellation")
+	defer span.End()
+
 	if s.cancellationBroadcaster == nil {
 		ch := make(chan struct{})
 		state.Put("cancelChan", (<-chan struct{})(ch))
@@ -24,6 +34,11 @@ func (s *stepSubscribeCancellation) Cleanup(state multistep.StateBag) {
 	if s.cancellationBroadcaster == nil {
 		return
 	}
+
+	ctx := state.Get("ctx").(gocontext.Context)
+
+	ctx, span := trace.StartSpan(ctx, "SubscribeCancellation_cleanup")
+	defer span.End()
 
 	buildJob := state.Get("buildJob").(Job)
 	ch := state.Get("cancelChan").(<-chan struct{})

--- a/step_transform_build_json.go
+++ b/step_transform_build_json.go
@@ -26,7 +26,7 @@ func (s *stepTransformBuildJSON) Run(state multistep.StateBag) multistep.StepAct
 	buildJob := state.Get("buildJob").(Job)
 	ctx := state.Get("ctx").(gocontext.Context)
 
-	ctx, span := trace.StartSpan(ctx, "stepTransformBuildJSON")
+	ctx, span := trace.StartSpan(ctx, "TransformBuildJSON.Run")
 	defer span.End()
 
 	if s.payloadFilterExecutable == "" {

--- a/step_transform_build_json.go
+++ b/step_transform_build_json.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mitchellh/multistep"
 	"github.com/travis-ci/worker/context"
+	"go.opencensus.io/trace"
 	gocontext "golang.org/x/net/context"
 )
 
@@ -24,6 +25,9 @@ type EnvVar struct {
 func (s *stepTransformBuildJSON) Run(state multistep.StateBag) multistep.StepAction {
 	buildJob := state.Get("buildJob").(Job)
 	ctx := state.Get("ctx").(gocontext.Context)
+
+	ctx, span := trace.StartSpan(ctx, "stepTransformBuildJSON")
+	defer span.End()
 
 	if s.payloadFilterExecutable == "" {
 		context.LoggerFromContext(ctx).Info("skipping json transformation, no filter executable defined")

--- a/step_update_state.go
+++ b/step_update_state.go
@@ -22,7 +22,7 @@ func (s *stepUpdateState) Run(state multistep.StateBag) multistep.StepAction {
 
 	logger := context.LoggerFromContext(ctx).WithField("self", "step_update_state")
 
-	ctx, span := trace.StartSpan(ctx, "stepUpdateState")
+	ctx, span := trace.StartSpan(ctx, "UpdateState.Run")
 	defer span.End()
 
 	instanceID := instance.ID()
@@ -61,7 +61,7 @@ func (s *stepUpdateState) Cleanup(state multistep.StateBag) {
 	ctx := state.Get("ctx").(gocontext.Context)
 	processedAt := state.Get("processedAt").(time.Time)
 
-	ctx, span := trace.StartSpan(ctx, "stepUpdateStateCleanup")
+	ctx, span := trace.StartSpan(ctx, "UpdateState.Cleanup")
 	defer span.End()
 
 	instance := state.Get("instance").(backend.Instance)

--- a/step_update_state.go
+++ b/step_update_state.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/travis-ci/worker/backend"
 	"github.com/travis-ci/worker/context"
+	"go.opencensus.io/trace"
 )
 
 type stepUpdateState struct{}
@@ -20,6 +21,9 @@ func (s *stepUpdateState) Run(state multistep.StateBag) multistep.StepAction {
 	logWriter := state.Get("logWriter").(LogWriter)
 
 	logger := context.LoggerFromContext(ctx).WithField("self", "step_update_state")
+
+	ctx, span := trace.StartSpan(ctx, "stepUpdateState")
+	defer span.End()
 
 	instanceID := instance.ID()
 	if instanceID != "" {
@@ -56,6 +60,9 @@ func (s *stepUpdateState) Cleanup(state multistep.StateBag) {
 	procCtx := state.Get("procCtx").(gocontext.Context)
 	ctx := state.Get("ctx").(gocontext.Context)
 	processedAt := state.Get("processedAt").(time.Time)
+
+	ctx, span := trace.StartSpan(ctx, "stepUpdateStateCleanup")
+	defer span.End()
 
 	instance := state.Get("instance").(backend.Instance)
 	instanceID := instance.ID()

--- a/step_upload_script.go
+++ b/step_upload_script.go
@@ -11,6 +11,7 @@ import (
 	"github.com/travis-ci/worker/backend"
 	"github.com/travis-ci/worker/context"
 	"github.com/travis-ci/worker/metrics"
+	"go.opencensus.io/trace"
 )
 
 type stepUploadScript struct {
@@ -28,6 +29,9 @@ func (s *stepUploadScript) Run(state multistep.StateBag) multistep.StepAction {
 	script := state.Get("script").([]byte)
 
 	logger := context.LoggerFromContext(ctx).WithField("self", "step_upload_script")
+
+	ctx, span := trace.StartSpan(ctx, "stepUploadScript")
+	defer span.End()
 
 	ctx, cancel := gocontext.WithTimeout(ctx, s.uploadTimeout)
 	defer cancel()

--- a/step_upload_script.go
+++ b/step_upload_script.go
@@ -30,7 +30,7 @@ func (s *stepUploadScript) Run(state multistep.StateBag) multistep.StepAction {
 
 	logger := context.LoggerFromContext(ctx).WithField("self", "step_upload_script")
 
-	ctx, span := trace.StartSpan(ctx, "stepUploadScript")
+	ctx, span := trace.StartSpan(ctx, "UploadScript.Run")
 	defer span.End()
 
 	ctx, cancel := gocontext.WithTimeout(ctx, s.uploadTimeout)

--- a/step_write_worker_info.go
+++ b/step_write_worker_info.go
@@ -1,11 +1,13 @@
 package worker
 
 import (
+	gocontext "context"
 	"fmt"
 	"strings"
 
 	"github.com/mitchellh/multistep"
 	"github.com/travis-ci/worker/backend"
+	"go.opencensus.io/trace"
 )
 
 type stepWriteWorkerInfo struct {
@@ -15,6 +17,10 @@ func (s *stepWriteWorkerInfo) Run(state multistep.StateBag) multistep.StepAction
 	logWriter := state.Get("logWriter").(LogWriter)
 	buildJob := state.Get("buildJob").(Job)
 	instance := state.Get("instance").(backend.Instance)
+	ctx := state.Get("ctx").(gocontext.Context)
+
+	ctx, span := trace.StartSpan(ctx, "stepWriteWorkerInfo")
+	defer span.End()
 
 	if hostname, ok := state.Get("hostname").(string); ok && hostname != "" {
 		_, _ = writeFold(logWriter, "worker_info", []byte(strings.Join([]string{

--- a/step_write_worker_info.go
+++ b/step_write_worker_info.go
@@ -19,7 +19,7 @@ func (s *stepWriteWorkerInfo) Run(state multistep.StateBag) multistep.StepAction
 	instance := state.Get("instance").(backend.Instance)
 	ctx := state.Get("ctx").(gocontext.Context)
 
-	ctx, span := trace.StartSpan(ctx, "stepWriteWorkerInfo")
+	ctx, span := trace.StartSpan(ctx, "WriteWorkerInfo.Run")
 	defer span.End()
 
 	if hostname, ok := state.Get("hostname").(string); ok && hostname != "" {

--- a/step_write_worker_info_test.go
+++ b/step_write_worker_info_test.go
@@ -58,6 +58,7 @@ func setupStepWriteWorkerInfo() (*stepWriteWorkerInfo, *byteBufferLogWriter, mul
 	}
 
 	state := &multistep.BasicStateBag{}
+	state.Put("ctx", ctx)
 	state.Put("logWriter", logWriter)
 	state.Put("instance", instance)
 	state.Put("hostname", "frizzlefry.example.local")


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

We merged a stackdriver trace prototype in #512 with a root span that started in `(*Processor).process`
This is a 2nd iteration that adds child spans to all steps added in that func to measure latency in this part of the worker (processor) run. 

## What approach did you choose and why?

ProcessorRun is at the heart of the execution actions in worker.  We wanted to start there. 

## How can you test this?

Tested locally running worker on staging.  The incremental addition of each child span in the steps can be seen here 
![webp net-gifmaker](https://user-images.githubusercontent.com/1622229/46749407-a40e9000-cc83-11e8-9f90-15f8270e734a.gif)

## What feedback would you like, if any?

Child spans added have been scoped to [this block of code](https://github.com/travis-ci/worker/blob/master/processor.go#L212-L247) in their individual `step_*` files, including cleanup where applicable.  Are there additional places I should be adding child spans in these files? Omissions? 
