### PR TITLE
Opencensus trace span attributes to Processor.Process.Run root span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
-- backend/gce: preliminary support for obtaining pre-warmed instances from the warmer service
 
 ### Changed
 
@@ -21,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 - trace: opencensus stackdriver trace for worker
+- backend/gce: preliminary support for obtaining pre-warmed instances from the warmer service
 
 ## [4.4.0] - 2018-10-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Security
 
+## [4.5.0] - 2018-10-12
+
+### Added
+- trace: opencensus stackdriver trace for worker
+
 ## [4.4.0] - 2018-10-05
 
 ### Added
@@ -796,7 +801,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/travis-ci/worker/compare/v4.4.0...HEAD
+[Unreleased]: https://github.com/travis-ci/worker/compare/v4.5.0...HEAD
+[4.5.0]: https://github.com/travis-ci/worker/compare/v4.4.0...v4.5.0
 [4.4.0]: https://github.com/travis-ci/worker/compare/v4.3.0...v4.4.0
 [4.3.0]: https://github.com/travis-ci/worker/compare/v4.2.0...v4.3.0
 [4.2.0]: https://github.com/travis-ci/worker/compare/v4.1.2...v4.2.0

--- a/processor.go
+++ b/processor.go
@@ -194,7 +194,7 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 	span.AddAttributes(
 
 		trace.StringAttribute("app", "worker"),
-		trace.Int64Attribute("JobID", (int64(job_id))),
+		trace.Int64Attribute("job_id", (int64(job_id))),
 		trace.StringAttribute("repo", repo),
 		trace.StringAttribute("infra", infra),
 		trace.StringAttribute("site", site),

--- a/processor.go
+++ b/processor.go
@@ -187,12 +187,11 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 	defer span.End()
 
 	span.AddAttributes(
-
 		trace.StringAttribute("app", "worker"),
 		trace.Int64Attribute("job_id", int64(buildJob.Payload().Job.ID)),
-		trace.StringAttribute("repo", string(buildJob.Payload().Repository.Slug)),
-		trace.StringAttribute("infra", string(p.config.ProviderName)),
-		trace.StringAttribute("site", string(p.config.TravisSite)),
+		trace.StringAttribute("repo", buildJob.Payload().Repository.Slug),
+		trace.StringAttribute("infra", p.config.ProviderName),
+		trace.StringAttribute("site", p.config.TravisSite),
 	)
 
 	state := new(multistep.BasicStateBag)

--- a/processor.go
+++ b/processor.go
@@ -186,8 +186,12 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 	ctx, span := trace.StartSpan(ctx, "ProcessorRun")
 	defer span.End()
 
+	jobID := buildJob.Payload().Job.ID
+
 	span.AddAttributes(
+
 		trace.StringAttribute("app", "worker"),
+		trace.Int64Attribute("JobID", (int64(jobID))),
 	)
 
 	state := new(multistep.BasicStateBag)

--- a/processor.go
+++ b/processor.go
@@ -187,11 +187,13 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 	defer span.End()
 
 	jobID := buildJob.Payload().Job.ID
+	repo := buildJob.Payload().Repository.Slug
 
 	span.AddAttributes(
 
 		trace.StringAttribute("app", "worker"),
 		trace.Int64Attribute("JobID", (int64(jobID))),
+		trace.StringAttribute("repo", repo),
 	)
 
 	state := new(multistep.BasicStateBag)

--- a/processor.go
+++ b/processor.go
@@ -186,7 +186,7 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 	ctx, span := trace.StartSpan(ctx, "ProcessorRun")
 	defer span.End()
 
-	jobID := buildJob.Payload().Job.ID
+	job_id := buildJob.Payload().Job.ID
 	repo := buildJob.Payload().Repository.Slug
 	infra := p.config.ProviderName
 	site := p.config.TravisSite
@@ -194,7 +194,7 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 	span.AddAttributes(
 
 		trace.StringAttribute("app", "worker"),
-		trace.Int64Attribute("JobID", (int64(jobID))),
+		trace.Int64Attribute("JobID", (int64(job_id))),
 		trace.StringAttribute("repo", repo),
 		trace.StringAttribute("infra", infra),
 		trace.StringAttribute("site", site),

--- a/processor.go
+++ b/processor.go
@@ -188,12 +188,16 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 
 	jobID := buildJob.Payload().Job.ID
 	repo := buildJob.Payload().Repository.Slug
+	infra := p.config.ProviderName
+	site := p.config.TravisSite
 
 	span.AddAttributes(
 
 		trace.StringAttribute("app", "worker"),
 		trace.Int64Attribute("JobID", (int64(jobID))),
 		trace.StringAttribute("repo", repo),
+		trace.StringAttribute("infra", infra),
+		trace.StringAttribute("site", site),
 	)
 
 	state := new(multistep.BasicStateBag)

--- a/processor.go
+++ b/processor.go
@@ -186,18 +186,13 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 	ctx, span := trace.StartSpan(ctx, "ProcessorRun")
 	defer span.End()
 
-	job_id := buildJob.Payload().Job.ID
-	repo := buildJob.Payload().Repository.Slug
-	infra := p.config.ProviderName
-	site := p.config.TravisSite
-
 	span.AddAttributes(
 
 		trace.StringAttribute("app", "worker"),
-		trace.Int64Attribute("job_id", (int64(job_id))),
-		trace.StringAttribute("repo", repo),
-		trace.StringAttribute("infra", infra),
-		trace.StringAttribute("site", site),
+		trace.Int64Attribute("job_id", (int64(buildJob.Payload().Job.ID))),
+		trace.StringAttribute("repo", (string(buildJob.Payload().Repository.Slug))),
+		trace.StringAttribute("infra", (string(p.config.ProviderName))),
+		trace.StringAttribute("site", (string(p.config.TravisSite))),
 	)
 
 	state := new(multistep.BasicStateBag)

--- a/processor.go
+++ b/processor.go
@@ -189,10 +189,10 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 	span.AddAttributes(
 
 		trace.StringAttribute("app", "worker"),
-		trace.Int64Attribute("job_id", (int64(buildJob.Payload().Job.ID))),
-		trace.StringAttribute("repo", (string(buildJob.Payload().Repository.Slug))),
-		trace.StringAttribute("infra", (string(p.config.ProviderName))),
-		trace.StringAttribute("site", (string(p.config.TravisSite))),
+		trace.Int64Attribute("job_id", int64(buildJob.Payload().Job.ID)),
+		trace.StringAttribute("repo", string(buildJob.Payload().Repository.Slug)),
+		trace.StringAttribute("infra", string(p.config.ProviderName)),
+		trace.StringAttribute("site", string(p.config.TravisSite)),
 	)
 
 	state := new(multistep.BasicStateBag)

--- a/step_check_cancellation.go
+++ b/step_check_cancellation.go
@@ -15,7 +15,7 @@ func (s *stepCheckCancellation) Run(state multistep.StateBag) multistep.StepActi
 
 	ctx := state.Get("ctx").(gocontext.Context)
 
-	ctx, span := trace.StartSpan(ctx, "stepCheckCancellation")
+	ctx, span := trace.StartSpan(ctx, "CheckCancellation.Run")
 	defer span.End()
 
 	select {


### PR DESCRIPTION
Refs https://github.com/travis-ci/reliability/issues/198

## What is the problem that this PR is trying to fix?
Follow up to #512 #516.  Once this is deployed to production, we want to be able to do filter queries in stackdriver based on infra/site, repo, or job_id. 

## What approach did you choose and why?
Since we'll be doing other root spans in https://github.com/travis-ci/reliability/issues/199 that will need different attributes, I didn't want to declare attributes globally for all root spans, kept it to where the root span is declared. 

## How can you test this?

Running worker locally. You'll get these in the stackdriver console.

![screen shot 2018-10-12 at 8 25 49 am](https://user-images.githubusercontent.com/1622229/46869050-8878c600-cdf8-11e8-8bea-dab323d248da.png)


## What feedback would you like, if any?

As we add more root spans, does it makes sense to have a top-level attribute declaration to omit duplication?  Other? 
