### PR TITLE
processor: track cumulative per-job timings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- processor: track cumulative per-job timings
 
 ### Changed
 - backend/gce: propagate warmed instance name and ip correctly

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -582,6 +582,8 @@ func (p *gceProvider) apiRateLimit(ctx gocontext.Context) error {
 	startWait := time.Now()
 	defer metrics.TimeSince("travis.worker.vm.provider.gce.rate-limit", startWait)
 
+	defer context.TimeSince(ctx, "gce_api_rate_limit", time.Now())
+
 	atomic.AddUint64(&p.rateLimitQueueDepth, 1)
 	// This decrements the counter, see the docs for atomic.AddUint64
 	defer atomic.AddUint64(&p.rateLimitQueueDepth, ^uint64(0))
@@ -916,6 +918,8 @@ func (p *gceProvider) stepInsertInstance(c *gceStartContext) multistep.StepActio
 }
 
 func (p *gceProvider) stepWaitForInstanceIP(c *gceStartContext) multistep.StepAction {
+	defer context.TimeSince(c.ctx, "gce_boot_poll", time.Now())
+
 	logger := context.LoggerFromContext(c.ctx).WithField("self", "backend/gce_provider")
 
 	gceInst := &gceInstance{

--- a/context/package.go
+++ b/context/package.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/getsentry/raven-go"
 	"github.com/sirupsen/logrus"
@@ -27,6 +28,7 @@ const (
 	repositoryKey
 	jwtKey
 	instanceIDKey
+	timingsKey
 )
 
 // FromUUID generates a new context with the given context as its parent and
@@ -76,6 +78,25 @@ func FromRepository(ctx context.Context, repository string) context.Context {
 // can be retrieved again using InstanceIDFromContext.
 func FromInstanceID(ctx context.Context, instanceID string) context.Context {
 	return context.WithValue(ctx, instanceIDKey, instanceID)
+}
+
+// WithTimings initializes the timings map in the context, to be mutated
+// by TimeSince for accumulated timings per request
+func WithTimings(ctx context.Context) context.Context {
+	return context.WithValue(ctx, timingsKey, make(map[string]time.Duration))
+}
+
+// TimeSince accumulates timing over the course of a request,
+// it returns "total time this request spent doing X"
+func TimeSince(ctx context.Context, name string, since time.Time) {
+	if timings, ok := ctx.Value(timingsKey).(map[string]time.Duration); ok {
+		elapsed := time.Since(since)
+		if _, ok := timings[name]; ok {
+			timings[name] += elapsed
+		} else {
+			timings[name] = elapsed
+		}
+	}
 }
 
 // UUIDFromContext returns the UUID stored in the context with FromUUID. If no
@@ -132,6 +153,25 @@ func RepositoryFromContext(ctx context.Context) (string, bool) {
 func InstanceIDFromContext(ctx context.Context) (string, bool) {
 	instanceID, ok := ctx.Value(instanceIDKey).(string)
 	return instanceID, ok
+}
+
+// TimingsFromContext returns the timings stored within the context
+func TimingsFromContext(ctx context.Context) (map[string]time.Duration, bool) {
+	timings, ok := ctx.Value(timingsKey).(map[string]time.Duration)
+	return timings, ok
+}
+
+// FormattedTimingsFromContext returns a set of logrus fields
+func FormattedTimingsFromContext(ctx context.Context) logrus.Fields {
+	fields := make(logrus.Fields)
+	timings, ok := TimingsFromContext(ctx)
+	if !ok {
+		return fields
+	}
+	for k, v := range timings {
+		fields[k+"_ms"] = int64(v.Seconds() * 1e3)
+	}
+	return fields
 }
 
 // LoggerFromContext returns a logrus.Entry with the PID of the current process

--- a/processor.go
+++ b/processor.go
@@ -186,6 +186,8 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 	ctx, span := trace.StartSpan(ctx, "ProcessorRun")
 	defer span.End()
 
+	ctx = context.WithTimings(ctx)
+
 	span.AddAttributes(
 		trace.StringAttribute("app", "worker"),
 		trace.Int64Attribute("job_id", int64(buildJob.Payload().Job.ID)),
@@ -257,6 +259,10 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 
 	logger.Info("starting job")
 	runner.Run(state)
-	logger.Info("finished job")
+
+	logger.WithFields(
+		context.FormattedTimingsFromContext(ctx),
+	).Info("finished job")
+
 	p.ProcessedCount++
 }

--- a/step_generate_script.go
+++ b/step_generate_script.go
@@ -20,6 +20,8 @@ func (s *stepGenerateScript) Run(state multistep.StateBag) multistep.StepAction 
 	buildJob := state.Get("buildJob").(Job)
 	ctx := state.Get("ctx").(gocontext.Context)
 
+	defer context.TimeSince(ctx, "step_generate_script_run", time.Now())
+
 	ctx, span := trace.StartSpan(ctx, "GenerateScript.Run")
 	defer span.End()
 

--- a/step_run_script.go
+++ b/step_run_script.go
@@ -33,6 +33,8 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 	logWriter := state.Get("logWriter").(LogWriter)
 	cancelChan := state.Get("cancelChan").(<-chan struct{})
 
+	defer context.TimeSince(ctx, "step_run_script_run", time.Now())
+
 	ctx, span := trace.StartSpan(ctx, "RunScript.Run")
 	defer span.End()
 

--- a/step_sleep.go
+++ b/step_sleep.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/mitchellh/multistep"
+	"github.com/travis-ci/worker/context"
 	"go.opencensus.io/trace"
 )
 
@@ -14,6 +15,8 @@ type stepSleep struct {
 
 func (s *stepSleep) Run(state multistep.StateBag) multistep.StepAction {
 	ctx := state.Get("ctx").(gocontext.Context)
+
+	defer context.TimeSince(ctx, "step_sleep_run", time.Now())
 
 	ctx, span := trace.StartSpan(ctx, "Sleep.Run")
 	defer span.End()

--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -26,6 +26,8 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 	logger := context.LoggerFromContext(ctx).WithField("self", "step_start_instance")
 	logWriter := state.Get("logWriter").(LogWriter)
 
+	defer context.TimeSince(ctx, "step_start_instance_run", time.Now())
+
 	ctx, span := trace.StartSpan(ctx, "StartInstance.Run")
 	defer span.End()
 

--- a/step_upload_script.go
+++ b/step_upload_script.go
@@ -30,6 +30,8 @@ func (s *stepUploadScript) Run(state multistep.StateBag) multistep.StepAction {
 
 	logger := context.LoggerFromContext(ctx).WithField("self", "step_upload_script")
 
+	defer context.TimeSince(ctx, "step_upload_script_run", time.Now())
+
 	ctx, span := trace.StartSpan(ctx, "UploadScript.Run")
 	defer span.End()
 


### PR DESCRIPTION
This patch tracks a cumulative sum of timings per-job. It answers the question "how much time of this job was spent on X", where X is currently the duration of various steps, as well as the cumulative time spent in the rate limiter.

Sample log output:

```
time="2018-10-16T18:32:20+02:00" level=info msg="finished job" gce_api_rate_limit_ms=2261 gce_boot_poll_ms=5736 job_id=729708 job_path=igorwwwwwwwwwwwwwwwwwwww/hello-world/jobs/729708 pid=61852 processor=dc6e4c01-1771-4689-ae47-e022e70f7ecf@61852.gopher.local repository=igorwwwwwwwwwwwwwwwwwwww/hello-world self=processor step_generate_script_run_ms=554 step_run_script_run_ms=17666 step_sleep_run_ms=1004 step_start_instance_run_ms=10026 step_upload_script_run_ms=28569
```

This will also go into honeycomb.