### PR TITLE
move context.WithTimings before root span creation

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -183,10 +183,10 @@ func (p *Processor) Terminate() {
 }
 
 func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
+	ctx = context.WithTimings(ctx)
+
 	ctx, span := trace.StartSpan(ctx, "ProcessorRun")
 	defer span.End()
-
-	ctx = context.WithTimings(ctx)
 
 	span.AddAttributes(
 		trace.StringAttribute("app", "worker"),


### PR DESCRIPTION
Tiny follow-up to https://github.com/travis-ci/worker/pull/522.