### PR TITLE
Expand set of traced functions (ratelimit, backend/gce, GCEapi)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
-- processor: track cumulative per-job timings
 
 ### Changed
-- build: update all dependencies, build binaries via go 1.11.1
-- backend/gce: propagate warmed instance name and ip correctly
+- trace: expanded set of trace functions for stackdriver trace
+    * ratelimit (redis and GCE API rate limiting)
+    * backend/gce
+    * amqp_job
 
 ### Deprecated
 

--- a/amqp_job.go
+++ b/amqp_job.go
@@ -143,9 +143,6 @@ func (j *amqpJob) Finish(ctx gocontext.Context, state FinishState) error {
 }
 
 func (j *amqpJob) LogWriter(ctx gocontext.Context, defaultLogTimeout time.Duration) (LogWriter, error) {
-	ctx, span := trace.StartSpan(ctx, "amqpJob.LogWriter")
-	defer span.End()
-
 	logTimeout := time.Duration(j.payload.Timeouts.LogSilence) * time.Second
 	if logTimeout == 0 {
 		logTimeout = defaultLogTimeout
@@ -155,9 +152,6 @@ func (j *amqpJob) LogWriter(ctx gocontext.Context, defaultLogTimeout time.Durati
 }
 
 func (j *amqpJob) createStateUpdateBody(ctx gocontext.Context, state string) map[string]interface{} {
-	ctx, span := trace.StartSpan(ctx, "amqpJob.createStateUpdateBody")
-	defer span.End()
-
 	body := map[string]interface{}{
 		"id":    j.Payload().Job.ID,
 		"state": state,
@@ -210,9 +204,6 @@ func (j *amqpJob) sendStateUpdate(ctx gocontext.Context, event, state string) er
 }
 
 func (j *amqpJob) SetupContext(ctx gocontext.Context) gocontext.Context {
-	ctx, span := trace.StartSpan(ctx, "amqpJob.SetupContext")
-	defer span.End()
-
 	return ctx
 }
 

--- a/amqp_job.go
+++ b/amqp_job.go
@@ -103,6 +103,7 @@ func (j *amqpJob) Received(ctx gocontext.Context) error {
 func (j *amqpJob) Started(ctx gocontext.Context) error {
 	ctx, span := trace.StartSpan(ctx, "amqpJob.Started")
 	defer span.End()
+
 	j.started = time.Now()
 
 	metrics.TimeSince("travis.worker.job.start_time", j.received)
@@ -113,6 +114,7 @@ func (j *amqpJob) Started(ctx gocontext.Context) error {
 func (j *amqpJob) Finish(ctx gocontext.Context, state FinishState) error {
 	ctx, span := trace.StartSpan(ctx, "amqpJob.Finished")
 	defer span.End()
+
 	j.finished = time.Now()
 
 	if j.received.IsZero() {

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -35,6 +35,7 @@ import (
 	"github.com/travis-ci/worker/remote"
 	"github.com/travis-ci/worker/ssh"
 	"github.com/travis-ci/worker/winrm"
+	"go.opencensus.io/trace"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/jwt"
 	"google.golang.org/api/compute/v1"
@@ -578,6 +579,9 @@ func newGCEProvider(cfg *config.ProviderConfig) (Provider, error) {
 }
 
 func (p *gceProvider) apiRateLimit(ctx gocontext.Context) error {
+	ctx, span := trace.StartSpan(ctx, "apiRateLimit")
+	defer span.End()
+
 	metrics.Gauge("travis.worker.vm.provider.gce.rate-limit.queue", int64(p.rateLimitQueueDepth))
 	startWait := time.Now()
 	defer metrics.TimeSince("travis.worker.vm.provider.gce.rate-limit", startWait)

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -589,7 +589,7 @@ func (p *gceProvider) apiRateLimit(ctx gocontext.Context) error {
 	errCount := 0
 
 	for {
-		ok, err := p.rateLimiter.RateLimit("gce-api", p.rateLimitMaxCalls, p.rateLimitDuration)
+		ok, err := p.rateLimiter.RateLimit(ctx, "gce-api", p.rateLimitMaxCalls, p.rateLimitDuration)
 		if err != nil {
 			errCount++
 			if errCount >= 5 {

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -1374,6 +1374,7 @@ type warmerResponse struct {
 func (i *gceInstance) sshConnection(ctx gocontext.Context) (remote.Remoter, error) {
 	ctx, span := trace.StartSpan(ctx, "GCE.sshConnection")
 	defer span.End()
+
 	ip, err := i.getCachedIP(ctx)
 	if err != nil {
 		return nil, err

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -17,23 +17,23 @@ const (
 	redisRateLimiterPoolIdleTimeout = 3 * time.Minute
 )
 
+// RateLimiter checks if a call can be let through and returns true if it can.
+//
+// The name should be the same for all calls that should be affected by the
+// same rate limit. The maxCalls and per arguments must be the same for all
+// calls that use the same name, otherwise the behaviour is undefined.
+//
+// The rate limiter lets through maxCalls calls in a window of time specified
+// by the "per" argument. Note that the window is not sliding, so if you say 10
+// calls per minute, and 10 calls happen in the first second, no further calls
+// will be let through for another 59 seconds.
+//
+// The actual call should only be made if (true, nil) is returned. If (false,
+// nil) is returned, it means that the number of requests in the time window is
+// met, and you should sleep for a bit and try again.
+//
+// In case an error happens, (false, err) is returned.
 type RateLimiter interface {
-	// RateLimit checks if a call can be let through and returns true if it can.
-	//
-	// The name should be the same for all calls that should be affected by the
-	// same rate limit. The maxCalls and per arguments must be the same for all
-	// calls that use the same name, otherwise the behaviour is undefined.
-	//
-	// The rate limiter lets through maxCalls calls in a window of time specified
-	// by the "per" argument. Note that the window is not sliding, so if you say 10
-	// calls per minute, and 10 calls happen in the first second, no further calls
-	// will be let through for another 59 seconds.
-	//
-	// The actual call should only be made if (true, nil) is returned. If (false,
-	// nil) is returned, it means that the number of requests in the time window is
-	// met, and you should sleep for a bit and try again.
-	//
-	// In case an error happens, (false, err) is returned.
 	RateLimit(ctx gocontext.Context, name string, maxCalls uint64, per time.Duration) (bool, error)
 }
 

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -127,6 +127,6 @@ func (rl *redisRateLimiter) RateLimit(ctx gocontext.Context, name string, maxCal
 	return true, nil
 }
 
-func (rl nullRateLimiter) RateLimit(cxt gocontext.Context, name string, maxCalls uint64, per time.Duration) (bool, error) {
+func (rl nullRateLimiter) RateLimit(ctx gocontext.Context, name string, maxCalls uint64, per time.Duration) (bool, error) {
 	return true, nil
 }

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -35,7 +35,7 @@ func TestRateLimit(t *testing.T) {
 		t.Fatal("expected to not get rate limited, but was limited")
 	}
 
-	ok, err = rateLimiter.RateLimit("slow", 2, time.Hour)
+	ok, err = rateLimiter.RateLimit(context.TODO(), "slow", 2, time.Hour)
 	if err != nil {
 		t.Fatalf("rate limiter error: %v", err)
 	}

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -1,6 +1,7 @@
 package ratelimit
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -18,7 +19,7 @@ func TestRateLimit(t *testing.T) {
 
 	rateLimiter := NewRateLimiter(os.Getenv("REDIS_URL"), fmt.Sprintf("worker-test-rl-%d", os.Getpid()))
 
-	ok, err := rateLimiter.RateLimit(ctx, "slow", 2, time.Hour)
+	ok, err := rateLimiter.RateLimit(context.TODO(), "slow", 2, time.Hour)
 	if err != nil {
 		t.Fatalf("rate limiter error: %v", err)
 	}
@@ -26,7 +27,7 @@ func TestRateLimit(t *testing.T) {
 		t.Fatal("expected to not get rate limited, but was limited")
 	}
 
-	ok, err = rateLimiter.RateLimit(ctx, "slow", 2, time.Hour)
+	ok, err = rateLimiter.RateLimit(context.TODO(), "slow", 2, time.Hour)
 	if err != nil {
 		t.Fatalf("rate limiter error: %v", err)
 	}
@@ -34,7 +35,7 @@ func TestRateLimit(t *testing.T) {
 		t.Fatal("expected to not get rate limited, but was limited")
 	}
 
-	ok, err = rateLimiter.RateLimit(ctx, "slow", 2, time.Hour)
+	ok, err = rateLimiter.RateLimit("slow", 2, time.Hour)
 	if err != nil {
 		t.Fatalf("rate limiter error: %v", err)
 	}

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -18,7 +18,7 @@ func TestRateLimit(t *testing.T) {
 
 	rateLimiter := NewRateLimiter(os.Getenv("REDIS_URL"), fmt.Sprintf("worker-test-rl-%d", os.Getpid()))
 
-	ok, err := rateLimiter.RateLimit("slow", 2, time.Hour)
+	ok, err := rateLimiter.RateLimit(ctx, "slow", 2, time.Hour)
 	if err != nil {
 		t.Fatalf("rate limiter error: %v", err)
 	}
@@ -26,7 +26,7 @@ func TestRateLimit(t *testing.T) {
 		t.Fatal("expected to not get rate limited, but was limited")
 	}
 
-	ok, err = rateLimiter.RateLimit("slow", 2, time.Hour)
+	ok, err = rateLimiter.RateLimit(ctx, "slow", 2, time.Hour)
 	if err != nil {
 		t.Fatalf("rate limiter error: %v", err)
 	}
@@ -34,7 +34,7 @@ func TestRateLimit(t *testing.T) {
 		t.Fatal("expected to not get rate limited, but was limited")
 	}
 
-	ok, err = rateLimiter.RateLimit("slow", 2, time.Hour)
+	ok, err = rateLimiter.RateLimit(ctx, "slow", 2, time.Hour)
 	if err != nil {
 		t.Fatalf("rate limiter error: %v", err)
 	}


### PR DESCRIPTION
Refs https://github.com/travis-ci/reliability/issues/199

## What is the problem that this PR is trying to fix?

See the steps and latency of things in our 
* backend/gce infra, including GCEAPI rate limiting
* redis rate limiting

## What approach did you choose and why?
Extension of  #516 

## How can you test this?
Running worker locally and viewing the traces on stackdriver staging project.  An example of an expanded trace is [here](https://console.cloud.google.com/traces/traces?project=travis-staging-1&organizationId=928883094116&q=%2Bapp:worker&tid=dbc795f7d2ec1089f71e12b013ec2c3c&start=1539812529379&end=1539816129379)

## What feedback would you like, if any?

what expanded traces would be useful, what would be noise? 
I tried to trace http requests in image.makeImageRequest in `api_selector.go` , but ran into some problems. 
