### PR TITLE
google: support loading default credentials for gce and stackdriver

### DIFF
--- a/backend/gce.go
+++ b/backend/gce.go
@@ -39,6 +39,7 @@ import (
 	"github.com/travis-ci/worker/winrm"
 	"go.opencensus.io/trace"
 	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
@@ -676,7 +677,11 @@ func (p *gceProvider) Setup(ctx gocontext.Context) error {
 
 func buildGoogleComputeService(cfg *config.ProviderConfig) (*compute.Service, error) {
 	if !cfg.IsSet("ACCOUNT_JSON") {
-		return nil, fmt.Errorf("missing ACCOUNT_JSON")
+		client, err := google.DefaultClient(gocontext.TODO(), compute.DevstorageFullControlScope, compute.ComputeScope)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not build default client")
+		}
+		return compute.New(client)
 	}
 
 	a, err := loadGoogleAccountJSON(cfg.Get("ACCOUNT_JSON"))

--- a/cli.go
+++ b/cli.go
@@ -140,8 +140,7 @@ func (i *CLI) Setup() (bool, error) {
 	i.setupSentry()
 	i.setupMetrics()
 
-	err := i.setupOpenCensus(i.Config.StackdriverTraceAccountJSON)
-
+	err := i.setupOpenCensus
 	if err != nil {
 		logger.WithField("err", err).Error("failed to set up opencensus")
 		return false, err
@@ -354,6 +353,11 @@ func (i *CLI) setupMetrics() {
 }
 
 func loadStackdriverTraceJSON(ctx gocontext.Context, stackdriverTraceAccountJSON string) (*google.Credentials, error) {
+	if stackdriverTraceAccountJSON == "" {
+		client, err := google.FindDefaultCredentials(gocontext.TODO(), googlecloudtrace.ScopeTraceAppend)
+		return client, errors.Wrap(err, "could not build default client")
+	}
+
 	credBytes, err := loadBytes(stackdriverTraceAccountJSON)
 	if err != nil {
 		return nil, err
@@ -384,14 +388,14 @@ func loadBytes(filenameOrJSON string) ([]byte, error) {
 	return bytes, nil
 }
 
-func (i *CLI) setupOpenCensus(stackdriverTraceAccountJSON string) error {
+func (i *CLI) setupOpenCensus() error {
 	opencensusEnabled := i.Config.OpencensusTracingEnabled
 
 	if !opencensusEnabled {
 		return nil
 	}
 
-	creds, err := loadStackdriverTraceJSON(gocontext.TODO(), stackdriverTraceAccountJSON)
+	creds, err := loadStackdriverTraceJSON(gocontext.TODO(), i.Config.StackdriverTraceAccountJSON)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We currently require an `account.json` file for google cloud authentication. Additionally setting the JSON in the env var directly is broken, because our config parser URL-decodes _everything_.

To integrate more nicely with the `gcloud` command line tooling (`gcloud auth application-default login`), we should have a much easier time setting up worker.

The main goal however is to allow integrating with [Service Accounts for Instances](https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances), so that we can run worker without requiring any additional JSON files at all.

refs https://github.com/travis-ci/reliability/issues/200