### PR TITLE
opencensus: fix orphaned spans

### DIFF
--- a/backend/gce.go
+++ b/backend/gce.go
@@ -591,8 +591,11 @@ func newGCEProvider(cfg *config.ProviderConfig) (Provider, error) {
 }
 
 func (p *gceProvider) apiRateLimit(ctx gocontext.Context) error {
-	ctx, span := trace.StartSpan(ctx, "apiRateLimit")
-	defer span.End()
+	if trace.FromContext(ctx) != nil {
+		var span *trace.Span
+		ctx, span = trace.StartSpan(ctx, "apiRateLimit")
+		defer span.End()
+	}
 
 	metrics.Gauge("travis.worker.vm.provider.gce.rate-limit.queue", int64(p.rateLimitQueueDepth))
 	startWait := time.Now()

--- a/processor.go
+++ b/processor.go
@@ -183,6 +183,7 @@ func (p *Processor) Terminate() {
 }
 
 func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
+	ctx = buildJob.SetupContext(ctx)
 	ctx = context.WithTimings(ctx)
 
 	ctx, span := trace.StartSpan(ctx, "ProcessorRun")
@@ -200,8 +201,7 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 	state.Put("hostname", p.ID)
 	state.Put("buildJob", buildJob)
 	state.Put("logWriterFactory", p.logWriterFactory)
-	state.Put("procCtx", buildJob.SetupContext(p.ctx))
-	state.Put("ctx", buildJob.SetupContext(ctx))
+	state.Put("ctx", ctx)
 	state.Put("processedAt", time.Now().UTC())
 	state.Put("infra", p.config.Infra)
 

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -81,8 +81,11 @@ func (rl *redisRateLimiter) RateLimit(ctx gocontext.Context, name string, maxCal
 	conn := rl.pool.Get()
 	defer conn.Close()
 
-	ctx, span := trace.StartSpan(ctx, "Redis.RateLimit")
-	defer span.End()
+	if trace.FromContext(ctx) != nil {
+		var span *trace.Span
+		ctx, span = trace.StartSpan(ctx, "Redis.RateLimit")
+		defer span.End()
+	}
 
 	now := time.Now()
 	timestamp := now.Unix() - (now.Unix() % int64(per.Seconds()))

--- a/step_check_cancellation.go
+++ b/step_check_cancellation.go
@@ -20,14 +20,13 @@ func (s *stepCheckCancellation) Run(state multistep.StateBag) multistep.StepActi
 
 	select {
 	case <-cancelChan:
-		procCtx := state.Get("procCtx").(gocontext.Context)
 		ctx := state.Get("ctx").(gocontext.Context)
 		buildJob := state.Get("buildJob").(Job)
 		if _, ok := state.GetOk("logWriter"); ok {
 			logWriter := state.Get("logWriter").(LogWriter)
-			s.writeLogAndFinishWithState(procCtx, ctx, logWriter, buildJob, FinishStateCancelled, "\n\nDone: Job Cancelled\n\n")
+			s.writeLogAndFinishWithState(ctx, logWriter, buildJob, FinishStateCancelled, "\n\nDone: Job Cancelled\n\n")
 		} else {
-			err := buildJob.Finish(procCtx, FinishStateCancelled)
+			err := buildJob.Finish(ctx, FinishStateCancelled)
 			if err != nil {
 				context.LoggerFromContext(ctx).WithField("err", err).WithField("state", FinishStateCancelled).Error("couldn't update job state")
 			}
@@ -41,7 +40,7 @@ func (s *stepCheckCancellation) Run(state multistep.StateBag) multistep.StepActi
 
 func (s *stepCheckCancellation) Cleanup(state multistep.StateBag) {}
 
-func (s *stepCheckCancellation) writeLogAndFinishWithState(procCtx, ctx gocontext.Context, logWriter LogWriter, buildJob Job, state FinishState, logMessage string) {
+func (s *stepCheckCancellation) writeLogAndFinishWithState(ctx gocontext.Context, logWriter LogWriter, buildJob Job, state FinishState, logMessage string) {
 	ctx, span := trace.StartSpan(ctx, "WriteLogAndFinishWithState.CheckCancellation")
 	defer span.End()
 
@@ -50,7 +49,7 @@ func (s *stepCheckCancellation) writeLogAndFinishWithState(procCtx, ctx gocontex
 		context.LoggerFromContext(ctx).WithField("err", err).Error("couldn't write final log message")
 	}
 
-	err = buildJob.Finish(procCtx, state)
+	err = buildJob.Finish(ctx, state)
 	if err != nil {
 		context.LoggerFromContext(ctx).WithField("err", err).WithField("state", state).Error("couldn't update job state")
 	}

--- a/step_generate_script.go
+++ b/step_generate_script.go
@@ -16,7 +16,6 @@ type stepGenerateScript struct {
 }
 
 func (s *stepGenerateScript) Run(state multistep.StateBag) multistep.StepAction {
-	procCtx := state.Get("procCtx").(gocontext.Context)
 	buildJob := state.Get("buildJob").(Job)
 	ctx := state.Get("ctx").(gocontext.Context)
 
@@ -47,7 +46,7 @@ func (s *stepGenerateScript) Run(state multistep.StateBag) multistep.StepAction 
 
 	if err != nil {
 		logger.WithField("err", err).Error("couldn't generate build script, erroring job")
-		err := buildJob.Error(procCtx, "An error occurred while generating the build script.")
+		err := buildJob.Error(ctx, "An error occurred while generating the build script.")
 		if err != nil {
 			logger.WithField("err", err).Error("couldn't requeue job")
 		}

--- a/step_open_log_writer.go
+++ b/step_open_log_writer.go
@@ -17,7 +17,6 @@ type stepOpenLogWriter struct {
 }
 
 func (s *stepOpenLogWriter) Run(state multistep.StateBag) multistep.StepAction {
-	procCtx := state.Get("procCtx").(gocontext.Context)
 	ctx := state.Get("ctx").(gocontext.Context)
 	buildJob := state.Get("buildJob").(Job)
 	logWriterFactory := state.Get("logWriterFactory")
@@ -41,7 +40,7 @@ func (s *stepOpenLogWriter) Run(state multistep.StateBag) multistep.StepAction {
 		}).Error("couldn't open a log writer, attempting requeue")
 		context.CaptureError(ctx, err)
 
-		err := buildJob.Requeue(procCtx)
+		err := buildJob.Requeue(ctx)
 		if err != nil {
 			logger.WithField("err", err).Error("couldn't requeue job")
 		}

--- a/step_open_log_writer_test.go
+++ b/step_open_log_writer_test.go
@@ -37,7 +37,6 @@ func setupStepOpenLogWriter() (*stepOpenLogWriter, multistep.StateBag) {
 
 	state := &multistep.BasicStateBag{}
 	state.Put("ctx", ctx)
-	state.Put("procCtx", ctx)
 	state.Put("buildJob", job)
 
 	return s, state

--- a/step_update_state.go
+++ b/step_update_state.go
@@ -59,7 +59,6 @@ func (s *stepUpdateState) Run(state multistep.StateBag) multistep.StepAction {
 
 func (s *stepUpdateState) Cleanup(state multistep.StateBag) {
 	buildJob := state.Get("buildJob").(Job)
-	procCtx := state.Get("procCtx").(gocontext.Context)
 	ctx := state.Get("ctx").(gocontext.Context)
 	processedAt := state.Get("processedAt").(time.Time)
 
@@ -90,11 +89,11 @@ func (s *stepUpdateState) Cleanup(state multistep.StateBag) {
 
 		switch result.ExitCode {
 		case 0:
-			err = buildJob.Finish(procCtx, FinishStatePassed)
+			err = buildJob.Finish(ctx, FinishStatePassed)
 		case 1:
-			err = buildJob.Finish(procCtx, FinishStateFailed)
+			err = buildJob.Finish(ctx, FinishStateFailed)
 		default:
-			err = buildJob.Finish(procCtx, FinishStateErrored)
+			err = buildJob.Finish(ctx, FinishStateErrored)
 		}
 
 		if err != nil {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

There's some odd orphaned spans in stackdriver. This happens because the context being passed in is not always an actual child of the `Processor.process` one.

![screen shot 2018-10-19 at 17 11 02](https://user-images.githubusercontent.com/11158255/47227019-286abc80-d3c2-11e8-87ee-276c830e1f2d.png)

I believe some of these were introduced by https://github.com/travis-ci/worker/pull/526.

## What approach did you choose and why?

Some of them are from before the processor runs, during processor startup. For those, we can check that there is a parent span, and only record additional ones if that is the case.

In other cases we are using `procCtx`, a kind of processor-wide context. From what I've been able to tell, we do this to avoid running into issues with context timeouts, where we cannot do critical things like requeues.

My attempt at fixing that replaces `procCtx` with a copy of `ctx` that is made right before the timeout is applied. This way the timeout does not apply for the critical actions, but other properties of the context are still preserved.

I'd definitely like to know if there are any other reasons for the `procCtx`, and whether there is anything that could break by changing it this way.
