### PR TITLE
processor: log image name in job finished summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
     * backend/gce
     * amqp_job
 - google: support loading default credentials
+- processor: log image name in job finished summary
 
 ### Deprecated
 

--- a/processor.go
+++ b/processor.go
@@ -261,8 +261,8 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 	runner.Run(state)
 
 	fields := context.LoggerTimingsFromContext(ctx)
-	instance := state.Get("instance").(backend.Instance)
-	if instance != nil {
+	instance, ok := state.Get("instance").(backend.Instance)
+	if ok {
 		fields["instance_id"] = instance.ID()
 		fields["image_name"] = instance.ImageName()
 	}

--- a/processor.go
+++ b/processor.go
@@ -260,9 +260,13 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 	logger.Info("starting job")
 	runner.Run(state)
 
-	logger.WithFields(
-		context.LoggerTimingsFromContext(ctx),
-	).Info("finished job")
+	fields := context.LoggerTimingsFromContext(ctx)
+	instance := state.Get("instance").(backend.Instance)
+	if instance != nil {
+		fields["instance_id"] = instance.ID()
+		fields["image_name"] = instance.ImageName()
+	}
+	logger.WithFields(fields).Info("finished job")
 
 	p.ProcessedCount++
 }


### PR DESCRIPTION
This will allow us to see time-to-ssh grouped by image in honeycomb, which should help figure out if there is any image-specific correlation for outliers.