### PR TITLE
backend/gce: annotate trace with ssh attempt error

### DIFF
--- a/backend/gce.go
+++ b/backend/gce.go
@@ -1453,7 +1453,15 @@ func (i *gceInstance) sshConnection(ctx gocontext.Context) (remote.Remoter, erro
 		return nil, err
 	}
 
-	return i.sshDialer.Dial(fmt.Sprintf("%s:22", ip), i.authUser, i.provider.sshDialTimeout)
+	conn, err := i.sshDialer.Dial(fmt.Sprintf("%s:22", ip), i.authUser, i.provider.sshDialTimeout)
+	if err != nil {
+		span.SetStatus(trace.Status{
+			Code:    trace.StatusCodeUnavailable,
+			Message: err.Error(),
+		})
+	}
+
+	return conn, err
 }
 
 func (i *gceInstance) winrmRemoter(ctx gocontext.Context) (remote.Remoter, error) {


### PR DESCRIPTION
This should allow us to tell what the SSH dial attempts are failing with during `boot_poll_ssh`.

It would be interesting to see if it is networking in general, or something SSH specific.