### PR TITLE
Worker trace v3: /backend/*{all}, image/selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 ### Changed
+-trace:
+    * image/selector, api_selector, env_selector for all backends
 
 ### Deprecated
 

--- a/backend/cloudbrain.go
+++ b/backend/cloudbrain.go
@@ -440,7 +440,7 @@ func (p *cbProvider) imageSelect(ctx gocontext.Context, startAttributes *StartAt
 	jobID, _ := context.JobIDFromContext(ctx)
 	repo, _ := context.RepositoryFromContext(ctx)
 
-	imageName, err := p.imageSelector.Select(&image.Params{
+	imageName, err := p.imageSelector.Select(ctx, &image.Params{
 		Infra:    p.imageSelectorInfra,
 		Language: startAttributes.Language,
 		OsxImage: startAttributes.OsxImage,

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -360,7 +360,7 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 	if startAttributes.ImageName != "" {
 		imageName = startAttributes.ImageName
 	} else {
-		selectedImageID, err := p.imageSelector.Select(&image.Params{
+		selectedImageID, err := p.imageSelector.Select(ctx, &image.Params{
 			Language: startAttributes.Language,
 			Infra:    "docker",
 		})
@@ -836,8 +836,8 @@ func (i *dockerInstance) StartupDuration() time.Duration {
 	return i.startBooting.Sub(containerCreated)
 }
 
-func (s *dockerTagImageSelector) Select(params *image.Params) (string, error) {
-	images, err := s.client.ImageList(gocontext.TODO(), dockertypes.ImageListOptions{All: true})
+func (s *dockerTagImageSelector) Select(ctx gocontext.Context, params *image.Params) (string, error) {
+	images, err := s.client.ImageList(ctx, dockertypes.ImageListOptions{All: true})
 	if err != nil {
 		return "", errors.Wrap(err, "failed to list docker images")
 	}

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -1153,7 +1153,7 @@ func (p *gceProvider) imageSelect(ctx gocontext.Context, startAttributes *StartA
 	if startAttributes.ImageName != "" {
 		imageName = startAttributes.ImageName
 	} else {
-		imageName, err = p.imageSelector.Select(&image.Params{
+		imageName, err = p.imageSelector.Select(ctx, &image.Params{
 			Infra:    "gce",
 			Language: startAttributes.Language,
 			OsxImage: startAttributes.OsxImage,

--- a/backend/jupiterbrain.go
+++ b/backend/jupiterbrain.go
@@ -534,7 +534,7 @@ func (p *jupiterBrainProvider) getImageName(ctx gocontext.Context, startAttribut
 	jobID, _ := context.JobIDFromContext(ctx)
 	repo, _ := context.RepositoryFromContext(ctx)
 
-	return p.imageSelector.Select(&image.Params{
+	return p.imageSelector.Select(ctx, &image.Params{
 		Infra:    "jupiterbrain",
 		Language: startAttributes.Language,
 		OsxImage: startAttributes.OsxImage,

--- a/backend/openstack.go
+++ b/backend/openstack.go
@@ -572,7 +572,7 @@ func (p *osProvider) getImageName(ctx gocontext.Context, startAttributes *StartA
 	jobID, _ := context.JobIDFromContext(ctx)
 	repo, _ := context.RepositoryFromContext(ctx)
 
-	imageName, err := p.imageSelector.Select(&image.Params{
+	imageName, err := p.imageSelector.Select(ctx, &image.Params{
 		Infra:    "openstack",
 		Language: startAttributes.Language,
 		OsxImage: startAttributes.OsxImage,

--- a/image/api_selector.go
+++ b/image/api_selector.go
@@ -134,7 +134,7 @@ func (as *APISelector) makeImageRequest(ctx gocontext.Context, urlString string,
 		}
 
 		req.Header.Add("Content-Type", imageAPIRequestContentType)
-		req.WithContext(ctx)
+		req = req.WithContext(ctx)
 		resp, err := client.Do(req)
 		if err != nil {
 			return err

--- a/image/api_selector.go
+++ b/image/api_selector.go
@@ -10,9 +10,13 @@ import (
 	"strings"
 	"time"
 
+	gocontext "context"
+
 	"github.com/cenk/backoff"
 	"github.com/pkg/errors"
 	workererrors "github.com/travis-ci/worker/errors"
+	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/trace"
 )
 
 const (
@@ -28,8 +32,7 @@ type APISelector struct {
 
 func NewAPISelector(u *url.URL) *APISelector {
 	return &APISelector{
-		baseURL: u,
-
+		baseURL:        u,
 		maxInterval:    10 * time.Second,
 		maxElapsedTime: time.Minute,
 	}
@@ -43,13 +46,13 @@ func (as *APISelector) SetMaxElapsedTime(maxElapsedTime time.Duration) {
 	as.maxElapsedTime = maxElapsedTime
 }
 
-func (as *APISelector) Select(params *Params) (string, error) {
+func (as *APISelector) Select(ctx gocontext.Context, params *Params) (string, error) {
 	tagSets, err := as.buildCandidateTags(params)
 	if err != nil {
 		return "default", err
 	}
 
-	imageName, err := as.queryWithTags(params.Infra, tagSets)
+	imageName, err := as.queryWithTags(ctx, params.Infra, tagSets)
 	if err != nil {
 		return "default", err
 	}
@@ -61,7 +64,10 @@ func (as *APISelector) Select(params *Params) (string, error) {
 	return "default", nil
 }
 
-func (as *APISelector) queryWithTags(infra string, tags []*tagSet) (string, error) {
+func (as *APISelector) queryWithTags(ctx gocontext.Context, infra string, tags []*tagSet) (string, error) {
+	ctx, span := trace.StartSpan(ctx, "APISelector.querywithTags")
+	defer span.End()
+
 	bodyLines := []string{}
 	lastJobID := uint64(0)
 	lastRepo := ""
@@ -98,7 +104,7 @@ func (as *APISelector) queryWithTags(infra string, tags []*tagSet) (string, erro
 		return "", err
 	}
 
-	imageResp, err := as.makeImageRequest(u.String(), bodyLines)
+	imageResp, err := as.makeImageRequest(ctx, u.String(), bodyLines)
 	if err != nil {
 		return "", err
 	}
@@ -110,17 +116,26 @@ func (as *APISelector) queryWithTags(infra string, tags []*tagSet) (string, erro
 	return imageResp.Data[0].Name, nil
 }
 
-func (as *APISelector) makeImageRequest(urlString string, bodyLines []string) (*apiSelectorImageResponse, error) {
+func (as *APISelector) makeImageRequest(ctx gocontext.Context, urlString string, bodyLines []string) (*apiSelectorImageResponse, error) {
 	var responseBody []byte
 
 	b := backoff.NewExponentialBackOff()
 	b.MaxInterval = as.maxInterval
 	b.MaxElapsedTime = as.maxElapsedTime
 
-	err := backoff.Retry(func() error {
-		resp, err := http.Post(urlString, imageAPIRequestContentType,
-			strings.NewReader(strings.Join(bodyLines, "\n")+"\n"))
+	client := &http.Client{
+		Transport: &ochttp.Transport{},
+	}
 
+	err := backoff.Retry(func() error {
+		req, err := http.NewRequest("POST", urlString, strings.NewReader(strings.Join(bodyLines, "\n")+"\n"))
+		if err != nil {
+			return err
+		}
+
+		req.Header.Add("Content-Type", imageAPIRequestContentType)
+		req.WithContext(ctx)
+		resp, err := client.Do(req)
 		if err != nil {
 			return err
 		}

--- a/image/api_selector_test.go
+++ b/image/api_selector_test.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -160,7 +161,7 @@ func TestAPISelector_Select(t *testing.T) {
 
 	as := NewAPISelector(u)
 
-	actual, _ := as.Select(&Params{
+	actual, _ := as.Select(context.TODO(), &Params{
 		Infra:    "test",
 		Language: "ruby",
 		OsxImage: "meow",
@@ -177,7 +178,7 @@ func TestAPISelector_SelectDefault(t *testing.T) {
 	}))
 	defer ts.Close()
 	u, _ := url.Parse(ts.URL)
-	actual, err := NewAPISelector(u).Select(&Params{})
+	actual, err := NewAPISelector(u).Select(context.TODO(), &Params{})
 	assert.Equal(t, actual, "default")
 	assert.NoError(t, err)
 }
@@ -191,7 +192,7 @@ func TestAPISelector_SelectDefaultWhenBadResponse(t *testing.T) {
 	as := NewAPISelector(u)
 	as.SetMaxInterval(time.Millisecond)
 	as.SetMaxElapsedTime(10 * time.Millisecond)
-	actual, err := as.Select(&Params{})
+	actual, err := as.Select(context.TODO(), &Params{})
 	assert.Equal(t, actual, "default")
 	assert.EqualError(t, err, "expected 200 status code from job-board, received status=500 body=\"\"")
 }
@@ -202,7 +203,7 @@ func TestAPISelector_SelectDefaultWhenBadJSON(t *testing.T) {
 	}))
 	defer ts.Close()
 	u, _ := url.Parse(ts.URL)
-	actual, err := NewAPISelector(u).Select(&Params{})
+	actual, err := NewAPISelector(u).Select(context.TODO(), &Params{})
 	assert.Equal(t, actual, "default")
 	assert.EqualError(t, err, "unexpected end of JSON input")
 }
@@ -217,7 +218,7 @@ func TestAPISelector_SelectTrailingComma(t *testing.T) {
 
 	as := NewAPISelector(u)
 
-	actual, err := as.Select(&Params{
+	actual, err := as.Select(context.TODO(), &Params{
 		Infra:    "test,",
 		Language: "ruby,",
 		OsxImage: "meow,",

--- a/image/env_selector.go
+++ b/image/env_selector.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	gocontext "context"
 	"strings"
 
 	"github.com/travis-ci/worker/config"
@@ -32,7 +33,7 @@ func (es *EnvSelector) buildLookup() {
 	es.lookup = lookup
 }
 
-func (es *EnvSelector) Select(params *Params) (string, error) {
+func (es *EnvSelector) Select(ctx gocontext.Context, params *Params) (string, error) {
 	imageName := "default"
 
 	for _, key := range es.buildCandidateKeys(params) {

--- a/image/env_selector_test.go
+++ b/image/env_selector_test.go
@@ -1,6 +1,7 @@
 package image
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -79,7 +80,7 @@ func TestEnvSelector_Select(t *testing.T) {
 		}
 
 		for _, tc := range tesm.O {
-			actual, _ := es.Select(tc.P)
+			actual, _ := es.Select(context.TODO(), tc.P)
 			assert.Equal(t, tc.E, actual, fmt.Sprintf("%#v %q", tc.P, tc.E))
 		}
 	}

--- a/image/selector.go
+++ b/image/selector.go
@@ -1,6 +1,8 @@
 package image
 
+import gocontext "context"
+
 // Selector is the interface for selecting an image!
 type Selector interface {
-	Select(*Params) (string, error)
+	Select(gocontext.Context, *Params) (string, error)
 }

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -38,7 +38,6 @@ type RateLimiter interface {
 }
 
 type redisRateLimiter struct {
-	ctx    gocontext.Context
 	pool   *redis.Pool
 	prefix string
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

refs: https://github.com/travis-ci/reliability/issues/199

This is the last of items of interest to trace in worker, namely:
* any latency in http calls to job-board for /image package and selector interface. 

## What approach did you choose and why?

## How can you test this?
This is a[ staging trace](https://console.cloud.google.com/traces/traces?project=travis-staging-1&authuser=1&organizationId=928883094116&q=%2Bapp:worker&start=1540820511990&end=1540824111990&tid=a456089ccad2eb79bbf2b3e94ef27fe1) ran on this branch 

## What feedback would you like, if any?

De we haz all the interesting bits we want to trace now? 
