### PR TITLE
backend/gce: trace calls to google cloud API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 -trace:
-    * image/selector, api_selector, env_selector for all backends
+    * image/: selector, api_selector, env_selector for all backends
+    * backend/gce: calls to google cloud API
 
 ### Deprecated
 

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -38,6 +38,7 @@ import (
 	"github.com/travis-ci/worker/remote"
 	"github.com/travis-ci/worker/ssh"
 	"github.com/travis-ci/worker/winrm"
+	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/trace"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -717,7 +718,11 @@ func buildGoogleComputeService(cfg *config.ProviderConfig) (*compute.Service, er
 		TokenURL: "https://accounts.google.com/o/oauth2/token",
 	}
 
-	client := config.Client(oauth2.NoContext)
+	ctx := gocontext.WithValue(gocontext.Background(), oauth2.HTTPClient, &http.Client{
+		Transport: &ochttp.Transport{},
+	})
+
+	client := config.Client(ctx)
 
 	if gceCustomHTTPTransport != nil {
 		client.Transport = gceCustomHTTPTransport


### PR DESCRIPTION
Refs: https://github.com/travis-ci/reliability/issues/199
by passing in context through the client
similarly to what was done for gcloud-cleanup
https://github.com/travis-ci/gcloud-cleanup/pull/44

## What is the problem that this PR is trying to fix?
Capture traces for GCE api calls. 

## What approach did you choose and why?
Pass in context through the existing client. 

## How can you test this?
See yourself a trace with GCE api calls [here](https://console.cloud.google.com/traces/traces?project=travis-staging-1&authuser=1&organizationId=928883094116&q=%2Bapp:worker&tid=4e1824e8e932906b21da2552a14c906f)!

## What feedback would you like, if any?

