### PR TITLE
introduce http_proxy variable in docker container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- backend/docker: support for setting `HTTP_PROXY` variable in jobs
 
 ### Changed
 -trace:


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

This is to support http proxies in enterprise, in collaboration with @schultyy.

## What approach did you choose and why?

Setting an environment variable on the docker container. In the long-term, it would probably be better to put this kind of logic into `travis-build` (especially to make this work across infras), but from what I've heard it is currently easier to roll out a newer version of worker on enterprise than travis-build.

So that's what we're going with for now.

## How can you test this?

I'm testing it with a local worker. We can also test it with our enterprise test installation.

It can be tested by setting the environment variable:

```
export TRAVIS_WORKER_DOCKER_HTTP_PROXY=http://proxy:80880
```

That should make the `http_proxy` and `HTTP_PROXY` env vars set in the container.