### PR TITLE
backend/docker: support for additional env vars HTTPS_PROXY, FTP_PROXY, NO_PROXY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 ### Changed
+- backend/docker: additional support for additional env vars `HTTPS_PROXY`, `FTP_PROXY`, `NO_PROXY`
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 ### Changed
-- backend/docker: additional support for additional env vars `HTTPS_PROXY`, `FTP_PROXY`, `NO_PROXY`
 
 ### Deprecated
 
@@ -16,6 +15,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Fixed
 
 ### Security
+
+## [4.6.1] - 2018-10-30
+
+### Changed
+- backend/docker: additional support for additional env vars `HTTPS_PROXY`, `FTP_PROXY`, `NO_PROXY`
 
 ## [4.6.0] - 2018-10-30
 
@@ -832,7 +836,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/travis-ci/worker/compare/v4.6.0...HEAD
+[Unreleased]: https://github.com/travis-ci/worker/compare/v4.6.1...HEAD
+[4.6.1]: https://github.com/travis-ci/worker/compare/v4.6.0...v4.6.1
 [4.6.0]: https://github.com/travis-ci/worker/compare/v4.5.2...v4.6.0
 [4.5.2]: https://github.com/travis-ci/worker/compare/v4.5.1...v4.5.2
 [4.5.1]: https://github.com/travis-ci/worker/compare/v4.5.0...v4.5.1


### PR DESCRIPTION
In addition to `HTTP_PROXY`, we now also support: `HTTPS_PROXY`, `FTP_PROXY`, `NO_PROXY`. This is specifically needed for an enterprise customer.

These can be configured via:

```
export TRAVIS_WORKER_DOCKER_API_VERSION=1.37
export TRAVIS_WORKER_DOCKER_HTTP_PROXY=...
export TRAVIS_WORKER_DOCKER_HTTPS_PROXY=...
export TRAVIS_WORKER_DOCKER_FTP_PROXY=...
export TRAVIS_WORKER_DOCKER_NO_PROXY=...
```

Follow-up to https://github.com/travis-ci/worker/pull/537