### PR TITLE
backend:gce opencensus trace- add time.Sleep calls to processor.Run root span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- trace:
+    * backend/gce: calls to `time.Sleep`
 
 ### Changed
 

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -644,6 +644,12 @@ func (p *gceProvider) apiRateLimit(ctx gocontext.Context) error {
 
 		// Sleep for up to 1 second
 		time.Sleep(time.Millisecond * time.Duration(mathrand.Intn(1000)))
+
+		if trace.FromContext(ctx) != nil {
+			var span *trace.Span
+			ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.apiRateLimit")
+			defer span.End()
+		}
 	}
 }
 
@@ -1062,6 +1068,12 @@ func (p *gceProvider) stepWaitForInstanceIP(c *gceStartContext) multistep.StepAc
 	})
 
 	time.Sleep(p.bootPrePollSleep)
+
+	if trace.FromContext(ctx) != nil {
+		var span *trace.Span
+		ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.WaitForInstanceIP")
+		defer span.End()
+	}
 
 	zoneOpCall := p.client.ZoneOperations.Get(p.projectID, c.zoneName, c.instanceInsertOpName).Context(c.ctx)
 
@@ -1600,6 +1612,12 @@ func (i *gceInstance) UploadScript(ctx gocontext.Context, script []byte) error {
 
 			i.progresser.Progress(&ProgressEntry{Message: ".", Raw: true})
 			time.Sleep(i.provider.uploadRetrySleep)
+			if trace.FromContext(ctx) != nil {
+				var span *trace.Span
+				ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.uploadRetrySleep")
+				defer span.End()
+			}
+
 		}
 	}()
 
@@ -1810,6 +1828,10 @@ func (i *gceInstance) stepWaitForInstanceDeleted(c *gceInstanceStopContext) mult
 	}).Debug("sleeping before first checking instance delete operation")
 
 	time.Sleep(i.ic.StopPrePollSleep)
+
+	//ctx := state.Get("ctx").(gocontext.Context)
+	//ctx, span := trace.StartSpan(ctx, "WaitForInstanceDeleted.StopPrePollSleep")
+	//defer span.End()
 
 	zoneOpCall := i.client.ZoneOperations.Get(i.projectID,
 		i.zoneName, c.instanceDeleteOp.Name)

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -643,12 +643,11 @@ func (p *gceProvider) apiRateLimit(ctx gocontext.Context) error {
 		}
 
 		// Sleep for up to 1 second
+		var span *trace.Span
+		ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.apiRateLimit")
 		time.Sleep(time.Millisecond * time.Duration(mathrand.Intn(1000)))
-		if trace.FromContext(ctx) != nil {
-			var span *trace.Span
-			ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.apiRateLimit")
-			defer span.End()
-		}
+		span.End()
+
 	}
 }
 
@@ -1066,12 +1065,9 @@ func (p *gceProvider) stepWaitForInstanceIP(c *gceStartContext) multistep.StepAc
 		State:   ProgressNeutral,
 	})
 
+	ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.WaitForInstanceIP")
 	time.Sleep(p.bootPrePollSleep)
-	if trace.FromContext(ctx) != nil {
-		var span *trace.Span
-		ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.WaitForInstanceIP")
-		defer span.End()
-	}
+	span.End()
 
 	zoneOpCall := p.client.ZoneOperations.Get(p.projectID, c.zoneName, c.instanceInsertOpName).Context(c.ctx)
 
@@ -1146,12 +1142,11 @@ func (p *gceProvider) stepWaitForInstanceIP(c *gceStartContext) multistep.StepAc
 		}).Debug("sleeping before checking instance insert operation")
 
 		c.progresser.Progress(&ProgressEntry{Message: ".", Raw: true})
+
+		var span *trace.Span
+		ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.afterInstanceInsertCompletion")
 		time.Sleep(p.bootPollSleep)
-		if trace.FromContext(ctx) != nil {
-			var span *trace.Span
-			ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.afterInstanceInsertCompletion")
-			defer span.End()
-		}
+		span.End()
 	}
 }
 
@@ -1614,12 +1609,11 @@ func (i *gceInstance) UploadScript(ctx gocontext.Context, script []byte) error {
 			}
 
 			i.progresser.Progress(&ProgressEntry{Message: ".", Raw: true})
+			var span *trace.Span
+			ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.uploadRetry")
 			time.Sleep(i.provider.uploadRetrySleep)
-			if trace.FromContext(ctx) != nil {
-				var span *trace.Span
-				ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.uploadRetry")
-				defer span.End()
-			}
+			span.End()
+
 		}
 	}()
 
@@ -1829,13 +1823,11 @@ func (i *gceInstance) stepWaitForInstanceDeleted(c *gceInstanceStopContext) mult
 		"duration": i.ic.StopPrePollSleep,
 	}).Debug("sleeping before first checking instance delete operation")
 
-	time.Sleep(i.ic.StopPrePollSleep)
+	var span *trace.Span
 	ctx := c.ctx
-	if trace.FromContext(ctx) != nil {
-		var span *trace.Span
-		ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.WaitForInstanceDeleted")
-		defer span.End()
-	}
+	ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.WaitForInstanceDeleted")
+	time.Sleep(i.ic.StopPrePollSleep)
+	span.End()
 
 	zoneOpCall := i.client.ZoneOperations.Get(i.projectID,
 		i.zoneName, c.instanceDeleteOp.Name)

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -644,10 +644,15 @@ func (p *gceProvider) apiRateLimit(ctx gocontext.Context) error {
 
 		// Sleep for up to 1 second
 		var span *trace.Span
-		ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.apiRateLimit")
-		time.Sleep(time.Millisecond * time.Duration(mathrand.Intn(1000)))
-		span.End()
+		if trace.FromContext(ctx) != nil {
+			ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.apiRateLimit")
+		}
 
+		time.Sleep(time.Millisecond * time.Duration(mathrand.Intn(1000)))
+
+		if trace.StartSpan != nil {
+			span.End()
+		}
 	}
 }
 

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -650,7 +650,7 @@ func (p *gceProvider) apiRateLimit(ctx gocontext.Context) error {
 
 		time.Sleep(time.Millisecond * time.Duration(mathrand.Intn(1000)))
 
-		if ctx != nil {
+		if trace.FromContext(ctx) != nil {
 			span.End()
 		}
 	}

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -644,7 +644,6 @@ func (p *gceProvider) apiRateLimit(ctx gocontext.Context) error {
 
 		// Sleep for up to 1 second
 		time.Sleep(time.Millisecond * time.Duration(mathrand.Intn(1000)))
-
 		if trace.FromContext(ctx) != nil {
 			var span *trace.Span
 			ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.apiRateLimit")
@@ -1068,7 +1067,6 @@ func (p *gceProvider) stepWaitForInstanceIP(c *gceStartContext) multistep.StepAc
 	})
 
 	time.Sleep(p.bootPrePollSleep)
-
 	if trace.FromContext(ctx) != nil {
 		var span *trace.Span
 		ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.WaitForInstanceIP")

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -650,7 +650,7 @@ func (p *gceProvider) apiRateLimit(ctx gocontext.Context) error {
 
 		time.Sleep(time.Millisecond * time.Duration(mathrand.Intn(1000)))
 
-		if trace.StartSpan != nil {
+		if ctx != nil {
 			span.End()
 		}
 	}

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -1620,7 +1620,6 @@ func (i *gceInstance) UploadScript(ctx gocontext.Context, script []byte) error {
 				ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.uploadRetry")
 				defer span.End()
 			}
-
 		}
 	}()
 


### PR DESCRIPTION
Refs https://github.com/travis-ci/reliability/issues/199

## What is the problem that this PR is trying to fix?
Even though we have sleep times as constants during a job run, we don't have any indication of how many times those sleeps are called as a result of retries.  This adds them to worker trace to give us that data. 

## What approach did you choose and why?

Passing in context to `time.Sleep` calls in the same manner as https://github.com/travis-ci/worker/pull/528, so that we don't orphan any outside of the Processor.Run 

## How can you test this?

Staging worker with time.Sleep spans added [here](https://console.cloud.google.com/traces/traces?project=travis-staging-1&tid=ba1e9379f01be950fb19af218ee8c549&start=1541075763880&end=1541079363880&q=ProcessorRun) 

![screen shot 2018-11-01 at 9 46 56 am](https://user-images.githubusercontent.com/1622229/47855484-1f62ed80-ddbb-11e8-865a-9d13655d39df.png)

## What feedback would you like, if any?
I'm not entirely sure if this is the way I should be doing this, I simply followed patterns and this is the only thing that compiled. 😅 
