### PR TITLE
backend/gce: track metric for rate of calls to gce api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 ### Changed
-- backend/gce: track metric for rate of calls to gce api
+- backend/gce: track `worker.google.compute.api.client` metric for rate of calls to gce api
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 ### Changed
+- backend/gce: track metric for rate of calls to gce api
 
 ### Deprecated
 

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -694,9 +694,26 @@ func (p *gceProvider) Setup(ctx gocontext.Context) error {
 	return nil
 }
 
+type MetricsTransport struct {
+	Name      string
+	Transport http.RoundTripper
+}
+
+func (m *MetricsTransport) RoundTrip(req *Request) (*Response, error) {
+	metrics.Mark(m.Name)
+	return m.Transport.RoundTrip(req)
+}
+
 func buildGoogleComputeService(cfg *config.ProviderConfig) (*compute.Service, error) {
+	ctx := gocontext.WithValue(gocontext.Background(), oauth2.HTTPClient, &http.Client{
+		Transport: &MetricsTransport{
+			Name:      "worker.google.compute.api.client",
+			Transport: &ochttp.Transport{},
+		},
+	})
+	
 	if !cfg.IsSet("ACCOUNT_JSON") {
-		client, err := google.DefaultClient(gocontext.TODO(), compute.DevstorageFullControlScope, compute.ComputeScope)
+		client, err := google.DefaultClient(ctx, compute.DevstorageFullControlScope, compute.ComputeScope)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not build default client")
 		}
@@ -717,10 +734,6 @@ func buildGoogleComputeService(cfg *config.ProviderConfig) (*compute.Service, er
 		},
 		TokenURL: "https://accounts.google.com/o/oauth2/token",
 	}
-
-	ctx := gocontext.WithValue(gocontext.Background(), oauth2.HTTPClient, &http.Client{
-		Transport: &ochttp.Transport{},
-	})
 
 	client := config.Client(ctx)
 

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -699,7 +699,7 @@ type MetricsTransport struct {
 	Transport http.RoundTripper
 }
 
-func (m *MetricsTransport) RoundTrip(req *http.Request) (*httpResponse, error) {
+func (m *MetricsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	metrics.Mark(m.Name)
 	return m.Transport.RoundTrip(req)
 }

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -699,7 +699,7 @@ type MetricsTransport struct {
 	Transport http.RoundTripper
 }
 
-func (m *MetricsTransport) RoundTrip(req *Request) (*Response, error) {
+func (m *MetricsTransport) RoundTrip(req *http.Request) (*httpResponse, error) {
 	metrics.Mark(m.Name)
 	return m.Transport.RoundTrip(req)
 }


### PR DESCRIPTION
The goal is to get a better idea of how many calls we are actually sending to the API, since the GCE quotas page only gives us 5 minute averages, and we'll want to know more about the peaks.