### PR TITLE
Do not override context in existing child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Removed
 
 ### Fixed
+- trace:
+    * fixed child span rendering for time.Sleep
 
 ### Security
 

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -645,7 +645,7 @@ func (p *gceProvider) apiRateLimit(ctx gocontext.Context) error {
 		// Sleep for up to 1 second
 		var span *trace.Span
 		if trace.FromContext(ctx) != nil {
-			ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.apiRateLimit")
+			_, span = trace.StartSpan(ctx, "GCE.timeSleep.apiRateLimit")
 		}
 
 		time.Sleep(time.Millisecond * time.Duration(mathrand.Intn(1000)))
@@ -1083,7 +1083,7 @@ func (p *gceProvider) stepWaitForInstanceIP(c *gceStartContext) multistep.StepAc
 		State:   ProgressNeutral,
 	})
 
-	ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.WaitForInstanceIP")
+	_, span = trace.StartSpan(ctx, "GCE.timeSleep.WaitForInstanceIP")
 	time.Sleep(p.bootPrePollSleep)
 	span.End()
 
@@ -1162,7 +1162,7 @@ func (p *gceProvider) stepWaitForInstanceIP(c *gceStartContext) multistep.StepAc
 		c.progresser.Progress(&ProgressEntry{Message: ".", Raw: true})
 
 		var span *trace.Span
-		ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.afterInstanceInsertCompletion")
+		_, span = trace.StartSpan(ctx, "GCE.timeSleep.afterInstanceInsertCompletion")
 		time.Sleep(p.bootPollSleep)
 		span.End()
 	}
@@ -1628,7 +1628,7 @@ func (i *gceInstance) UploadScript(ctx gocontext.Context, script []byte) error {
 
 			i.progresser.Progress(&ProgressEntry{Message: ".", Raw: true})
 			var span *trace.Span
-			ctx, span = trace.StartSpan(ctx, "GCE.timeSleep.uploadRetry")
+			_, span = trace.StartSpan(ctx, "GCE.timeSleep.uploadRetry")
 			time.Sleep(i.provider.uploadRetrySleep)
 			span.End()
 


### PR DESCRIPTION
passing context through a var declaration with the same name as the parent in a loop results in grandchildren-of-children without being tied to their parents.

## What is the problem that this PR is trying to fix?
This weird rendering of a loop child span [here](https://console.cloud.google.com/traces/traces?organizationId=928883094116&project=eco-emissary-99515&tid=0257f175c9cf5650c303e8fc4af246fd&q=%2Bapp:worker&start=1541430390845&end=1541433990845)
## What approach did you choose and why?

use a blank identifier to ignore a new context declaration. 

## How can you test this?
ran a worker in staging, this fixes the span rendering. ✅ 

## What feedback would you like, if any?
