### PR TITLE
Add option for SIGTERM to cause graceful shutdown

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -606,8 +606,13 @@ func (i *CLI) signalHandler() {
 				i.logger.Warn("SIGINT received, starting graceful shutdown")
 				i.ProcessorPool.GracefulShutdown(false)
 			case syscall.SIGTERM:
-				i.logger.Warn("SIGTERM received, shutting down immediately")
-				i.cancel()
+				if i.Config.GracefulExitOnTerm {
+					i.logger.Warn("SIGTERM received, starting graceful shutdown")
+					i.ProcessorPool.GracefulShutdown(false)
+				} else {
+					i.logger.Warn("SIGTERM received, shutting down immediately")
+					i.cancel()
+				}
 			case syscall.SIGTTIN:
 				i.logger.Info("SIGTTIN received, adding processor to pool")
 				i.ProcessorPool.Incr()

--- a/config/config.go
+++ b/config/config.go
@@ -166,6 +166,9 @@ var (
 			Value: defaultMaxLogLength,
 			Usage: "The maximum length of a log in bytes",
 		}),
+		NewConfigDef("GracefulExitOnTerm", &cli.BoolFlag{
+			Usage: "Make SIGTERM cause a graceful shutdown",
+		}),
 		NewConfigDef("JobBoardURL", &cli.StringFlag{
 			Usage: "The base URL for job-board used with http queue",
 		}),
@@ -403,6 +406,7 @@ type Config struct {
 	MaxLogLength        int           `config:"max-log-length"`
 	ScriptUploadTimeout time.Duration `config:"script-upload-timeout"`
 	StartupTimeout      time.Duration `config:"startup-timeout"`
+	GracefulExitOnTerm  bool          `config:"graceful-exit-on-term"`
 
 	BuildTraceEnabled     bool   `config:"build-trace-enabled"`
 	BuildTraceS3Bucket    string `config:"build-trace-s3-bucket"`


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

For rolling out new deployments, Kubernetes will send a SIGTERM to a pod, then wait a configurable amount of time for the process to exit, after which it will send a SIGKILL. It would be ideal if when worker received this SIGTERM, it did a graceful exit, draining the pool as jobs complete. Then we could configure our deployment rollouts to automatically do the right thing.

## What approach did you choose and why?

Rather than change the default behavior of worker, which does this behavior on SIGINT and uses SIGTERM to shutdown immediately, I added a config option that the signal handler checks to determine what to do when a SIGTERM is received.

## How can you test this?

Will deploy to macstadium-staging, kick off some jobs, and try to do a deployment.

## What feedback would you like, if any?

Any.