### PR TITLE
processor: include final error in "finished job" log message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 ### Changed
+- processor: include final error in "finished job" log message
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 ### Changed
-- processor: include final error in "finished job" log message
+- processor: include state, requeue, err in "finished job" log message
 
 ### Deprecated
 

--- a/file_job.go
+++ b/file_job.go
@@ -26,6 +26,8 @@ type fileJob struct {
 	payload         *JobPayload
 	rawPayload      *simplejson.Json
 	startAttributes *backend.StartAttributes
+	finishState     FinishState
+	requeued        bool
 }
 
 func (j *fileJob) Payload() *JobPayload {
@@ -38,6 +40,14 @@ func (j *fileJob) RawPayload() *simplejson.Json {
 
 func (j *fileJob) StartAttributes() *backend.StartAttributes {
 	return j.startAttributes
+}
+
+func (j *fileJob) FinishState() FinishState {
+	return j.finishState
+}
+
+func (j *fileJob) Requeued() bool {
+	return j.requeued
 }
 
 func (j *fileJob) Received(_ gocontext.Context) error {
@@ -66,6 +76,8 @@ func (j *fileJob) Requeue(ctx gocontext.Context) error {
 	context.LoggerFromContext(ctx).WithField("self", "file_job").Info("requeueing job")
 
 	metrics.Mark("worker.job.requeue")
+
+	j.requeued = true
 
 	var err error
 

--- a/http_job.go
+++ b/http_job.go
@@ -25,6 +25,8 @@ type httpJob struct {
 	received        time.Time
 	started         time.Time
 	finished        time.Time
+	finishState     FinishState
+	requeued        bool
 	stateCount      uint
 
 	refreshClaim func(gocontext.Context)
@@ -64,6 +66,14 @@ func (j *httpJob) StartAttributes() *backend.StartAttributes {
 	return j.startAttributes
 }
 
+func (j *httpJob) FinishState() FinishState {
+	return j.finishState
+}
+
+func (j *httpJob) Requeued() bool {
+	return j.requeued
+}
+
 func (j *httpJob) Error(ctx gocontext.Context, errMessage string) error {
 	log, err := j.LogWriter(ctx, time.Minute)
 	if err != nil {
@@ -82,6 +92,8 @@ func (j *httpJob) Requeue(ctx gocontext.Context) error {
 	context.LoggerFromContext(ctx).WithField("self", "http_job").Info("requeueing job")
 
 	metrics.Mark("worker.job.requeue")
+
+	j.requeued = true
 
 	j.received = time.Time{}
 	j.started = time.Time{}

--- a/job.go
+++ b/job.go
@@ -91,6 +91,8 @@ type Job interface {
 	Payload() *JobPayload
 	RawPayload() *simplejson.Json
 	StartAttributes() *backend.StartAttributes
+	FinishState() FinishState
+	Requeued() bool
 
 	Received(gocontext.Context) error
 	Started(gocontext.Context) error

--- a/package_test.go
+++ b/package_test.go
@@ -40,6 +40,8 @@ type fakeJob struct {
 	payload         *JobPayload
 	rawPayload      *simplejson.Json
 	startAttributes *backend.StartAttributes
+	finishState     FinishState
+	requeued        bool
 
 	events []string
 
@@ -56,6 +58,14 @@ func (fj *fakeJob) RawPayload() *simplejson.Json {
 
 func (fj *fakeJob) StartAttributes() *backend.StartAttributes {
 	return fj.startAttributes
+}
+
+func (fj *fakeJob) FinishState() FinishState {
+	return fj.finishState
+}
+
+func (fj *fakeJob) Requeued() bool {
+	return fj.requeued
 }
 
 func (fj *fakeJob) Received(ctx gocontext.Context) error {
@@ -89,6 +99,7 @@ func (fj *fakeJob) Error(ctx gocontext.Context, msg string) error {
 }
 
 func (fj *fakeJob) Requeue(ctx gocontext.Context) error {
+	fj.requeued = true
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -99,6 +110,7 @@ func (fj *fakeJob) Requeue(ctx gocontext.Context) error {
 }
 
 func (fj *fakeJob) Finish(ctx gocontext.Context, state FinishState) error {
+	fj.finishState = state
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/processor.go
+++ b/processor.go
@@ -266,6 +266,10 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 		fields["instance_id"] = instance.ID()
 		fields["image_name"] = instance.ImageName()
 	}
+	err, ok := state.Get("err").(error)
+	if ok {
+		fields["err"] = err
+	}
 	logger.WithFields(fields).Info("finished job")
 
 	p.ProcessedCount++

--- a/processor.go
+++ b/processor.go
@@ -270,6 +270,12 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 	if ok {
 		fields["err"] = err
 	}
+	if fields["state"] != "" {
+		fields["state"] = buildJob.FinishState()
+	}
+	if buildJob.Requeued() {
+		fields["requeued"] = 1
+	}
 	logger.WithFields(fields).Info("finished job")
 
 	p.ProcessedCount++

--- a/processor.go
+++ b/processor.go
@@ -270,7 +270,7 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 	if ok {
 		fields["err"] = err
 	}
-	if fields["state"] != "" {
+	if buildJob.FinishState() != "" {
 		fields["state"] = buildJob.FinishState()
 	}
 	if buildJob.Requeued() {

--- a/step_check_cancellation.go
+++ b/step_check_cancellation.go
@@ -2,11 +2,14 @@ package worker
 
 import (
 	gocontext "context"
+	"errors"
 
 	"github.com/mitchellh/multistep"
 	"github.com/travis-ci/worker/context"
 	"go.opencensus.io/trace"
 )
+
+var JobCancelledError = errors.New("job cancelled")
 
 type stepCheckCancellation struct{}
 
@@ -31,6 +34,7 @@ func (s *stepCheckCancellation) Run(state multistep.StateBag) multistep.StepActi
 				context.LoggerFromContext(ctx).WithField("err", err).WithField("state", FinishStateCancelled).Error("couldn't update job state")
 			}
 		}
+		state.Put("err", JobCancelledError)
 		return multistep.ActionHalt
 	default:
 	}

--- a/step_generate_script.go
+++ b/step_generate_script.go
@@ -45,13 +45,13 @@ func (s *stepGenerateScript) Run(state multistep.StateBag) multistep.StepAction 
 	}
 
 	if err != nil {
+		state.Put("err", err)
+
 		logger.WithField("err", err).Error("couldn't generate build script, erroring job")
 		err := buildJob.Error(ctx, "An error occurred while generating the build script.")
 		if err != nil {
 			logger.WithField("err", err).Error("couldn't requeue job")
 		}
-
-		state.Put("err", err)
 
 		return multistep.ActionHalt
 	}

--- a/step_generate_script.go
+++ b/step_generate_script.go
@@ -51,6 +51,8 @@ func (s *stepGenerateScript) Run(state multistep.StateBag) multistep.StepAction 
 			logger.WithField("err", err).Error("couldn't requeue job")
 		}
 
+		state.Put("err", err)
+
 		return multistep.ActionHalt
 	}
 

--- a/step_open_log_writer.go
+++ b/step_open_log_writer.go
@@ -44,6 +44,9 @@ func (s *stepOpenLogWriter) Run(state multistep.StateBag) multistep.StepAction {
 		if err != nil {
 			logger.WithField("err", err).Error("couldn't requeue job")
 		}
+
+		state.Put("err", err)
+
 		return multistep.ActionHalt
 	}
 	logWriter.SetMaxLogLength(s.maxLogLength)

--- a/step_open_log_writer.go
+++ b/step_open_log_writer.go
@@ -34,6 +34,8 @@ func (s *stepOpenLogWriter) Run(state multistep.StateBag) multistep.StepAction {
 		logWriter, err = buildJob.LogWriter(ctx, s.defaultLogTimeout)
 	}
 	if err != nil {
+		state.Put("err", err)
+
 		logger.WithFields(logrus.Fields{
 			"err":         err,
 			"log_timeout": s.defaultLogTimeout,
@@ -44,8 +46,6 @@ func (s *stepOpenLogWriter) Run(state multistep.StateBag) multistep.StepAction {
 		if err != nil {
 			logger.WithField("err", err).Error("couldn't requeue job")
 		}
-
-		state.Put("err", err)
 
 		return multistep.ActionHalt
 	}

--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -72,6 +72,8 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 				logger.WithField("err", err).WithField("state", FinishStateErrored).Error("couldn't mark job as finished")
 			}
 
+			state.Put("err", err)
+
 			return multistep.ActionHalt
 		}
 
@@ -85,6 +87,8 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 		if err != nil {
 			logger.WithField("err", err).Error("couldn't requeue job")
 		}
+
+		state.Put("err", err)
 
 		return multistep.ActionHalt
 	}

--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -63,6 +63,8 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 	}
 
 	if err != nil {
+		state.Put("err", err)
+
 		jobAbortErr, ok := errors.Cause(err).(workererrors.JobAbortError)
 		if ok {
 			logWriter.WriteAndClose([]byte(jobAbortErr.UserFacingErrorMessage()))
@@ -71,8 +73,6 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 			if err != nil {
 				logger.WithField("err", err).WithField("state", FinishStateErrored).Error("couldn't mark job as finished")
 			}
-
-			state.Put("err", err)
 
 			return multistep.ActionHalt
 		}
@@ -87,8 +87,6 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 		if err != nil {
 			logger.WithField("err", err).Error("couldn't requeue job")
 		}
-
-		state.Put("err", err)
 
 		return multistep.ActionHalt
 	}

--- a/step_upload_script.go
+++ b/step_upload_script.go
@@ -63,6 +63,8 @@ func (s *stepUploadScript) Run(state multistep.StateBag) multistep.StepAction {
 			logger.WithField("err", err).Error("couldn't requeue job")
 		}
 
+		state.Put("err", err)
+
 		return multistep.ActionHalt
 	}
 

--- a/step_upload_script.go
+++ b/step_upload_script.go
@@ -46,6 +46,8 @@ func (s *stepUploadScript) Run(state multistep.StateBag) multistep.StepAction {
 
 	err := instance.UploadScript(ctx, script)
 	if err != nil {
+		state.Put("err", err)
+
 		errMetric := "worker.job.upload.error"
 		if errors.Cause(err) == backend.ErrStaleVM {
 			errMetric += ".stalevm"
@@ -62,8 +64,6 @@ func (s *stepUploadScript) Run(state multistep.StateBag) multistep.StepAction {
 		if err != nil {
 			logger.WithField("err", err).Error("couldn't requeue job")
 		}
-
-		state.Put("err", err)
 
 		return multistep.ActionHalt
 	}


### PR DESCRIPTION
The goal of this is to make it easier to correlate per-job stats with errors. e.g. how does "context deadline exceeded" correlate with how long steps are taking. Where is the time for those errors being spent?

Since honeycomb does not have joins (and it would be impractical due to the sampling anyway), we need to propagate some of this information back up to the top level event.