### PR TITLE
trace: add return code for steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 - processor: include state, requeue, err in "finished job" log message
+- trace: include return code for start_instance, upload_script, run_script, download_trace steps
 
 ### Deprecated
 

--- a/step_download_trace.go
+++ b/step_download_trace.go
@@ -49,6 +49,11 @@ func (s *stepDownloadTrace) Run(state multistep.StateBag) multistep.StepAction {
 
 	buf, err := instance.DownloadTrace(ctx)
 	if err != nil {
+		span.SetStatus(trace.Status{
+			Code:    trace.StatusCodeUnavailable,
+			Message: err.Error(),
+		})
+
 		if err == backend.ErrDownloadTraceNotImplemented || os.IsNotExist(errors.Cause(err)) {
 			logger.WithFields(logrus.Fields{
 				"err": err,
@@ -75,6 +80,11 @@ func (s *stepDownloadTrace) Run(state multistep.StateBag) multistep.StepAction {
 
 	if err != nil {
 		metrics.Mark("worker.job.trace.persist.error")
+
+		span.SetStatus(trace.Status{
+			Code:    trace.StatusCodeUnavailable,
+			Message: err.Error(),
+		})
 
 		logger.WithFields(logrus.Fields{
 			"err": err,

--- a/step_generate_script.go
+++ b/step_generate_script.go
@@ -47,6 +47,11 @@ func (s *stepGenerateScript) Run(state multistep.StateBag) multistep.StepAction 
 	if err != nil {
 		state.Put("err", err)
 
+		span.SetStatus(trace.Status{
+			Code:    trace.StatusCodeUnavailable,
+			Message: err.Error(),
+		})
+
 		logger.WithField("err", err).Error("couldn't generate build script, erroring job")
 		err := buildJob.Error(ctx, "An error occurred while generating the build script.")
 		if err != nil {

--- a/step_start_instance.go
+++ b/step_start_instance.go
@@ -65,6 +65,11 @@ func (s *stepStartInstance) Run(state multistep.StateBag) multistep.StepAction {
 	if err != nil {
 		state.Put("err", err)
 
+		span.SetStatus(trace.Status{
+			Code:    trace.StatusCodeUnavailable,
+			Message: err.Error(),
+		})
+
 		jobAbortErr, ok := errors.Cause(err).(workererrors.JobAbortError)
 		if ok {
 			logWriter.WriteAndClose([]byte(jobAbortErr.UserFacingErrorMessage()))

--- a/step_upload_script.go
+++ b/step_upload_script.go
@@ -48,6 +48,11 @@ func (s *stepUploadScript) Run(state multistep.StateBag) multistep.StepAction {
 	if err != nil {
 		state.Put("err", err)
 
+		span.SetStatus(trace.Status{
+			Code:    trace.StatusCodeUnavailable,
+			Message: err.Error(),
+		})
+
 		errMetric := "worker.job.upload.error"
 		if errors.Cause(err) == backend.ErrStaleVM {
 			errMetric += ".stalevm"


### PR DESCRIPTION
This allows us to see if a step failed in stackdriver, and see what exactly the error was.