### PR TITLE
Make sure we still save the build trace after RunScript errors

### DIFF
--- a/backend/gce.go
+++ b/backend/gce.go
@@ -720,7 +720,7 @@ func buildGoogleComputeService(cfg *config.ProviderConfig) (*compute.Service, er
 			Transport: &ochttp.Transport{},
 		},
 	})
-	
+
 	if !cfg.IsSet("ACCOUNT_JSON") {
 		client, err := google.DefaultClient(ctx, compute.DevstorageFullControlScope, compute.ComputeScope)
 		if err != nil {

--- a/step_run_script.go
+++ b/step_run_script.go
@@ -68,12 +68,12 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 			state.Put("err", r.err)
 			logger.Info("hard timeout exceeded, terminating")
 			s.writeLogAndFinishWithState(preTimeoutCtx, ctx, logWriter, buildJob, FinishStateErrored, "\n\nThe job exceeded the maximum time limit for jobs, and has been terminated.\n\n")
-			return multistep.ActionHalt
+			return multistep.ActionContinue
 		}
 		if logWriter.MaxLengthReached() {
 			state.Put("err", MaxLogLengthExceeded)
 			s.writeLogAndFinishWithState(preTimeoutCtx, ctx, logWriter, buildJob, FinishStateErrored, "\n\nThe job exceeded the maximum log length, and has been terminated.\n\n")
-			return multistep.ActionHalt
+			return multistep.ActionContinue
 		}
 
 		if r.err != nil {
@@ -110,12 +110,12 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 		if ctx.Err() == gocontext.DeadlineExceeded {
 			logger.Info("hard timeout exceeded, terminating")
 			s.writeLogAndFinishWithState(preTimeoutCtx, ctx, logWriter, buildJob, FinishStateErrored, "\n\nThe job exceeded the maximum time limit for jobs, and has been terminated.\n\n")
-			return multistep.ActionHalt
+			return multistep.ActionContinue
 		}
 		if logWriter.MaxLengthReached() {
 			state.Put("err", MaxLogLengthExceeded)
 			s.writeLogAndFinishWithState(preTimeoutCtx, ctx, logWriter, buildJob, FinishStateErrored, "\n\nThe job exceeded the maximum log length, and has been terminated.\n\n")
-			return multistep.ActionHalt
+			return multistep.ActionContinue
 		}
 
 		logger.Info("context was cancelled, stopping job")
@@ -133,7 +133,7 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 			state.Put("skipShutdown", true)
 		}
 
-		return multistep.ActionHalt
+		return multistep.ActionContinue
 	}
 }
 

--- a/step_run_script.go
+++ b/step_run_script.go
@@ -68,11 +68,13 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 			state.Put("err", r.err)
 			logger.Info("hard timeout exceeded, terminating")
 			s.writeLogAndFinishWithState(preTimeoutCtx, ctx, logWriter, buildJob, FinishStateErrored, "\n\nThe job exceeded the maximum time limit for jobs, and has been terminated.\n\n")
+			// Continue to the download trace step
 			return multistep.ActionContinue
 		}
 		if logWriter.MaxLengthReached() {
 			state.Put("err", MaxLogLengthExceeded)
 			s.writeLogAndFinishWithState(preTimeoutCtx, ctx, logWriter, buildJob, FinishStateErrored, "\n\nThe job exceeded the maximum log length, and has been terminated.\n\n")
+			// Continue to the download trace step
 			return multistep.ActionContinue
 		}
 
@@ -120,11 +122,13 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 		if ctx.Err() == gocontext.DeadlineExceeded {
 			logger.Info("hard timeout exceeded, terminating")
 			s.writeLogAndFinishWithState(preTimeoutCtx, ctx, logWriter, buildJob, FinishStateErrored, "\n\nThe job exceeded the maximum time limit for jobs, and has been terminated.\n\n")
+			// Continue to the download trace step
 			return multistep.ActionContinue
 		}
 		if logWriter.MaxLengthReached() {
 			state.Put("err", MaxLogLengthExceeded)
 			s.writeLogAndFinishWithState(preTimeoutCtx, ctx, logWriter, buildJob, FinishStateErrored, "\n\nThe job exceeded the maximum log length, and has been terminated.\n\n")
+			// Continue to the download trace step
 			return multistep.ActionContinue
 		}
 
@@ -154,7 +158,7 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 		if s.skipShutdownOnLogTimeout {
 			state.Put("skipShutdown", true)
 		}
-
+		// Continue to the download trace step
 		return multistep.ActionContinue
 	}
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
The build trace isn't saved in case of timeouts or log maxsize errors.

## What approach did you choose and why?
Continuing to the download trace step instead of `ActionHalt` when we encounter these errors.

## How can you test this?
Will test on staging.

## What feedback would you like, if any?
