### PR TITLE
trace: trace CLI.Setup and avoid orphaned spans during worker boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 - processor: include state, requeue, err in "finished job" log message
 - trace: include return code for start_instance, upload_script, run_script, download_trace steps
+- trace: instrument CLI.Setup
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Changed
 - processor: include state, requeue, err in "finished job" log message
 - trace: include return code for start_instance, upload_script, run_script, download_trace steps
-- trace: instrument CLI.Setup
+- trace: instrument CLI.Setup in order to avoid orphaned spans
 
 ### Deprecated
 

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -820,15 +820,6 @@ func (p *gceProvider) StartWithProgress(ctx gocontext.Context, startAttributes *
 		},
 	}
 
-	abandonedStart := false
-
-	defer func(c *gceStartContext) {
-		if c.instance != nil && abandonedStart {
-			p.apiRateLimit(c.ctx)
-			_, _ = p.client.Instances.Delete(p.projectID, c.zoneName, c.instance.Name).Do()
-		}
-	}(c)
-
 	go runner.Run(state)
 
 	logger.Debug("selecting over instance, error, and done channels")
@@ -836,7 +827,6 @@ func (p *gceProvider) StartWithProgress(ctx gocontext.Context, startAttributes *
 	case inst := <-c.instChan:
 		return inst, nil
 	case err := <-c.errChan:
-		abandonedStart = true
 		return nil, err
 	case <-ctx.Done():
 		if ctx.Err() == gocontext.DeadlineExceeded {
@@ -847,7 +837,6 @@ func (p *gceProvider) StartWithProgress(ctx gocontext.Context, startAttributes *
 			State:      ProgressFailure,
 			Interrupts: true,
 		})
-		abandonedStart = true
 		return nil, ctx.Err()
 	}
 }

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -720,7 +720,7 @@ func buildGoogleComputeService(cfg *config.ProviderConfig) (*compute.Service, er
 			Transport: &ochttp.Transport{},
 		},
 	})
-	
+
 	if !cfg.IsSet("ACCOUNT_JSON") {
 		client, err := google.DefaultClient(ctx, compute.DevstorageFullControlScope, compute.ComputeScope)
 		if err != nil {
@@ -1818,7 +1818,7 @@ func (i *gceInstance) Stop(ctx gocontext.Context) error {
 }
 
 func (i *gceInstance) stepDeleteInstance(c *gceInstanceStopContext) multistep.StepAction {
-	op, err := i.client.Instances.Delete(i.projectID, i.zoneName, i.instance.Name).Do()
+	op, err := i.client.Instances.Delete(i.projectID, i.zoneName, i.instance.Name).Context(c.ctx).Do()
 	if err != nil {
 		c.errChan <- err
 		return multistep.ActionHalt


### PR DESCRIPTION
We've been seeing some orphaned spans during worker boot. This ties them together:

![screen shot 2018-11-07 at 16 57 27](https://user-images.githubusercontent.com/11158255/48143030-41bea480-e2ae-11e8-943f-82c9540ece37.png)

The patch also removes an instance deletion that happens in `gce.go`. That really should be done via `StartInstance.Cleanup`. If there are any cases in which `StartInstance.Cleanup` does not properly delete the instance, I'd love to understand those. But from what I can tell, it should always take care of things.