### PR TITLE
track rate of gce api calls we would make (if it were not for rate limiting)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - processor: include state, requeue, err in "finished job" log message
 - trace: include return code for start_instance, upload_script, run_script, download_trace steps
 - trace: instrument CLI.Setup in order to avoid orphaned spans
+- backend/gce: track rate of rate limit start calls (number of gce api calls we would make without rate limiting)
 
 ### Deprecated
 

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -611,6 +611,8 @@ func (p *gceProvider) apiRateLimit(ctx gocontext.Context) error {
 		defer span.End()
 	}
 
+	metrics.Mark("travis.worker.vm.provider.gce.rate-limit.start")
+
 	metrics.Gauge("travis.worker.vm.provider.gce.rate-limit.queue", int64(p.rateLimitQueueDepth))
 	startWait := time.Now()
 	defer metrics.TimeSince("travis.worker.vm.provider.gce.rate-limit", startWait)


### PR DESCRIPTION
This is so that we can get a decent estimate of the API quota we need in practice.