### PR TITLE
store exit code in int32 instead of uint8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Removed
 
 ### Fixed
+- ssh: store exit code in int32 instead of uint8
 
 ### Security
 

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -739,7 +739,7 @@ func (i *dockerInstance) runScriptExec(ctx gocontext.Context, output io.Writer) 
 		}
 
 		if !inspect.Running {
-			return &RunResult{Completed: true, ExitCode: uint8(inspect.ExitCode)}, nil
+			return &RunResult{Completed: true, ExitCode: int32(inspect.ExitCode)}, nil
 		}
 
 		select {

--- a/backend/jupiterbrain.go
+++ b/backend/jupiterbrain.go
@@ -449,14 +449,14 @@ func (i *jupiterBrainInstance) RunScript(ctx gocontext.Context, output io.Writer
 	defer conn.Close()
 
 	resultChan := make(chan struct {
-		exitStatus uint8
+		exitStatus int32
 		err        error
 	}, 1)
 
 	go func() {
 		exitStatus, err := conn.RunCommand("bash ~/wrapper.sh", output)
 		resultChan <- struct {
-			exitStatus uint8
+			exitStatus int32
 			err        error
 		}{
 			exitStatus,

--- a/backend/package.go
+++ b/backend/package.go
@@ -114,7 +114,7 @@ type Instance interface {
 // RunResult represents the result of running a script with Instance.RunScript.
 type RunResult struct {
 	// The exit code of the script. Only valid if Completed is true.
-	ExitCode uint8
+	ExitCode int32
 
 	// Whether the script finished running or not. Can be false if there was a
 	// connection error in the middle of the script run.

--- a/remote/package.go
+++ b/remote/package.go
@@ -5,6 +5,6 @@ import "io"
 type Remoter interface {
 	UploadFile(path string, data []byte) (bool, error)
 	DownloadFile(path string) ([]byte, error)
-	RunCommand(command string, output io.Writer) (uint8, error)
+	RunCommand(command string, output io.Writer) (int32, error)
 	Close() error
 }

--- a/ssh/package.go
+++ b/ssh/package.go
@@ -21,7 +21,7 @@ type Dialer interface {
 type Connection interface {
 	UploadFile(path string, data []byte) (bool, error)
 	DownloadFile(path string) ([]byte, error)
-	RunCommand(command string, output io.Writer) (uint8, error)
+	RunCommand(command string, output io.Writer) (int32, error)
 	Close() error
 }
 
@@ -164,7 +164,7 @@ func (c *sshConnection) DownloadFile(path string) ([]byte, error) {
 	return buf, nil
 }
 
-func (c *sshConnection) RunCommand(command string, output io.Writer) (uint8, error) {
+func (c *sshConnection) RunCommand(command string, output io.Writer) (int32, error) {
 	session, err := c.client.NewSession()
 	if err != nil {
 		return 0, errors.Wrap(err, "error creating SSH session")
@@ -187,7 +187,7 @@ func (c *sshConnection) RunCommand(command string, output io.Writer) (uint8, err
 
 	switch err := err.(type) {
 	case *ssh.ExitError:
-		return uint8(err.ExitStatus()), nil
+		return int32(err.ExitStatus()), nil
 	default:
 		return 0, errors.Wrap(err, "error running script")
 	}

--- a/winrm/package.go
+++ b/winrm/package.go
@@ -68,9 +68,9 @@ func (r *Remoter) DownloadFile(path string) ([]byte, error) {
 	return nil, errNotImplemented
 }
 
-func (r *Remoter) RunCommand(command string, output io.Writer) (uint8, error) {
+func (r *Remoter) RunCommand(command string, output io.Writer) (int32, error) {
 	exitCode, err := r.winrmClient.Run(command, output, output)
-	return uint8(exitCode), err
+	return int32(exitCode), err
 }
 
 func (r *Remoter) Close() error {


### PR DESCRIPTION
value is generally signed 16-bit int, can be negative.

vaguely refs https://github.com/travis-ci/reliability/issues/196.