### PR TITLE
backend/gce: cache gce api calls for image and machine type, reduce total api call volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- backend/gce: cache gce api calls for image and machine type, reduce total api call volume
 
 ### Changed
 


### PR DESCRIPTION
We can see the number of api calls made by worker for a sample job in stackdriver trace:

<img width="357" alt="screen shot 2018-11-15 at 13 52 56" src="https://user-images.githubusercontent.com/11158255/48554125-d55f2900-e8dd-11e8-823d-a4edb9d7b5d4.png">

Since we're hitting some GCE API rate limiting troubles, it would be good to reduce the number of calls per job.

It turns out that two of the calls can be cached. The image select and the machine type. That saves us two calls per job.

This patch does just that. This will hopefully reduce our GCE API traffic by 20-30%. 🤞 