### PR TITLE
Adding zone information when using warmed instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Removed
 
 ### Fixed
+- backend/gce: gets zone information from warmer in order to delete instances successfully
 
 ### Security
 

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -958,9 +958,11 @@ func (p *gceProvider) stepInsertInstance(c *gceStartContext) multistep.StepActio
 			logger.WithFields(logrus.Fields{
 				"ip":   warmerResponse.IP,
 				"name": warmerResponse.Name,
+        "zone": warmerResponse.Zone
 			}).Info("got instance from warmer")
 
 			inst.Name = warmerResponse.Name
+      inst.Zone = warmerResponse.Zone
 			c.instance = inst
 			c.instanceWarmedIP = warmerResponse.IP
 			if p.ic.PublicIPConnect && warmerResponse.PublicIP != "" {
@@ -1466,6 +1468,7 @@ type warmerRequest struct {
 
 type warmerResponse struct {
 	Name          string `json:"name"`
+  Zone          string `json:"zone"`
 	IP            string `json:"ip"`
 	PublicIP      string `json:"public_ip"`
 	SSHPrivateKey string `json:"ssh_private_key"`
@@ -1550,7 +1553,7 @@ func (i *gceInstance) refreshInstance(ctx gocontext.Context) error {
 	defer span.End()
 
 	i.provider.apiRateLimit(ctx)
-	inst, err := i.client.Instances.Get(i.projectID, i.zoneName, i.instance.Name).Context(ctx).Do()
+	inst, err := i.client.Instances.Get(i.projectID, i.instance.Zone, i.instance.Name).Context(ctx).Do()
 	if err != nil {
 		return err
 	}
@@ -1812,7 +1815,7 @@ func (i *gceInstance) Stop(ctx gocontext.Context) error {
 }
 
 func (i *gceInstance) stepDeleteInstance(c *gceInstanceStopContext) multistep.StepAction {
-	op, err := i.client.Instances.Delete(i.projectID, i.zoneName, i.instance.Name).Context(c.ctx).Do()
+	op, err := i.client.Instances.Delete(i.projectID, i.instance.Zone, i.instance.Name).Context(c.ctx).Do()
 	if err != nil {
 		c.errChan <- err
 		return multistep.ActionHalt
@@ -1842,7 +1845,7 @@ func (i *gceInstance) stepWaitForInstanceDeleted(c *gceInstanceStopContext) mult
 	span.End()
 
 	zoneOpCall := i.client.ZoneOperations.Get(i.projectID,
-		i.zoneName, c.instanceDeleteOp.Name)
+		i.instance.Zone, c.instanceDeleteOp.Name)
 
 	b := backoff.NewExponentialBackOff()
 	b.InitialInterval = i.ic.StopPollSleep

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -43,7 +43,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
-	"google.golang.org/api/compute/v1"
+	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
 
@@ -958,11 +958,11 @@ func (p *gceProvider) stepInsertInstance(c *gceStartContext) multistep.StepActio
 			logger.WithFields(logrus.Fields{
 				"ip":   warmerResponse.IP,
 				"name": warmerResponse.Name,
-        "zone": warmerResponse.Zone
+				"zone": warmerResponse.Zone,
 			}).Info("got instance from warmer")
 
 			inst.Name = warmerResponse.Name
-      inst.Zone = warmerResponse.Zone
+			inst.Zone = warmerResponse.Zone
 			c.instance = inst
 			c.instanceWarmedIP = warmerResponse.IP
 			if p.ic.PublicIPConnect && warmerResponse.PublicIP != "" {
@@ -1468,7 +1468,7 @@ type warmerRequest struct {
 
 type warmerResponse struct {
 	Name          string `json:"name"`
-  Zone          string `json:"zone"`
+	Zone          string `json:"zone"`
 	IP            string `json:"ip"`
 	PublicIP      string `json:"public_ip"`
 	SSHPrivateKey string `json:"ssh_private_key"`

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -1376,6 +1376,7 @@ func (p *gceProvider) buildInstance(ctx gocontext.Context, startAttributes *Star
 		},
 		MachineType: machineType.SelfLink,
 		Name:        hostname,
+		Zone:        zone.Name,
 		Metadata: &compute.Metadata{
 			Items: []*compute.MetadataItems{
 				&compute.MetadataItems{


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
VMs from warmer often don't get deleted because the worker ends up looking in the wrong zone when trying to delete them.

## What approach did you choose and why?
Passing back the zone information from warmer and then using that in the gce worker backend for the deletion.

## How can you test this?
Turn worker back on, see if it's able to delete instances this time

## What feedback would you like, if any?
How GOod is my Go code?