### PR TITLE
processor: generate per-job UUID to distinguish between job runs

### DIFF
--- a/amqp_job.go
+++ b/amqp_job.go
@@ -180,6 +180,10 @@ func (j *amqpJob) createStateUpdateBody(ctx gocontext.Context, state string) map
 		body["meta"].(map[string]interface{})["instance_id"] = instanceID
 	}
 
+	if uuid, ok := context.UUIDFromContext(ctx); ok {
+		body["meta"].(map[string]interface{})["uuid"] = uuid
+	}
+
 	if j.Payload().Job.QueuedAt != nil {
 		body["queued_at"] = j.Payload().Job.QueuedAt.UTC().Format(time.RFC3339)
 	}

--- a/processor.go
+++ b/processor.go
@@ -6,6 +6,7 @@ import (
 	gocontext "context"
 
 	"github.com/mitchellh/multistep"
+	"github.com/pborman/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/travis-ci/worker/backend"
 	"github.com/travis-ci/worker/config"
@@ -139,6 +140,8 @@ func (p *Processor) Run() {
 			ctx := context.FromJobID(context.FromRepository(p.ctx, buildJob.Payload().Repository.Slug), buildJob.Payload().Job.ID)
 			if buildJob.Payload().UUID != "" {
 				ctx = context.FromUUID(ctx, buildJob.Payload().UUID)
+			} else {
+				ctx = context.FromUUID(ctx, uuid.NewRandom().String())
 			}
 			logger.WithFields(logrus.Fields{
 				"job_id": jobID,


### PR DESCRIPTION
This allows hub (a downstream consumer) distinguish between job runs, which allows us to better handle certain races around state updates during requeue storms.

refs travis-ci/reliability#222