### PR TITLE
ratelimit: dynamic configuration of `max_calls` and `duration` via redis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- ratelimit: dynamic configuration of `max_calls` and `duration` via redis
 
 ### Changed
 

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -66,53 +66,59 @@ const (
 	defaultGCEImage              = "travis-ci.+"
 	defaultGCEGpuCount           = int64(0)
 	defaultGCEGpuType            = "nvidia-tesla-p100"
-	defaultGCERateLimitMaxCalls  = uint64(10)
-	defaultGCERateLimitDuration  = time.Second
-	defaultGCESSHDialTimeout     = 5 * time.Second
-	defaultGCEWarmerTimeout      = 5 * time.Second
+
+	defaultGCERateLimitMaxCalls         = uint64(10)
+	defaultGCERateLimitDuration         = time.Second
+	defaultGCERateLimitDynamicConfigTTL = time.Minute
+
+	defaultGCESSHDialTimeout = 5 * time.Second
+	defaultGCEWarmerTimeout  = 5 * time.Second
 )
 
 var (
 	gceHelp = map[string]string{
-		"ACCOUNT_JSON":              "[REQUIRED] account JSON config",
-		"AUTO_IMPLODE":              "schedule a poweroff at HARD_TIMEOUT_MINUTES in the future (default true)",
-		"BOOT_POLL_SLEEP":           fmt.Sprintf("sleep interval between polling server for instance ready status (default %v)", defaultGCEBootPollSleep),
-		"BOOT_PRE_POLL_SLEEP":       fmt.Sprintf("time to sleep prior to polling server for instance ready status (default %v)", defaultGCEBootPrePollSleep),
-		"DEFAULT_LANGUAGE":          fmt.Sprintf("default language to use when looking up image (default %q)", defaultGCELanguage),
-		"DETERMINISTIC_HOSTNAME":    "assign deterministic hostname based on repo slug and job id (default false)",
-		"DISK_SIZE":                 fmt.Sprintf("disk size in GB (default %v)", defaultGCEDiskSize),
-		"GPU_COUNT":                 fmt.Sprintf("number of GPUs to use (default %v)", defaultGCEGpuCount),
-		"GPU_TYPE":                  fmt.Sprintf("type of GPU to use (default %q)", defaultGCEGpuType),
-		"IMAGE_ALIASES":             "comma-delimited strings used as stable names for images, used only when image selector type is \"env\"",
-		"IMAGE_DEFAULT":             fmt.Sprintf("default image name to use when none found (default %q)", defaultGCEImage),
-		"IMAGE_SELECTOR_TYPE":       fmt.Sprintf("image selector type (\"env\" or \"api\", default %q)", defaultGCEImageSelectorType),
-		"IMAGE_SELECTOR_URL":        "URL for image selector API, used only when image selector is \"api\"",
-		"IMAGE_[ALIAS_]{ALIAS}":     "full name for a given alias given via IMAGE_ALIASES, where the alias form in the key is uppercased and normalized by replacing non-alphanumerics with _",
-		"MACHINE_TYPE":              fmt.Sprintf("machine name (default %q)", defaultGCEMachineType),
-		"NETWORK":                   fmt.Sprintf("network name (default %q)", defaultGCENetwork),
-		"PREEMPTIBLE":               "boot job instances with preemptible flag enabled (default false)",
-		"PREMIUM_MACHINE_TYPE":      fmt.Sprintf("premium machine type (default %q)", defaultGCEPremiumMachineType),
-		"PROJECT_ID":                "[REQUIRED] GCE project id",
-		"PUBLIC_IP":                 "boot job instances with a public ip, disable this for NAT (default true)",
-		"PUBLIC_IP_CONNECT":         "connect to the public ip of the instance instead of the internal, only takes effect if PUBLIC_IP is true (default true)",
-		"IMAGE_PROJECT_ID":          "GCE project id to use for images, will use PROJECT_ID if not specified",
-		"RATE_LIMIT_PREFIX":         "prefix for the rate limit key in Redis",
-		"RATE_LIMIT_REDIS_URL":      "URL to Redis instance to use for rate limiting",
-		"RATE_LIMIT_MAX_CALLS":      fmt.Sprintf("number of calls per duration to let through to the GCE API (default %d)", defaultGCERateLimitMaxCalls),
-		"RATE_LIMIT_DURATION":       fmt.Sprintf("interval in which to let max-calls through to the GCE API (default %v)", defaultGCERateLimitDuration),
-		"RATE_LIMIT_DYNAMIC_CONFIG": fmt.Sprintf("get max-calls and duration dynamically through redis (default false)"),
-		"REGION":                    fmt.Sprintf("only takes effect when SUBNETWORK is defined; region in which to deploy (default %v)", defaultGCERegion),
-		"SKIP_STOP_POLL":            "immediately return after issuing first instance deletion request (default false)",
-		"SSH_DIAL_TIMEOUT":          fmt.Sprintf("connection timeout for ssh connections (default %v)", defaultGCESSHDialTimeout),
-		"STOP_POLL_SLEEP":           fmt.Sprintf("sleep interval between polling server for instance stop status (default %v)", defaultGCEStopPollSleep),
-		"STOP_PRE_POLL_SLEEP":       fmt.Sprintf("time to sleep prior to polling server for instance stop status (default %v)", defaultGCEStopPrePollSleep),
-		"SUBNETWORK":                fmt.Sprintf("the subnetwork in which to launch build instances (gce internal default \"%v\")", defaultGCESubnet),
-		"UPLOAD_RETRIES":            fmt.Sprintf("number of times to attempt to upload script before erroring (default %d)", defaultGCEUploadRetries),
-		"UPLOAD_RETRY_SLEEP":        fmt.Sprintf("sleep interval between script upload attempts (default %v)", defaultGCEUploadRetrySleep),
-		"WARMER_URL":                "URL for warmer service",
-		"WARMER_TIMEOUT":            fmt.Sprintf("timeout for requests to warmer service (default %v)", defaultGCEWarmerTimeout),
-		"WARMER_SSH_PASSPHRASE":     fmt.Sprintf("The passphrase used to decipher instace SSH keys"),
-		"ZONE":                      fmt.Sprintf("zone name (default %q)", defaultGCEZone),
+		"ACCOUNT_JSON":           "[REQUIRED] account JSON config",
+		"AUTO_IMPLODE":           "schedule a poweroff at HARD_TIMEOUT_MINUTES in the future (default true)",
+		"BOOT_POLL_SLEEP":        fmt.Sprintf("sleep interval between polling server for instance ready status (default %v)", defaultGCEBootPollSleep),
+		"BOOT_PRE_POLL_SLEEP":    fmt.Sprintf("time to sleep prior to polling server for instance ready status (default %v)", defaultGCEBootPrePollSleep),
+		"DEFAULT_LANGUAGE":       fmt.Sprintf("default language to use when looking up image (default %q)", defaultGCELanguage),
+		"DETERMINISTIC_HOSTNAME": "assign deterministic hostname based on repo slug and job id (default false)",
+		"DISK_SIZE":              fmt.Sprintf("disk size in GB (default %v)", defaultGCEDiskSize),
+		"GPU_COUNT":              fmt.Sprintf("number of GPUs to use (default %v)", defaultGCEGpuCount),
+		"GPU_TYPE":               fmt.Sprintf("type of GPU to use (default %q)", defaultGCEGpuType),
+		"IMAGE_ALIASES":          "comma-delimited strings used as stable names for images, used only when image selector type is \"env\"",
+		"IMAGE_DEFAULT":          fmt.Sprintf("default image name to use when none found (default %q)", defaultGCEImage),
+		"IMAGE_SELECTOR_TYPE":    fmt.Sprintf("image selector type (\"env\" or \"api\", default %q)", defaultGCEImageSelectorType),
+		"IMAGE_SELECTOR_URL":     "URL for image selector API, used only when image selector is \"api\"",
+		"IMAGE_[ALIAS_]{ALIAS}":  "full name for a given alias given via IMAGE_ALIASES, where the alias form in the key is uppercased and normalized by replacing non-alphanumerics with _",
+		"MACHINE_TYPE":           fmt.Sprintf("machine name (default %q)", defaultGCEMachineType),
+		"NETWORK":                fmt.Sprintf("network name (default %q)", defaultGCENetwork),
+		"PREEMPTIBLE":            "boot job instances with preemptible flag enabled (default false)",
+		"PREMIUM_MACHINE_TYPE":   fmt.Sprintf("premium machine type (default %q)", defaultGCEPremiumMachineType),
+		"PROJECT_ID":             "[REQUIRED] GCE project id",
+		"PUBLIC_IP":              "boot job instances with a public ip, disable this for NAT (default true)",
+		"PUBLIC_IP_CONNECT":      "connect to the public ip of the instance instead of the internal, only takes effect if PUBLIC_IP is true (default true)",
+		"IMAGE_PROJECT_ID":       "GCE project id to use for images, will use PROJECT_ID if not specified",
+
+		"RATE_LIMIT_PREFIX":             "prefix for the rate limit key in Redis",
+		"RATE_LIMIT_REDIS_URL":          "URL to Redis instance to use for rate limiting",
+		"RATE_LIMIT_MAX_CALLS":          fmt.Sprintf("number of calls per duration to let through to the GCE API (default %d)", defaultGCERateLimitMaxCalls),
+		"RATE_LIMIT_DURATION":           fmt.Sprintf("interval in which to let max-calls through to the GCE API (default %v)", defaultGCERateLimitDuration),
+		"RATE_LIMIT_DYNAMIC_CONFIG":     "get max-calls and duration dynamically through redis (default false)",
+		"RATE_LIMIT_DYNAMIC_CONFIG_TTL": fmt.Sprintf("time to cache dynamic config for (default %v)", defaultGCERateLimitDynamicConfigTTL),
+
+		"REGION":                fmt.Sprintf("only takes effect when SUBNETWORK is defined; region in which to deploy (default %v)", defaultGCERegion),
+		"SKIP_STOP_POLL":        "immediately return after issuing first instance deletion request (default false)",
+		"SSH_DIAL_TIMEOUT":      fmt.Sprintf("connection timeout for ssh connections (default %v)", defaultGCESSHDialTimeout),
+		"STOP_POLL_SLEEP":       fmt.Sprintf("sleep interval between polling server for instance stop status (default %v)", defaultGCEStopPollSleep),
+		"STOP_PRE_POLL_SLEEP":   fmt.Sprintf("time to sleep prior to polling server for instance stop status (default %v)", defaultGCEStopPrePollSleep),
+		"SUBNETWORK":            fmt.Sprintf("the subnetwork in which to launch build instances (gce internal default \"%v\")", defaultGCESubnet),
+		"UPLOAD_RETRIES":        fmt.Sprintf("number of times to attempt to upload script before erroring (default %d)", defaultGCEUploadRetries),
+		"UPLOAD_RETRY_SLEEP":    fmt.Sprintf("sleep interval between script upload attempts (default %v)", defaultGCEUploadRetrySleep),
+		"WARMER_URL":            "URL for warmer service",
+		"WARMER_TIMEOUT":        fmt.Sprintf("timeout for requests to warmer service (default %v)", defaultGCEWarmerTimeout),
+		"WARMER_SSH_PASSPHRASE": fmt.Sprintf("The passphrase used to decipher instace SSH keys"),
+		"ZONE":                  fmt.Sprintf("zone name (default %q)", defaultGCEZone),
 	}
 
 	errGCEMissingIPAddressError   = fmt.Errorf("no IP address found")
@@ -475,12 +481,22 @@ func newGCEProvider(cfg *config.ProviderConfig) (Provider, error) {
 		return nil, err
 	}
 
+	rateLimitDynamicConfigTTL := defaultGCERateLimitDynamicConfigTTL
+	if cfg.IsSet("RATE_LIMIT_DYNAMIC_CONFIG_TTL") {
+		rldcttl, err := time.ParseDuration(cfg.Get("RATE_LIMIT_DYNAMIC_CONFIG_TTL"))
+		if err != nil {
+			return nil, err
+		}
+		rateLimitDynamicConfigTTL = rldcttl
+	}
+
 	var rateLimiter ratelimit.RateLimiter
 	if cfg.IsSet("RATE_LIMIT_REDIS_URL") {
 		rateLimiter = ratelimit.NewRateLimiter(
 			cfg.Get("RATE_LIMIT_REDIS_URL"),
 			cfg.Get("RATE_LIMIT_PREFIX"),
 			asBool(cfg.Get("RATE_LIMIT_DYNAMIC_CONFIG")),
+			rateLimitDynamicConfigTTL,
 		)
 	} else {
 		rateLimiter = ratelimit.NewNullRateLimiter()

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -74,44 +74,45 @@ const (
 
 var (
 	gceHelp = map[string]string{
-		"ACCOUNT_JSON":           "[REQUIRED] account JSON config",
-		"AUTO_IMPLODE":           "schedule a poweroff at HARD_TIMEOUT_MINUTES in the future (default true)",
-		"BOOT_POLL_SLEEP":        fmt.Sprintf("sleep interval between polling server for instance ready status (default %v)", defaultGCEBootPollSleep),
-		"BOOT_PRE_POLL_SLEEP":    fmt.Sprintf("time to sleep prior to polling server for instance ready status (default %v)", defaultGCEBootPrePollSleep),
-		"DEFAULT_LANGUAGE":       fmt.Sprintf("default language to use when looking up image (default %q)", defaultGCELanguage),
-		"DETERMINISTIC_HOSTNAME": "assign deterministic hostname based on repo slug and job id (default false)",
-		"DISK_SIZE":              fmt.Sprintf("disk size in GB (default %v)", defaultGCEDiskSize),
-		"GPU_COUNT":              fmt.Sprintf("number of GPUs to use (default %v)", defaultGCEGpuCount),
-		"GPU_TYPE":               fmt.Sprintf("type of GPU to use (default %q)", defaultGCEGpuType),
-		"IMAGE_ALIASES":          "comma-delimited strings used as stable names for images, used only when image selector type is \"env\"",
-		"IMAGE_DEFAULT":          fmt.Sprintf("default image name to use when none found (default %q)", defaultGCEImage),
-		"IMAGE_SELECTOR_TYPE":    fmt.Sprintf("image selector type (\"env\" or \"api\", default %q)", defaultGCEImageSelectorType),
-		"IMAGE_SELECTOR_URL":     "URL for image selector API, used only when image selector is \"api\"",
-		"IMAGE_[ALIAS_]{ALIAS}":  "full name for a given alias given via IMAGE_ALIASES, where the alias form in the key is uppercased and normalized by replacing non-alphanumerics with _",
-		"MACHINE_TYPE":           fmt.Sprintf("machine name (default %q)", defaultGCEMachineType),
-		"NETWORK":                fmt.Sprintf("network name (default %q)", defaultGCENetwork),
-		"PREEMPTIBLE":            "boot job instances with preemptible flag enabled (default false)",
-		"PREMIUM_MACHINE_TYPE":   fmt.Sprintf("premium machine type (default %q)", defaultGCEPremiumMachineType),
-		"PROJECT_ID":             "[REQUIRED] GCE project id",
-		"PUBLIC_IP":              "boot job instances with a public ip, disable this for NAT (default true)",
-		"PUBLIC_IP_CONNECT":      "connect to the public ip of the instance instead of the internal, only takes effect if PUBLIC_IP is true (default true)",
-		"IMAGE_PROJECT_ID":       "GCE project id to use for images, will use PROJECT_ID if not specified",
-		"RATE_LIMIT_PREFIX":      "prefix for the rate limit key in Redis",
-		"RATE_LIMIT_REDIS_URL":   "URL to Redis instance to use for rate limiting",
-		"RATE_LIMIT_MAX_CALLS":   fmt.Sprintf("number of calls per duration to let through to the GCE API (default %d)", defaultGCERateLimitMaxCalls),
-		"RATE_LIMIT_DURATION":    fmt.Sprintf("interval in which to let max-calls through to the GCE API (default %v)", defaultGCERateLimitDuration),
-		"REGION":                 fmt.Sprintf("only takes effect when SUBNETWORK is defined; region in which to deploy (default %v)", defaultGCERegion),
-		"SKIP_STOP_POLL":         "immediately return after issuing first instance deletion request (default false)",
-		"SSH_DIAL_TIMEOUT":       fmt.Sprintf("connection timeout for ssh connections (default %v)", defaultGCESSHDialTimeout),
-		"STOP_POLL_SLEEP":        fmt.Sprintf("sleep interval between polling server for instance stop status (default %v)", defaultGCEStopPollSleep),
-		"STOP_PRE_POLL_SLEEP":    fmt.Sprintf("time to sleep prior to polling server for instance stop status (default %v)", defaultGCEStopPrePollSleep),
-		"SUBNETWORK":             fmt.Sprintf("the subnetwork in which to launch build instances (gce internal default \"%v\")", defaultGCESubnet),
-		"UPLOAD_RETRIES":         fmt.Sprintf("number of times to attempt to upload script before erroring (default %d)", defaultGCEUploadRetries),
-		"UPLOAD_RETRY_SLEEP":     fmt.Sprintf("sleep interval between script upload attempts (default %v)", defaultGCEUploadRetrySleep),
-		"WARMER_URL":             "URL for warmer service",
-		"WARMER_TIMEOUT":         fmt.Sprintf("timeout for requests to warmer service (default %v)", defaultGCEWarmerTimeout),
-		"WARMER_SSH_PASSPHRASE":  fmt.Sprintf("The passphrase used to decipher instace SSH keys"),
-		"ZONE":                   fmt.Sprintf("zone name (default %q)", defaultGCEZone),
+		"ACCOUNT_JSON":              "[REQUIRED] account JSON config",
+		"AUTO_IMPLODE":              "schedule a poweroff at HARD_TIMEOUT_MINUTES in the future (default true)",
+		"BOOT_POLL_SLEEP":           fmt.Sprintf("sleep interval between polling server for instance ready status (default %v)", defaultGCEBootPollSleep),
+		"BOOT_PRE_POLL_SLEEP":       fmt.Sprintf("time to sleep prior to polling server for instance ready status (default %v)", defaultGCEBootPrePollSleep),
+		"DEFAULT_LANGUAGE":          fmt.Sprintf("default language to use when looking up image (default %q)", defaultGCELanguage),
+		"DETERMINISTIC_HOSTNAME":    "assign deterministic hostname based on repo slug and job id (default false)",
+		"DISK_SIZE":                 fmt.Sprintf("disk size in GB (default %v)", defaultGCEDiskSize),
+		"GPU_COUNT":                 fmt.Sprintf("number of GPUs to use (default %v)", defaultGCEGpuCount),
+		"GPU_TYPE":                  fmt.Sprintf("type of GPU to use (default %q)", defaultGCEGpuType),
+		"IMAGE_ALIASES":             "comma-delimited strings used as stable names for images, used only when image selector type is \"env\"",
+		"IMAGE_DEFAULT":             fmt.Sprintf("default image name to use when none found (default %q)", defaultGCEImage),
+		"IMAGE_SELECTOR_TYPE":       fmt.Sprintf("image selector type (\"env\" or \"api\", default %q)", defaultGCEImageSelectorType),
+		"IMAGE_SELECTOR_URL":        "URL for image selector API, used only when image selector is \"api\"",
+		"IMAGE_[ALIAS_]{ALIAS}":     "full name for a given alias given via IMAGE_ALIASES, where the alias form in the key is uppercased and normalized by replacing non-alphanumerics with _",
+		"MACHINE_TYPE":              fmt.Sprintf("machine name (default %q)", defaultGCEMachineType),
+		"NETWORK":                   fmt.Sprintf("network name (default %q)", defaultGCENetwork),
+		"PREEMPTIBLE":               "boot job instances with preemptible flag enabled (default false)",
+		"PREMIUM_MACHINE_TYPE":      fmt.Sprintf("premium machine type (default %q)", defaultGCEPremiumMachineType),
+		"PROJECT_ID":                "[REQUIRED] GCE project id",
+		"PUBLIC_IP":                 "boot job instances with a public ip, disable this for NAT (default true)",
+		"PUBLIC_IP_CONNECT":         "connect to the public ip of the instance instead of the internal, only takes effect if PUBLIC_IP is true (default true)",
+		"IMAGE_PROJECT_ID":          "GCE project id to use for images, will use PROJECT_ID if not specified",
+		"RATE_LIMIT_PREFIX":         "prefix for the rate limit key in Redis",
+		"RATE_LIMIT_REDIS_URL":      "URL to Redis instance to use for rate limiting",
+		"RATE_LIMIT_MAX_CALLS":      fmt.Sprintf("number of calls per duration to let through to the GCE API (default %d)", defaultGCERateLimitMaxCalls),
+		"RATE_LIMIT_DURATION":       fmt.Sprintf("interval in which to let max-calls through to the GCE API (default %v)", defaultGCERateLimitDuration),
+		"RATE_LIMIT_DYNAMIC_CONFIG": fmt.Sprintf("get max-calls and duration dynamically through redis (default false)"),
+		"REGION":                    fmt.Sprintf("only takes effect when SUBNETWORK is defined; region in which to deploy (default %v)", defaultGCERegion),
+		"SKIP_STOP_POLL":            "immediately return after issuing first instance deletion request (default false)",
+		"SSH_DIAL_TIMEOUT":          fmt.Sprintf("connection timeout for ssh connections (default %v)", defaultGCESSHDialTimeout),
+		"STOP_POLL_SLEEP":           fmt.Sprintf("sleep interval between polling server for instance stop status (default %v)", defaultGCEStopPollSleep),
+		"STOP_PRE_POLL_SLEEP":       fmt.Sprintf("time to sleep prior to polling server for instance stop status (default %v)", defaultGCEStopPrePollSleep),
+		"SUBNETWORK":                fmt.Sprintf("the subnetwork in which to launch build instances (gce internal default \"%v\")", defaultGCESubnet),
+		"UPLOAD_RETRIES":            fmt.Sprintf("number of times to attempt to upload script before erroring (default %d)", defaultGCEUploadRetries),
+		"UPLOAD_RETRY_SLEEP":        fmt.Sprintf("sleep interval between script upload attempts (default %v)", defaultGCEUploadRetrySleep),
+		"WARMER_URL":                "URL for warmer service",
+		"WARMER_TIMEOUT":            fmt.Sprintf("timeout for requests to warmer service (default %v)", defaultGCEWarmerTimeout),
+		"WARMER_SSH_PASSPHRASE":     fmt.Sprintf("The passphrase used to decipher instace SSH keys"),
+		"ZONE":                      fmt.Sprintf("zone name (default %q)", defaultGCEZone),
 	}
 
 	errGCEMissingIPAddressError   = fmt.Errorf("no IP address found")
@@ -190,10 +191,11 @@ type gceProvider struct {
 	sshDialer             ssh.Dialer
 	sshDialTimeout        time.Duration
 
-	rateLimiter         ratelimit.RateLimiter
-	rateLimitMaxCalls   uint64
-	rateLimitDuration   time.Duration
-	rateLimitQueueDepth uint64
+	rateLimiter            ratelimit.RateLimiter
+	rateLimitMaxCalls      uint64
+	rateLimitDuration      time.Duration
+	rateLimitDynamicConfig bool
+	rateLimitQueueDepth    uint64
 
 	warmerUrl           *url.URL
 	warmerTimeout       time.Duration
@@ -520,6 +522,11 @@ func newGCEProvider(cfg *config.ProviderConfig) (Provider, error) {
 		rateLimitDuration = rld
 	}
 
+	rateLimitDynamicConfig := false
+	if cfg.IsSet("RATE_LIMIT_DYNAMIC_CONFIG") {
+		rateLimitDynamicConfig := asBool(cfg.Get("RATE_LIMIT_DYNAMIC_CONFIG"))
+	}
+
 	sshDialTimeout := defaultGCESSHDialTimeout
 	if cfg.IsSet("SSH_DIAL_TIMEOUT") {
 		sshDialTimeout, err = time.ParseDuration(cfg.Get("SSH_DIAL_TIMEOUT"))
@@ -596,9 +603,10 @@ func newGCEProvider(cfg *config.ProviderConfig) (Provider, error) {
 		uploadRetries:         uploadRetries,
 		uploadRetrySleep:      uploadRetrySleep,
 
-		rateLimiter:       rateLimiter,
-		rateLimitMaxCalls: rateLimitMaxCalls,
-		rateLimitDuration: rateLimitDuration,
+		rateLimiter:            rateLimiter,
+		rateLimitMaxCalls:      rateLimitMaxCalls,
+		rateLimitDuration:      rateLimitDuration,
+		rateLimitDynamicConfig: rateLimitDynamicConfig,
 
 		warmerUrl:           warmerUrl,
 		warmerTimeout:       warmerTimeout,
@@ -628,7 +636,7 @@ func (p *gceProvider) apiRateLimit(ctx gocontext.Context) error {
 	errCount := 0
 
 	for {
-		ok, err := p.rateLimiter.RateLimit(ctx, "gce-api", p.rateLimitMaxCalls, p.rateLimitDuration)
+		ok, err := p.rateLimiter.RateLimit(ctx, "gce-api", p.rateLimitMaxCalls, p.rateLimitDuration, p.rateLimitDynamicConfig)
 		if err != nil {
 			errCount++
 			if errCount >= 5 {

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -524,7 +524,7 @@ func newGCEProvider(cfg *config.ProviderConfig) (Provider, error) {
 
 	rateLimitDynamicConfig := false
 	if cfg.IsSet("RATE_LIMIT_DYNAMIC_CONFIG") {
-		rateLimitDynamicConfig := asBool(cfg.Get("RATE_LIMIT_DYNAMIC_CONFIG"))
+		rateLimitDynamicConfig = asBool(cfg.Get("RATE_LIMIT_DYNAMIC_CONFIG"))
 	}
 
 	sshDialTimeout := defaultGCESSHDialTimeout

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -7,8 +7,8 @@ import (
 
 	gocontext "context"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/garyburd/redigo/redis"
+	"github.com/sirupsen/logrus"
 	"github.com/travis-ci/worker/context"
 	"go.opencensus.io/trace"
 )

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -7,7 +7,9 @@ import (
 
 	gocontext "context"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/garyburd/redigo/redis"
+	"github.com/travis-ci/worker/context"
 	"go.opencensus.io/trace"
 )
 
@@ -197,9 +199,15 @@ func (rl *redisRateLimiter) loadDynamicConfig(ctx gocontext.Context, conn redis.
 
 	expires := time.Now().Add(time.Second * 10)
 
-	rl.cacheExpiresAt = &expires
+	logger := context.LoggerFromContext(ctx).WithField("self", "ratelimit/redis")
+	logger.WithFields(logrus.Fields{
+		"max_calls": *maxCalls,
+		"duration":  *per,
+	}).Info("refreshed dynamic config")
+
 	rl.cachedMaxCalls = maxCalls
 	rl.cachedDuration = per
+	rl.cacheExpiresAt = &expires
 
 	return nil
 }

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -88,6 +88,16 @@ func (rl *redisRateLimiter) RateLimit(ctx gocontext.Context, name string, maxCal
 		defer span.End()
 	}
 
+	// if dynamic config is enabled, it is possible to override
+	// max_calls and duration at runtime by setting redis keys:
+	//
+	// * <prefix>:<name>:max_calls
+	// * <prefix>:<name>:duration
+	//
+	// for example:
+	//
+	// * worker-rate-limit-gce-api-1:gce-api:max_calls 3000
+	// * worker-rate-limit-gce-api-1:gce-api:duration  100s
 	if rl.dynamicConfig {
 		key := fmt.Sprintf("%s:%s:max_calls", rl.prefix, name)
 		dynMaxCalls, err := redis.Uint64(conn.Do("GET", key))

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -19,7 +19,7 @@ func TestRateLimit(t *testing.T) {
 
 	rateLimiter := NewRateLimiter(os.Getenv("REDIS_URL"), fmt.Sprintf("worker-test-rl-%d", os.Getpid()))
 
-	ok, err := rateLimiter.RateLimit(context.TODO(), "slow", 2, time.Hour)
+	ok, err := rateLimiter.RateLimit(context.TODO(), "slow", 2, time.Hour, false)
 	if err != nil {
 		t.Fatalf("rate limiter error: %v", err)
 	}
@@ -27,7 +27,7 @@ func TestRateLimit(t *testing.T) {
 		t.Fatal("expected to not get rate limited, but was limited")
 	}
 
-	ok, err = rateLimiter.RateLimit(context.TODO(), "slow", 2, time.Hour)
+	ok, err = rateLimiter.RateLimit(context.TODO(), "slow", 2, time.Hour, false)
 	if err != nil {
 		t.Fatalf("rate limiter error: %v", err)
 	}
@@ -35,7 +35,7 @@ func TestRateLimit(t *testing.T) {
 		t.Fatal("expected to not get rate limited, but was limited")
 	}
 
-	ok, err = rateLimiter.RateLimit(context.TODO(), "slow", 2, time.Hour)
+	ok, err = rateLimiter.RateLimit(context.TODO(), "slow", 2, time.Hour, false)
 	if err != nil {
 		t.Fatalf("rate limiter error: %v", err)
 	}

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -17,9 +17,9 @@ func TestRateLimit(t *testing.T) {
 		t.Log("Note: The TestRateLimit test is known to have a bug if run near the top of the hour. Since the rate limiter isn't a moving window, it could end up checking against two different buckets on either side of the top of the hour, so if you see that just re-run it after you've passed the top of the hour.")
 	}
 
-	rateLimiter := NewRateLimiter(os.Getenv("REDIS_URL"), fmt.Sprintf("worker-test-rl-%d", os.Getpid()))
+	rateLimiter := NewRateLimiter(os.Getenv("REDIS_URL"), fmt.Sprintf("worker-test-rl-%d", os.Getpid()), false)
 
-	ok, err := rateLimiter.RateLimit(context.TODO(), "slow", 2, time.Hour, false)
+	ok, err := rateLimiter.RateLimit(context.TODO(), "slow", 2, time.Hour)
 	if err != nil {
 		t.Fatalf("rate limiter error: %v", err)
 	}
@@ -27,7 +27,7 @@ func TestRateLimit(t *testing.T) {
 		t.Fatal("expected to not get rate limited, but was limited")
 	}
 
-	ok, err = rateLimiter.RateLimit(context.TODO(), "slow", 2, time.Hour, false)
+	ok, err = rateLimiter.RateLimit(context.TODO(), "slow", 2, time.Hour)
 	if err != nil {
 		t.Fatalf("rate limiter error: %v", err)
 	}
@@ -35,7 +35,7 @@ func TestRateLimit(t *testing.T) {
 		t.Fatal("expected to not get rate limited, but was limited")
 	}
 
-	ok, err = rateLimiter.RateLimit(context.TODO(), "slow", 2, time.Hour, false)
+	ok, err = rateLimiter.RateLimit(context.TODO(), "slow", 2, time.Hour)
 	if err != nil {
 		t.Fatalf("rate limiter error: %v", err)
 	}

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -17,7 +17,7 @@ func TestRateLimit(t *testing.T) {
 		t.Log("Note: The TestRateLimit test is known to have a bug if run near the top of the hour. Since the rate limiter isn't a moving window, it could end up checking against two different buckets on either side of the top of the hour, so if you see that just re-run it after you've passed the top of the hour.")
 	}
 
-	rateLimiter := NewRateLimiter(os.Getenv("REDIS_URL"), fmt.Sprintf("worker-test-rl-%d", os.Getpid()), false)
+	rateLimiter := NewRateLimiter(os.Getenv("REDIS_URL"), fmt.Sprintf("worker-test-rl-%d", os.Getpid()), false, time.Minute)
 
 	ok, err := rateLimiter.RateLimit(context.TODO(), "slow", 2, time.Hour)
 	if err != nil {


### PR DESCRIPTION
In order to be able to adjust our rate limiting on the fly it would be good to be able to dynamically configure it through redis.

This allows the values to be changed without deploying or restarting worker. This will allow us to slowly approach our API quotas.

The main risk is increased traffic to redis. I think redis should be able to handle a couple hundred requests per second easily though. So I'm not too worried. In the worst case we can cache the config value in memory though and update it every couple seconds (maybe using something like [go-cache](https://github.com/patrickmn/go-cache)).

To enable in worker (terraform-config):

```
TRAVIS_WORKER_GCE_RATE_LIMIT_DYNAMIC_CONFIG=true
```

To set the values in redis:

```
trvs redis-cli travis-production REDIS_URL mset worker-rate-limit-gce-api-1:gce-api:max_calls 3000 worker-rate-limit-gce-api-1:gce-api:duration 100s
```

That should make the rate-limiter perform 3000 calls per 100 seconds across all workers in `production-1`.

refs https://github.com/travis-ci/reliability/issues/222