### PR TITLE
backend/gce: add missing rate limit calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Removed
 
 ### Fixed
+- backend/gce: add missing rate limit calls
 
 ### Security
 

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -719,6 +719,7 @@ func (p *gceProvider) Setup(ctx gocontext.Context) error {
 	}
 
 	if p.cfg.IsSet("SUBNETWORK") {
+		p.apiRateLimit(ctx)
 		p.ic.Subnetwork, err = p.client.Subnetworks.Get(p.projectID, region, p.cfg.Get("SUBNETWORK")).Context(ctx).Do()
 		if err != nil {
 			return err
@@ -813,6 +814,7 @@ func (p *gceProvider) StartWithProgress(ctx gocontext.Context, startAttributes *
 	if startAttributes.VMConfig.Zone != "" {
 		logger.WithField("zone", startAttributes.VMConfig.Zone).Debug("setting zone from vm config")
 
+		p.apiRateLimit(ctx)
 		zone, err = p.client.Zones.Get(p.projectID, startAttributes.VMConfig.Zone).Context(ctx).Do()
 		if err != nil {
 			return nil, err
@@ -1103,6 +1105,7 @@ func (p *gceProvider) stepWaitForInstanceIP(c *gceStartContext) multistep.StepAc
 	time.Sleep(p.bootPrePollSleep)
 	span.End()
 
+	p.apiRateLimit(ctx)
 	zoneOpCall := p.client.ZoneOperations.Get(p.projectID, c.zoneName, c.instanceInsertOpName).Context(c.ctx)
 
 	c.progresser.Progress(&ProgressEntry{
@@ -1288,6 +1291,7 @@ func (p *gceProvider) buildInstance(ctx gocontext.Context, startAttributes *Star
 	diskType := p.ic.DiskType
 
 	if startAttributes.VMConfig.Zone != "" {
+		p.apiRateLimit(ctx)
 		zone, err = p.client.Zones.Get(p.projectID, startAttributes.VMConfig.Zone).Context(ctx).Do()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
There is a mismatch between attempted and actual GCE calls. I would expect the attempted ones to be higher, but that is often not the case. For example:

![image](https://user-images.githubusercontent.com/11158255/49082603-72a94e00-f24a-11e8-8011-ef6d90e269b6.png)

![image](https://user-images.githubusercontent.com/11158255/49082615-7dfc7980-f24a-11e8-8832-6f04d9decb7f.png)

refs https://github.com/travis-ci/reliability/issues/222