### PR TITLE
ratelimit: trace redis connection pool checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 
 ### Changed
+- ratelimit: trace redis connection pool checkout
 
 ### Deprecated
 

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -95,8 +95,12 @@ func (rl *redisRateLimiter) RateLimit(ctx gocontext.Context, name string, maxCal
 		defer span.End()
 	}
 
+	poolCheckoutStart := time.Now()
+
 	conn := rl.pool.Get()
 	defer conn.Close()
+
+	context.TimeSince(ctx, "rate_limit_redis_pool_wait", poolCheckoutStart)
 
 	if trace.FromContext(ctx) != nil {
 		var span *trace.Span

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -89,12 +89,18 @@ func NewNullRateLimiter() RateLimiter {
 // for this is unknown, but it's probably wise to limit the number of clients
 // to 5 or 6 for the time being.
 func (rl *redisRateLimiter) RateLimit(ctx gocontext.Context, name string, maxCalls uint64, per time.Duration) (bool, error) {
+	if trace.FromContext(ctx) != nil {
+		var span *trace.Span
+		ctx, span = trace.StartSpan(ctx, "Redis.RateLimit")
+		defer span.End()
+	}
+
 	conn := rl.pool.Get()
 	defer conn.Close()
 
 	if trace.FromContext(ctx) != nil {
 		var span *trace.Span
-		ctx, span = trace.StartSpan(ctx, "Redis.RateLimit")
+		ctx, span = trace.StartSpan(ctx, "Redis.RateLimit.WithPool")
 		defer span.End()
 	}
 


### PR DESCRIPTION
Looking at a trace, there is some unaccounted time spent in the rate limiter. One possible explanation for that would be contention on the redis connection pool.

![screen shot 2018-11-28 at 11 17 38](https://user-images.githubusercontent.com/11158255/49145483-30dadf00-f300-11e8-9a93-4a5434f9c9dc.png)

This extra span should help validate that theory.

refs https://github.com/travis-ci/reliability/issues/222