### PR TITLE
Make worker pool size manageable by software

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -100,19 +100,6 @@ func (i *CLI) Setup() (bool, error) {
 
 	i.Config = config.FromCLIContext(i.c)
 
-	if i.c.String("remote-controller-addr") != "" {
-		if i.c.String("remote-controller-auth") != "" {
-			i.setupRemoteController()
-		} else {
-			i.logger.Info("skipping remote controller setup without remote-controller-auth set")
-		}
-		go func() {
-			httpAddr := i.c.String("remote-controller-addr")
-			i.logger.Info("listening at ", httpAddr)
-			http.ListenAndServe(httpAddr, nil)
-		}()
-	}
-
 	if i.c.Bool("echo-config") {
 		config.WriteEnvConfig(i.Config, os.Stdout)
 		return false, nil
@@ -182,6 +169,19 @@ func (i *CLI) Setup() (bool, error) {
 	logger.WithField("pool", pool).Debug("built")
 
 	i.ProcessorPool = pool
+
+	if i.c.String("remote-controller-addr") != "" {
+		if i.c.String("remote-controller-auth") != "" {
+			i.setupRemoteController()
+		} else {
+			i.logger.Info("skipping remote controller setup without remote-controller-auth set")
+		}
+		go func() {
+			httpAddr := i.c.String("remote-controller-addr")
+			i.logger.Info("listening at ", httpAddr)
+			http.ListenAndServe(httpAddr, nil)
+		}()
+	}
 
 	err = i.setupJobQueueAndCanceller()
 	if err != nil {

--- a/cli.go
+++ b/cli.go
@@ -490,12 +490,12 @@ func (i *CLI) heartbeatCheck(heartbeatURL, heartbeatAuthToken string) error {
 
 func (i *CLI) setupRemoteController() {
 	i.logger.Info("setting up remote controller")
-	&RemoteController{
+	(&RemoteController{
 		pool:       i.ProcessorPool,
 		auth:       i.c.String("remote-controller-auth"),
 		workerInfo: i.workerInfo,
 		cancel:     i.cancel,
-	}.Setup()
+	}).Setup()
 }
 
 func (i *CLI) workerInfo() workerInfo {

--- a/cli.go
+++ b/cli.go
@@ -117,7 +117,7 @@ func (i *CLI) Setup() (bool, error) {
 			if httpPort == "" {
 				httpPort = i.c.String("pprof-port")
 			}
-			httpAddr := fmt.Sprintf("localhost:%s", httpPort)
+			httpAddr := fmt.Sprintf("0.0.0.0:%s", httpPort)
 			i.logger.Info("listening at ", httpAddr)
 			http.ListenAndServe(httpAddr, nil)
 		}()
@@ -499,9 +499,8 @@ func (i *CLI) heartbeatCheck(heartbeatURL, heartbeatAuthToken string) error {
 }
 
 func (i *CLI) setupHTTPAPI() {
-	i.logger.Info("setting up HTTP API")
-	http.HandleFunc("/worker", i.httpAPI)
-	http.HandleFunc("/worker/", i.httpAPI)
+	apiHandler := &APIHandler{i: i}
+	apiHandler.Setup()
 }
 
 func (i *CLI) httpAPI(w http.ResponseWriter, req *http.Request) {

--- a/cli.go
+++ b/cli.go
@@ -100,14 +100,14 @@ func (i *CLI) Setup() (bool, error) {
 
 	i.Config = config.FromCLIContext(i.c)
 
-	if i.c.String("http-api-addr") != "" {
-		if i.c.String("http-api-auth") != "" {
-			i.setupHTTPAPI()
+	if i.c.String("remote-controller-addr") != "" {
+		if i.c.String("remote-controller-auth") != "" {
+			i.setupRemoteController()
 		} else {
-			i.logger.Info("skipping HTTP API setup without http-api-auth set")
+			i.logger.Info("skipping remote controller setup without remote-controller-auth set")
 		}
 		go func() {
-			httpAddr := i.c.String("http-api-addr")
+			httpAddr := i.c.String("remote-controller-addr")
 			i.logger.Info("listening at ", httpAddr)
 			http.ListenAndServe(httpAddr, nil)
 		}()
@@ -488,15 +488,14 @@ func (i *CLI) heartbeatCheck(heartbeatURL, heartbeatAuthToken string) error {
 	return nil
 }
 
-func (i *CLI) setupHTTPAPI() {
-	i.logger.Info("setting up HTTP API")
-	apiHandler := &APIHandler{
+func (i *CLI) setupRemoteController() {
+	i.logger.Info("setting up remote controller")
+	&RemoteController{
 		pool:       i.ProcessorPool,
-		auth:       i.c.String("http-api-auth"),
+		auth:       i.c.String("remote-controller-auth"),
 		workerInfo: i.workerInfo,
 		cancel:     i.cancel,
-	}
-	apiHandler.Setup()
+	}.Setup()
 }
 
 func (i *CLI) workerInfo() workerInfo {

--- a/cli.go
+++ b/cli.go
@@ -100,23 +100,14 @@ func (i *CLI) Setup() (bool, error) {
 
 	i.Config = config.FromCLIContext(i.c)
 
-	if i.c.String("pprof-port") != "" && i.c.String("http-api-port") != "" {
-		return false, fmt.Errorf("only one http port is allowed. "+
-			"pprof-port=%v http-api-port=%v",
-			i.c.String("pprof-port"), i.c.String("http-api-port"))
-	}
-	if i.c.String("pprof-port") != "" || i.c.String("http-api-port") != "" {
+	if i.c.String("http-api-addr") != "" {
 		if i.c.String("http-api-auth") != "" {
 			i.setupHTTPAPI()
 		} else {
 			i.logger.Info("skipping HTTP API setup without http-api-auth set")
 		}
 		go func() {
-			httpPort := i.c.String("http-api-port")
-			if httpPort == "" {
-				httpPort = i.c.String("pprof-port")
-			}
-			httpAddr := fmt.Sprintf("0.0.0.0:%s", httpPort)
+			httpAddr := i.c.String("http-api-addr")
 			i.logger.Info("listening at ", httpAddr)
 			http.ListenAndServe(httpAddr, nil)
 		}()

--- a/config/config.go
+++ b/config/config.go
@@ -223,11 +223,11 @@ var (
 		NewConfigDef("ProgressType", &cli.StringFlag{
 			Usage: "Report progress for supported backends (valid values \"text\" or unset)",
 		}),
-		NewConfigDef("http-api-addr", &cli.StringFlag{
-			Usage: "enable http api (and pprof) at address",
+		NewConfigDef("remote-controller-addr", &cli.StringFlag{
+			Usage: "enable remote controller http api (and pprof) at address",
 		}),
-		NewConfigDef("http-api-auth", &cli.StringFlag{
-			Usage: "username:password for http api basic auth",
+		NewConfigDef("remote-controller-auth", &cli.StringFlag{
+			Usage: "username:password for http api basic auth for remote controller",
 		}),
 		NewConfigDef("silence-metrics", &cli.BoolFlag{
 			Usage: "deprecated flag",

--- a/config/config.go
+++ b/config/config.go
@@ -223,11 +223,8 @@ var (
 		NewConfigDef("ProgressType", &cli.StringFlag{
 			Usage: "Report progress for supported backends (valid values \"text\" or unset)",
 		}),
-		NewConfigDef("pprof-port", &cli.StringFlag{
-			Usage: "enable pprof http endpoint (and internal http api) at port",
-		}),
-		NewConfigDef("http-api-port", &cli.StringFlag{
-			Usage: "enable http api (and pprof) at port",
+		NewConfigDef("http-api-addr", &cli.StringFlag{
+			Usage: "enable http api (and pprof) at address",
 		}),
 		NewConfigDef("http-api-auth", &cli.StringFlag{
 			Usage: "username:password for http api basic auth",

--- a/http_api.go
+++ b/http_api.go
@@ -41,6 +41,9 @@ func (api *APIHandler) CheckAuth(next http.Handler) http.Handler {
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}
+
+		// pass it on!
+		next.ServeHTTP(w, req)
 	})
 }
 

--- a/http_api.go
+++ b/http_api.go
@@ -1,0 +1,104 @@
+package worker
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+// APIHandler handles requests to worker's HTTP API.
+type APIHandler struct {
+	i *CLI
+}
+
+// Setup installs the HTTP routes that will handle requests to the HTTP API.
+func (api *APIHandler) Setup() {
+	api.i.logger.Info("setting up HTTP API")
+	r := mux.NewRouter()
+	r.HandleFunc("/healthz", api.HealthCheck).Methods("GET")
+	r.HandleFunc("/worker", api.GetWorkerInfo).Methods("GET")
+	r.HandleFunc("/worker", api.UpdateWorkerInfo).Methods("PATCH")
+	r.Use(api.CheckAuth)
+	http.Handle("/", r)
+}
+
+// CheckAuth is a middleware for all HTTP API methods that ensures that the
+// configured basic auth credentials were passed in the request.
+func (api *APIHandler) CheckAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		username, password, ok := req.BasicAuth()
+		if !ok {
+			w.Header().Set("WWW-Authenticate", "Basic realm=\"travis-ci/worker\"")
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		authBytes := []byte(fmt.Sprintf("%s:%s", username, password))
+		if subtle.ConstantTimeCompare(authBytes, []byte(api.i.c.String("http-api-auth"))) != 1 {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+	})
+}
+
+// HealthCheck indicates whether worker is currently functioning in a healthy
+// way. This can be used by a system like Kubernetes to determine whether to
+// replace an instance of worker with a new one.
+func (api *APIHandler) HealthCheck(w http.ResponseWriter, req *http.Request) {
+	// TODO actually check that processors are running and ready
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, "OK")
+}
+
+// GetWorkerInfo writes a JSON payload with useful information about the current
+// state of worker as a whole.
+func (api *APIHandler) GetWorkerInfo(w http.ResponseWriter, req *http.Request) {
+	info := api.i.workerInfo()
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(info)
+}
+
+// UpdateWorkerInfo allows reconfiguring some parts of worker on the fly.
+//
+// The main use of this is adjusting the size of the processor pool without
+// interrupting existing running jobs.
+func (api *APIHandler) UpdateWorkerInfo(w http.ResponseWriter, req *http.Request) {
+	var info workerInfo
+	if err := json.NewDecoder(req.Body).Decode(&info); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(errorResponse{
+			Message: err.Error(),
+		})
+		return
+	}
+
+	if info.PoolSize > 0 {
+		api.i.ProcessorPool.SetSize(info.PoolSize)
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+type workerInfo struct {
+	Version          string `json:"version"`
+	Revision         string `json:"revision"`
+	PoolSize         int    `json:"poolSize"`
+	ExpectedPoolSize int    `json:"expectedPoolSize"`
+}
+
+func (i *CLI) workerInfo() workerInfo {
+	return workerInfo{
+		Version:          VersionString,
+		Revision:         RevisionString,
+		PoolSize:         i.ProcessorPool.Size(),
+		ExpectedPoolSize: i.ProcessorPool.ExpectedSize(),
+	}
+}
+
+type errorResponse struct {
+	Message string `json:"error"`
+}

--- a/processor.go
+++ b/processor.go
@@ -283,3 +283,12 @@ func (p *Processor) process(ctx gocontext.Context, buildJob Job) {
 
 	p.ProcessedCount++
 }
+
+func (p *Processor) processorInfo() processorInfo {
+	return processorInfo{
+		ID:        p.ID,
+		Processed: p.ProcessedCount,
+		Status:    p.CurrentStatus,
+		LastJobID: p.LastJobID,
+	}
+}


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

To run worker correctly in Kubernetes, we need to be able to control rollouts of new instances of worker such that the pool size doesn't exceed our computing capacity for running CI jobs. We're writing a Kubernetes controller for that, but to do its job, worker needs to have API for controlling the pool size. Some of that was present in the existing HTTP API, but it was missing some important things.

## What approach did you choose and why?

* Refactored HTTP API to use a Gorilla mux and have its own struct with the API handlers
* Changed the API URLs, methods, and format to be more resource-oriented and use JSON for easier use by other software
* Added API to ProcessorPool to set the size of the processor pool, instead of only being able to increment and decrement
* Firmed up the contract around `ProcessorPool.Size()`: it now includes processors that are still waiting to gracefully shutdown. Also added the old concept (which excludes processors that have been told to shutdown) back under a new name: `ExpectedSize()` (as it is expected to be the eventual size of the pool)
* Changed behavior when pool size is configured to be 0: now worker will wait for the first processor to start before falling through to the wait group. This lets the pool size be entirely managed by an outside service. In this mode, worker doesn't know what its pool size should be, and is waiting for another process to tell it how many processors it should start.

## How can you test this?

I'm testing this with an extra deployment in macstadium-staging, making manual requests to the HTTP API to make adjustments to the pool size.

## What feedback would you like, if any?

Any.