### PR TITLE
Allow graceful shutdown when no processors were started

### DIFF
--- a/processor_pool.go
+++ b/processor_pool.go
@@ -184,6 +184,13 @@ func (p *ProcessorPool) GracefulShutdown(togglePause bool) {
 		}
 	}
 
+	// In case no processors were ever started, we still want a graceful shutdown
+	// request to proceed. Without this, we will wait forever until the process is
+	// forcefully killed.
+	p.startProcessorOnce.Do(func() {
+		close(p.firstProcessorStarted)
+	})
+
 	ps := len(p.processors)
 	for i := 0; i < ps; i++ {
 		// Use Decr to make sure the processor is removed from the list in the pool


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

This addresses an edge case in the behavior added in #566 where if a worker is waiting for its first processor to start, a graceful shutdown request will never proceed.

## What approach did you choose and why?

When we receive a graceful shutdown request, attempt to close the channel waiting for the first processor. Essentially this is pretending a processor was started, so we stop waiting for it and proceed as normal.

## How can you test this?

It's pretty to produce the behavior by starting worker with POOL_SIZE=0 and sending it a SIGINT (or deleting the pod in Kubernetes). The process should die quickly, rather than wait indefinitely.

## What feedback would you like, if any?

Any.