### PR TITLE
Add ready check endpoint for remote controller

### DIFF
--- a/processor_pool.go
+++ b/processor_pool.go
@@ -84,6 +84,12 @@ func (p *ProcessorPool) Each(f func(int, *Processor)) {
 	}
 }
 
+// Ready returns true if the processor pool is running as expected.
+// Returns false if the processor pool has not been started yet.
+func (p *ProcessorPool) Ready() bool {
+	return p.queue != nil && p.logWriterFactory != nil
+}
+
 // Size returns the number of processors that are currently running.
 //
 // This includes processors that are in the process of gracefully shutting down. It's

--- a/processor_pool.go
+++ b/processor_pool.go
@@ -87,7 +87,7 @@ func (p *ProcessorPool) Each(f func(int, *Processor)) {
 // Ready returns true if the processor pool is running as expected.
 // Returns false if the processor pool has not been started yet.
 func (p *ProcessorPool) Ready() bool {
-	return p.queue != nil && p.logWriterFactory != nil
+	return p.queue != nil
 }
 
 // Size returns the number of processors that are currently running.

--- a/remote_controller.go
+++ b/remote_controller.go
@@ -23,6 +23,7 @@ func (api *RemoteController) Setup() {
 	r := mux.NewRouter()
 
 	r.HandleFunc("/healthz", api.HealthCheck).Methods("GET")
+	r.HandleFunc("/ready", api.ReadyCheck).Methods("GET")
 
 	r.HandleFunc("/worker", api.GetWorkerInfo).Methods("GET")
 	r.HandleFunc("/worker", api.UpdateWorkerInfo).Methods("PATCH")
@@ -41,8 +42,8 @@ func (api *RemoteController) Setup() {
 // configured basic auth credentials were passed in the request.
 func (api *RemoteController) CheckAuth(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		// skip auth for the health check endpoint
-		if strings.HasPrefix(req.URL.Path, "/healthz") {
+		// skip auth for the health and ready check endpoints
+		if strings.HasPrefix(req.URL.Path, "/healthz") || strings.HasPrefix(req.URL.Path, "/ready") {
 			next.ServeHTTP(w, req)
 			return
 		}
@@ -69,9 +70,22 @@ func (api *RemoteController) CheckAuth(next http.Handler) http.Handler {
 // way. This can be used by a system like Kubernetes to determine whether to
 // replace an instance of worker with a new one.
 func (api *RemoteController) HealthCheck(w http.ResponseWriter, req *http.Request) {
-	// TODO actually check that processors are running and ready
 	w.WriteHeader(http.StatusOK)
 	fmt.Fprint(w, "OK")
+}
+
+// ReadyCheck indicates whether the worker is ready to receive requests.
+// This is intended to be used as a readiness check in a system like Kubernetes.
+// We should not attempt to interact with the remote controller until this returns
+// a successful status.
+func (api *RemoteController) ReadyCheck(w http.ResponseWriter, req *http.Request) {
+	if api.pool.Ready() {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "OK")
+	} else {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprint(w, "Not Ready")
+	}
 }
 
 // GetWorkerInfo writes a JSON payload with useful information about the current


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Sometimes the worker operator makes requests to the HTTP API before the processor pool has started. This causes a crash because some properties of the ProcessorPool are not set until it's running.

## What approach did you choose and why?

Add a ready check endpoint to the API which checks the pool for its readiness. We'll define a readiness probe for worker pods in Kubernetes so that the pod will not be considered ready until this check passes. It makes sense that the worker pod as a whole wouldn't be ready until the processor pool is up and running.

## How can you test this?

Test in staging with the worker-operator.

## What feedback would you like, if any?

Any.