### PR TITLE
GCE requeue resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Removed
 
 ### Fixed
+- cli: assign job queue priority only when job queue is non-nil
+- backend/gce:
+  - consistently retry GCP API calls with exponential backoff
+  - switch both instance and disk zone when retrying in different zone
 
 ## [6.1.0] - 2018-12-13
 

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -778,7 +778,6 @@ func (p *gceProvider) Setup(ctx gocontext.Context) error {
 	}
 
 	err = p.backoffRetry(ctx, func() error {
-		var zlErr error
 		p.apiRateLimit(ctx)
 		zl, zlErr := p.client.Zones.List(p.projectID).
 			Context(ctx).

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -840,6 +840,7 @@ func (p *gceProvider) Setup(ctx gocontext.Context) error {
 			}
 		}
 	}
+	logger.WithField("map", p.machineTypeSelfLinks).Debug("built machine type self link map")
 
 	return err
 }
@@ -1472,8 +1473,10 @@ func (p *gceProvider) buildInstance(ctx gocontext.Context, c *gceStartContext) (
 		machineType = p.ic.PremiumMachineType
 	}
 
-	if machineTypeSelfLink, ok := p.machineTypeSelfLinks[gceMtKey(c.zoneName, machineType)]; ok {
-		inst.MachineType = machineTypeSelfLink
+	var ok bool
+	inst.MachineType, ok = p.machineTypeSelfLinks[gceMtKey(c.zoneName, machineType)]
+	if !ok {
+		return nil, fmt.Errorf("no machine type %s for zone %s", machineType, c.zoneName)
 	}
 
 	// Set accelerator config based on number and type of requested GPUs (empty if none)

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -695,9 +695,7 @@ func (p *gceProvider) apiRateLimit(ctx gocontext.Context) error {
 }
 
 func (p *gceProvider) Setup(ctx gocontext.Context) error {
-	var err error
-
-	err = p.backoffRetry(ctx, func() error {
+	err := p.backoffRetry(ctx, func() error {
 		p.apiRateLimit(ctx)
 		zone, zErr := p.client.Zones.
 			Get(p.projectID, p.cfg.Get("ZONE")).

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -1249,7 +1249,11 @@ func (p *gceProvider) stepWaitForInstanceIP(c *gceStartContext) multistep.StepAc
 
 		err := p.backoffRetry(ctx, func() error {
 			p.apiRateLimit(c.ctx)
-			op, zoErr := p.client.ZoneOperations.Get(p.projectID, c.zoneName, c.instanceInsertOpName).Context(ctx).Do()
+			op, zoErr := p.client.ZoneOperations.
+				Get(p.projectID, c.zoneName, c.instanceInsertOpName).
+				Context(ctx).
+				Do()
+
 			if zoErr == nil {
 				zoneOp.Status = op.Status
 				zoneOp.Error = op.Error
@@ -1434,6 +1438,7 @@ func (p *gceProvider) buildInstance(ctx gocontext.Context, c *gceStartContext) (
 	inst := &compute.Instance{
 		Description: fmt.Sprintf("Travis CI %s test VM", c.startAttributes.Language),
 		Name:        fmt.Sprintf("travis-job-%s", uuid.NewRandom()),
+		Zone:        c.zoneName,
 	}
 
 	diskInitParams := &compute.AttachedDiskInitializeParams{
@@ -1782,6 +1787,7 @@ func (i *gceInstance) refreshInstance(ctx gocontext.Context) error {
 			Get(i.projectID, zone, i.instance.Name).
 			Context(ctx).
 			Do()
+
 		if err != nil {
 			return err
 		}
@@ -2038,7 +2044,11 @@ func (i *gceInstance) Stop(ctx gocontext.Context) error {
 
 func (i *gceInstance) stepDeleteInstance(c *gceInstanceStopContext) multistep.StepAction {
 	err := i.provider.backoffRetry(c.ctx, func() error {
-		op, err := i.client.Instances.Delete(i.projectID, i.getZoneName(), i.instance.Name).Context(c.ctx).Do()
+		op, err := i.client.Instances.
+			Delete(i.projectID, i.getZoneName(), i.instance.Name).
+			Context(c.ctx).
+			Do()
+
 		if err != nil {
 			return err
 		}
@@ -2075,8 +2085,9 @@ func (i *gceInstance) stepWaitForInstanceDeleted(c *gceInstanceStopContext) mult
 
 	err := i.provider.backoffRetry(ctx, func() error {
 		i.provider.apiRateLimit(c.ctx)
-		zoneOp, err := i.client.ZoneOperations.Get(i.projectID,
-			i.getZoneName(), c.instanceDeleteOp.Name).Do()
+		zoneOp, err := i.client.ZoneOperations.
+			Get(i.projectID, i.getZoneName(), c.instanceDeleteOp.Name).
+			Do()
 
 		if err != nil {
 			return err

--- a/backend/gce_test.go
+++ b/backend/gce_test.go
@@ -126,5 +126,5 @@ func TestGCEProvider_SetupMakesRequests(t *testing.T) {
 	err := p.Setup(context.TODO())
 
 	assert.NotNil(t, err)
-	assert.Len(t, rl.Reqs, 1)
+	assert.True(t, len(rl.Reqs) >= 1)
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The most common errors that currently result in requeues are exacerbated by immediately requeueing.

## What approach did you choose and why?

Wrap each interaction with the GCE API in retry with exponential backoff so that problems such as Rate Limit Exceeded may be immediately mitigated instead of requeuing and possibly hitting the same error.

## How can you test this?

Canary deploy(s) probably?

## What feedback would you like, if any?

Is this awful? Non-awful?