### PR TITLE
Fix docs links for timeouted job

### DIFF
--- a/step_run_script.go
+++ b/step_run_script.go
@@ -153,7 +153,7 @@ func (s *stepRunScript) Run(state multistep.StateBag) multistep.StepAction {
 			Message: LogWriterTimeout.Error(),
 		})
 
-		s.writeLogAndFinishWithState(preTimeoutCtx, ctx, logWriter, buildJob, FinishStateErrored, fmt.Sprintf("\n\nNo output has been received in the last %v, this potentially indicates a stalled build or something wrong with the build itself.\nCheck the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received\n\nThe build has been terminated\n\n", s.logTimeout))
+		s.writeLogAndFinishWithState(preTimeoutCtx, ctx, logWriter, buildJob, FinishStateErrored, fmt.Sprintf("\n\nNo output has been received in the last %v, this potentially indicates a stalled build or something wrong with the build itself.\nCheck the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received\n\nThe build has been terminated\n\n", s.logTimeout))
 
 		if s.skipShutdownOnLogTimeout {
 			state.Put("skipShutdown", true)


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
A broken link to our docs, where the link doesn't send users to the right anchor due to case-sensitiveness :)

## What approach did you choose and why?

## How can you test this?
See:

https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received (working)
vs
https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received


## What feedback would you like, if any?
