### PR TITLE
randomize initial zone selection

### DIFF
--- a/backend/gce.go
+++ b/backend/gce.go
@@ -312,6 +312,10 @@ func newGCEProvider(cfg *config.ProviderConfig) (Provider, error) {
 		return nil, err
 	}
 
+	if !cfg.IsSet("ACCOUNT_JSON") {
+		return nil, fmt.Errorf("missing ACCOUNT_JSON")
+	}
+
 	projectID := cfg.Get("PROJECT_ID")
 	if metadata.OnGCE() {
 		projectID, err = metadata.ProjectID()

--- a/script/fmtpolice
+++ b/script/fmtpolice
@@ -2,7 +2,7 @@
 set -o errexit
 
 main() {
-  if [[ ! -n "${1}" ]]; then
+  if [[ -z "${1}" ]]; then
     git ls-files '*.go' | while read -r f; do
       __gofmt_check "${f}"
     done


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Workers, when deployed, are bound to a primary zone. Whenever a job (and VM) is started, the primary zone is used first, then an alternate zone is selected.

The core problem is when we start hitting zone exhaustion errors for a zone. Since there are pools of workers per zone, and each worker will try its primary zone first, which just puts more pressure on the api, raising the risk of api rate limit issues.

## What approach did you choose and why?

This is a first step towards a fix, but not yet the full fix.

This changes the concept of a primary zone, and instead has a random zone picked each try. A zone can still be defined in the config, but this zone will be used each and every time.

The follow up work to this PR is to block a zone for 10mins across all workers (possibly using Redis), which will help reduce api usage, and a better self healing worker setup.

## How can you test this?

I've tested this locally by connecting it to staging, and it worked a treat.

## What feedback would you like, if any?

This is for general discussion

I also need help understanding how to fix the test failures