### PR TITLE
.travis.yml: The ‘sudo’ Tag is now deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go: 1.11.x
-sudo: required
 dist: trusty
 group: edge
 


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"