### PR TITLE
snapcraft: Add initial snap packaging

### DIFF
--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -1,0 +1,52 @@
+name: travis-worker
+base: core18
+version: git
+grade: stable
+summary: Travis CI worker
+description: |-
+ This snap is for internal use by Travis to run worker nodes.
+confinement: strict
+
+apps:
+  daemon:
+    command: daemon.start
+    daemon: simple
+    plugs:
+      - lxd
+      - network
+
+parts:
+  travis-worker:
+    source: .
+    build-packages:
+      - gcc
+    plugin: go
+    go-packages:
+      - github.com/travis-ci/worker/cmd/travis-worker
+    go-importpath: github.com/travis-ci/worker
+    prime:
+      - bin/travis-worker
+    override-build: |-
+      set -eux
+
+      cd ${SNAPCRAFT_PROJECT_DIR}
+      VERSION="$(git describe --always --dirty --tags 2>/dev/null)"
+      REVISION="$(git rev-parse HEAD)"
+      REVISION_URL="https://github.com/travis-ci/worker/tree/${REVISION}"
+      GENERATED="$(date -u +'%Y-%m-%dT%H:%M:%S%z')"
+      COPYRIGHT="$(grep -i ^copyright LICENSE | sed 's/^[Cc]opyright //')"
+      cd -
+
+      sed -i "s#VersionString =.*#VersionString = \"${VERSION}\"#g" ../go/src/github.com/travis-ci/worker/version.go
+      sed -i "s#RevisionString =.*#RevisionString = \"${REVISION}\"#g" ../go/src/github.com/travis-ci/worker/version.go
+      sed -i "s#RevisionURLString =.*#RevisionURLString = \"${REVISION_URL}\"#g" ../go/src/github.com/travis-ci/worker/version.go
+      sed -i "s#GeneratedString =.*#GeneratedString = \"${GENERATED}\"#g" ../go/src/github.com/travis-ci/worker/version.go
+      sed -i "s#CopyrightString =.*#CopyrightString = \"${COPYRIGHT}\"#g" ../go/src/github.com/travis-ci/worker/version.go
+
+      set +ex
+      snapcraftctl build
+      set -ex
+
+  wrappers:
+    plugin: dump
+    source: .snapcraft/

--- a/.snapcraft/daemon.start
+++ b/.snapcraft/daemon.start
@@ -1,0 +1,11 @@
+#!/bin/sh
+export LXD_DIR=/var/snap/lxd/common/lxd/
+
+# Source the worker configuration
+if [ ! -e "${SNAP_COMMON}/worker.env" ]; then
+    echo "travis-worker isn't configured, please write its configuration to ${SNAP_COMMON}/worker.env" >&2
+    exit 1
+fi
+. ${SNAP_COMMON}/worker.env
+
+exec travis-worker


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>

## What is the problem that this PR is trying to fix?

Make it easy to install the worker on any architecture and in a reproducible way.

## What approach did you choose and why?

Ship it as a snap package so it can be installed on any distribution and any architecture.

## How can you test this?

Install the snap, configure it and join it to the staging CI environment.

## What feedback would you like, if any?
