### PR TITLE
Don't unescape ACCOUNT_JSON variable

### DIFF
--- a/config/provider_config.go
+++ b/config/provider_config.go
@@ -98,9 +98,11 @@ func ProviderConfigFromEnviron(providerName string) *ProviderConfig {
 
 				key := strings.ToUpper(strings.TrimPrefix(pair[0], prefix))
 				value := pair[1]
-				unescapedValue, err := url.QueryUnescape(value)
-				if err == nil {
-					value = unescapedValue
+				if !strings.HasSuffix(key, "ACCOUNT_JSON") {
+					unescapedValue, err := url.QueryUnescape(value)
+					if err == nil {
+						value = unescapedValue
+					}
 				}
 
 				pc.Set(key, value)


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
The GCE provider uses an ACCOUNT_JSON variable to fetch the credentials
for accessing the GCE API. This variable can either be a path to the
JSON or a string of the JSON. A similar implementation is used in
gcloud-cleanup.

In worker, the provider config is processed and all config variables are
'unescaped' as if it was a URL. This causes the JSON to become unusable,
mainly because the private key contains `+` symbols which get replaced
by spaces.

## What approach did you choose and why?
This solution simply checks if the key ends with ACCOUNT_JSON and skips
the 'unescape' step. This ensures backwards compatibility for any other
variables relying on this behavior. Ideally we should only run this step
when required, as in 'variable is a URL that needs unescaping'.

## How can you test this?
I've done a local run of the code with the .env config from staging. I'll also run it on staging after creating a new Docker image on the hub.

- [x] Local docker env
- [x] Staging Kubernetes

## What feedback would you like, if any?
Yes, please.

Side note:
I had trouble with GCR.io. I uploaded my locally build worker image to the staging GCR, but GKE didn't allow access to it (although it should with the oauth scopes set correctly), as worker is public and generally all our projects are, I've set the GCR of staging to 'public' now which circumvents the permission issue. We might want to look further into that if we want to rely on GCR more.
