### PR TITLE
Update for current LXD features

### DIFF
--- a/backend/lxd.go
+++ b/backend/lxd.go
@@ -463,13 +463,15 @@ func (p *lxdProvider) Start(ctx gocontext.Context, startAttributes *StartAttribu
 
 	// Create the container
 	config := map[string]string{
-		"security.devlxd":         "false",
-		"security.idmap.isolated": "true",
-		"security.idmap.size":     "100000",
-		"security.nesting":        "true",
-		"limits.memory":           p.limitMemory,
-		"limits.processes":        p.limitProcess,
-		"linux.kernel_modules":    "overlay",
+		"security.devlxd":                      "false",
+		"security.idmap.isolated":              "true",
+		"security.idmap.size":                  "100000",
+		"security.nesting":                     "true",
+		"security.syscalls.intercept.mknod":    "true",
+		"security.syscalls.intercept.setxattr": "true",
+		"limits.memory":                        p.limitMemory,
+		"limits.processes":                     p.limitProcess,
+		"linux.kernel_modules":                 "overlay",
 	}
 
 	if !p.limitCPUBurst {

--- a/backend/lxd.go
+++ b/backend/lxd.go
@@ -45,7 +45,7 @@ var (
 		"PROCESS":        fmt.Sprintf("maximum number of processes (default %q)", lxdLimitProcess),
 		"IMAGE":          fmt.Sprintf("image to use for the containers (default %q)", lxdImage),
 		"DOCKER_POOL":    fmt.Sprintf("storage pool to use for Docker (default %q)", lxdDockerPool),
-		"DOCKER_DISK":    fmt.Sprintf("storage pool to use for Docker (default %q)", lxdDockerDisk),
+		"DOCKER_DISK":    fmt.Sprintf("disk size to use for Docker (default %q)", lxdDockerDisk),
 		"NETWORK_STATIC": fmt.Sprintf("whether to statically set network configuration (default %v)", lxdNetworkStatic),
 		"NETWORK_DNS":    fmt.Sprintf("comma separated list of DNS servers (requires NETWORK_STATIC) (default %q)", lxdNetworkDns),
 	}

--- a/backend/lxd.go
+++ b/backend/lxd.go
@@ -191,7 +191,7 @@ func newLXDProvider(cfg *config.ProviderConfig) (Provider, error) {
 
 	limitDisk := lxdLimitDisk
 	if cfg.IsSet("DISK") {
-		limitNetwork = cfg.Get("DISK")
+		limitDisk = cfg.Get("DISK")
 	}
 
 	image := lxdImage

--- a/backend/lxd.go
+++ b/backend/lxd.go
@@ -453,6 +453,9 @@ func (p *lxdProvider) Start(ctx gocontext.Context, startAttributes *StartAttribu
 			Name: fmt.Sprintf("%s_docker", containerName),
 			Type: "custom",
 		}
+		vol.Config = map[string]string{
+			"size": p.dockerDisk,
+		}
 
 		err := p.client.CreateStoragePoolVolume(p.dockerPool, vol)
 		if err != nil {
@@ -530,7 +533,6 @@ func (p *lxdProvider) Start(ctx gocontext.Context, startAttributes *StartAttribu
 			"source": fmt.Sprintf("%s_docker", containerName),
 			"pool":   p.dockerPool,
 			"path":   "/var/lib/docker",
-			"size":   p.dockerDisk,
 		}
 	}
 

--- a/backend/lxd.go
+++ b/backend/lxd.go
@@ -519,6 +519,9 @@ func (p *lxdProvider) Start(ctx gocontext.Context, startAttributes *StartAttribu
 	// Network limits
 	container.Devices["eth0"] = container.ExpandedDevices["eth0"]
 	container.Devices["eth0"]["limits.max"] = p.limitNetwork
+	container.Devices["eth0"]["security.mac_filtering"] = "true"
+	container.Devices["eth0"]["security.ipv4_filtering"] = "true"
+	container.Devices["eth0"]["security.ipv6_filtering"] = "true"
 
 	// Docker storage
 	if p.dockerPool != "" {
@@ -554,6 +557,8 @@ func (p *lxdProvider) Start(ctx gocontext.Context, startAttributes *StartAttribu
         addresses: %s
       mtu: %s
 `, address, p.networkGateway, dns, p.networkMTU)
+
+		container.Devices["eth0"]["ipv4.address"] = address
 
 		args := lxd.ContainerFileArgs{
 			Type:    "file",

--- a/backend/lxd.go
+++ b/backend/lxd.go
@@ -447,7 +447,7 @@ func (p *lxdProvider) Start(ctx gocontext.Context, startAttributes *StartAttribu
 	// Create the container
 	config := map[string]string{
 		"security.idmap.isolated": "true",
-		"security.idmap.size":     "65536",
+		"security.idmap.size":     "100000",
 		"security.nesting":        "true",
 		"limits.memory":           p.limitMemory,
 		"limits.processes":        p.limitProcess,

--- a/backend/lxd.go
+++ b/backend/lxd.go
@@ -463,6 +463,7 @@ func (p *lxdProvider) Start(ctx gocontext.Context, startAttributes *StartAttribu
 
 	// Create the container
 	config := map[string]string{
+		"security.devlxd":         "false",
 		"security.idmap.isolated": "true",
 		"security.idmap.size":     "100000",
 		"security.nesting":        "true",


### PR DESCRIPTION
This sets a whole bunch of bunch of additional options and exposes some new settings:
 - Sets quota on Docker volume
 - Give us more rounded uid/gid allocation (easier to debug in `ps`)
 - Make main storage pool name configurable
 - Disable /dev/lxd access
 - Enable syscall interception (now disabled by default)
 - Enable MAC, IPv4 and IPv6 network filtering