### PR TITLE
Don't throw error if machine type self link doesn't exist

### DIFF
--- a/backend/gce.go
+++ b/backend/gce.go
@@ -813,13 +813,13 @@ func (p *gceProvider) Setup(ctx gocontext.Context) error {
 					p.machineTypeSelfLinks[key] = mt.SelfLink
 					return nil
 				}
-				return mtErr
+				return nil
 			})
 
-			if err != nil {
-				return errors.Wrap(err, "failed to find machine type self link")
-			}
 		}
+	}
+	if len(p.machineTypeSelfLinks) == 0 {
+		return errors.Wrap(errors.New("couldn't valid any MachineType"), "built machine type self link map is empty")
 	}
 	logger.WithField("map", p.machineTypeSelfLinks).Debug("built machine type self link map")
 

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -812,6 +812,13 @@ func (p *gceProvider) Setup(ctx gocontext.Context) error {
 				if mtErr == nil {
 					p.machineTypeSelfLinks[key] = mt.SelfLink
 					return nil
+				} else {
+					logger.WithFields(logrus.Fields{
+						"err":          mtErr,
+						"zone":         zoneName,
+						"machine_type": machineType,
+						"key":          key,
+					}).Debug("not found")
 				}
 				return nil
 			})
@@ -819,7 +826,7 @@ func (p *gceProvider) Setup(ctx gocontext.Context) error {
 		}
 	}
 	if len(p.machineTypeSelfLinks) == 0 {
-		return errors.Wrap(errors.New("couldn't valid any MachineType"), "built machine type self link map is empty")
+		return errors.Wrap(errors.New("couldn't validate any MachineType"), "built machine type self link map is empty")
 	}
 	logger.WithField("map", p.machineTypeSelfLinks).Debug("built machine type self link map")
 


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
We want to use new gen machine types n2, c2, but they are only available in us-central1-a and us-central1-c, worker was not able to start, failed with an error "failed to find machine type self link"

## What approach did you choose and why?
Remove error if machine type is not present in the zone and throw an error when link map is emtpy.

## How can you test this?

## What feedback would you like, if any?
Any welcome
