### PR TITLE
Remove Uninstalling section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,6 @@ you can run: `sudo snap install travis-worker --edge`
 1. `make`
 
 
-## Uninstalling
-
-In the case where Travis Worker has been installed via a deb package, there is a
-convenience script available which may be executed like so:
-
-``` bash
-curl -sSL https://raw.githubusercontent.com/travis-ci/worker/master/bin/travis-worker-uninstall |
-  sudo bash -
-```
-
 ## Configuring Travis Worker
 
 Travis Worker is configured with environment variables or command line flags via


### PR DESCRIPTION
Hello,

## What is the problem that this PR is trying to fix?
The `Uninstalling` readme section is confusing since `travis-worker-uninstall` script [was deleted](https://github.com/travis-ci/worker/commit/25d33b75e71ee623877636788f52935e709becb7).

## What approach did you choose and why?
I believe that it makes sense to just remove this section.

## How can you test this?
Read the README and see whether it's misleading.

## What feedback would you like, if any?
It would be nice to see any feedback.

Best regards!
