### PR TITLE
Create Dockerfile.ppc64le

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,0 +1,21 @@
+FROM ppc64le/golang:1.12 as builder
+MAINTAINER Travis CI GmbH <support+travis-worker-docker-image@travis-ci.org>
+
+COPY . /go/src/github.com/travis-ci/worker
+WORKDIR /go/src/github.com/travis-ci/worker
+ENV CGO_ENABLED 0
+RUN make build
+
+FROM ppc64le/alpine:latest
+RUN apk --no-cache add ca-certificates curl bash
+
+COPY --from=builder /go/bin/travis-worker /usr/local/bin/travis-worker
+COPY --from=builder /go/src/github.com/travis-ci/worker/systemd.service /app/systemd.service
+COPY --from=builder /go/src/github.com/travis-ci/worker/systemd-wrapper /app/systemd-wrapper
+COPY --from=builder /go/src/github.com/travis-ci/worker/.docker-entrypoint.sh /docker-entrypoint.sh
+
+VOLUME ["/var/tmp"]
+STOPSIGNAL SIGINT
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["/usr/local/bin/travis-worker"]


### PR DESCRIPTION
This commit adds a new Dockerfile for ppc64le which builds travis-worker binary and run it inside a Docker container.

## What is the problem that this PR is trying to fix?
Adds support for building travis-worker for ppc64le within a Docker container

## What approach did you choose and why?
Just replaced the base images with the ones related to ppc64le

## How can you test this?
Run on Power (you can get free access to Power at https://minicloud.parqtec.unicamp.br/)

## What feedback would you like, if any?
