### PR TITLE
Services start support on Bionic for TCI Enterprise in docker

### DIFF
--- a/backend/docker.go
+++ b/backend/docker.go
@@ -46,14 +46,14 @@ var (
 	defaultDockerSSHDialTimeout                = 5 * time.Second
 	defaultInspectInterval                     = 500 * time.Millisecond
 	defaultExecCmd                             = "bash /home/travis/build.sh"
-	defaultTmpfsMap                            = map[string]string{"/run": "rw,nosuid,nodev,exec,noatime,size=65536k", "/run/lock": "rw,nosuid,nodev,exec,noatime,size=65536k"}
+	defaultTmpfsMap                            = map[string]string{"/run": "rw,nosuid,nodev,exec,noatime,size=65536k"}
 	dockerHelp                                 = map[string]string{
 		"ENDPOINT / HOST":     "[REQUIRED] tcp or unix address for connecting to Docker",
 		"CERT_PATH":           "directory where ca.pem, cert.pem, and key.pem are located (default \"\")",
 		"CMD":                 "command (CMD) to run when creating containers (default \"/sbin/init\")",
 		"EXEC_CMD":            fmt.Sprintf("command to run via exec/ssh (default %q)", defaultExecCmd),
 		"INSPECT_INTERVAL":    fmt.Sprintf("time to wait between container inspections as duration (default %q)", defaultInspectInterval),
-		"TMPFS_MAP":           fmt.Sprintf("space-delimited key:value map of tmpfs mounts (default %q)", defaultTmpfsMap),
+		"TMPFS_MAP":           fmt.Sprintf("\"+\"-delimited key:value map of tmpfs mounts (example \"/run:rw,exec+/run/lock:rw,exec\", default %q)", defaultTmpfsMap),
 		"MEMORY":              "memory to allocate to each container (0 disables allocation, default \"4G\")",
 		"SHM":                 "/dev/shm to allocate to each container (0 disables allocation, default \"64MiB\")",
 		"CONTAINER_LABELS":    "comma- or space-delimited key:value pairs of labels to apply to each container (default \"\")",

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -433,6 +433,7 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 		Resources: dockercontainer.Resources{
 			Memory: int64(p.runMemory),
 		},
+		SecurityOpts: []string{"seccomp=unconfined"},
 	}
 
 	useCPUSets := p.runCPUs != uint(0)

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -53,7 +53,7 @@ var (
 		"CMD":                 "command (CMD) to run when creating containers (default \"/sbin/init\")",
 		"EXEC_CMD":            fmt.Sprintf("command to run via exec/ssh (default %q)", defaultExecCmd),
 		"INSPECT_INTERVAL":    fmt.Sprintf("time to wait between container inspections as duration (default %q)", defaultInspectInterval),
-		"TMPFS_MAP":           fmt.Sprintf("comma- or space-delimited key:value map of tmpfs mounts (default %q)", defaultTmpfsMap),
+		"TMPFS_MAP":           fmt.Sprintf("space-delimited key:value map of tmpfs mounts (default %q)", defaultTmpfsMap),
 		"MEMORY":              "memory to allocate to each container (0 disables allocation, default \"4G\")",
 		"SHM":                 "/dev/shm to allocate to each container (0 disables allocation, default \"64MiB\")",
 		"CONTAINER_LABELS":    "comma- or space-delimited key:value pairs of labels to apply to each container (default \"\")",
@@ -65,6 +65,7 @@ var (
 		"IMAGE_SELECTOR_TYPE": fmt.Sprintf("image selector type (\"tag\", \"api\", or \"env\", default %q)", defaultDockerImageSelectorType),
 		"IMAGE_SELECTOR_URL":  "URL for image selector API, used only when image selector is \"api\"",
 		"BINDS":               "Bind mount a volume (example: \"/var/run/docker.sock:/var/run/docker.sock\", default \"\")",
+		"SECURITY_OPT":        "Security configuration (example: \"seccomp=unconfined\") to turn off seccomp confinement for the container",
 	}
 )
 
@@ -90,6 +91,7 @@ type dockerProvider struct {
 	runPrivileged   bool
 	runCmd          []string
 	runBinds        []string
+	setSecurityOpt  []string
 	runMemory       uint64
 	runShm          uint64
 	runCPUs         uint
@@ -187,7 +189,12 @@ func newDockerProvider(cfg *config.ProviderConfig) (Provider, error) {
 		binds = strings.Split(cfg.Get("BINDS"), " ")
 	}
 
-	tmpFs := str2map(cfg.Get("TMPFS_MAP"))
+	securityOpt := []string{}
+	if cfg.IsSet("SECURITY_OPT") {
+		securityOpt = strings.Split(cfg.Get("SECURITY_OPT"), " ")
+	}
+
+	tmpFs := str2map(cfg.Get("TMPFS_MAP"), " ")
 	if len(tmpFs) == 0 {
 		tmpFs = defaultTmpfsMap
 	}
@@ -238,7 +245,7 @@ func newDockerProvider(cfg *config.ProviderConfig) (Provider, error) {
 
 	containerLabels := map[string]string{}
 	if cfg.IsSet("CONTAINER_LABELS") {
-		containerLabels = str2map(cfg.Get("CONTAINER_LABELS"))
+		containerLabels = str2map(cfg.Get("CONTAINER_LABELS"), " ,")
 	}
 
 	httpProxy := cfg.Get("HTTP_PROXY")
@@ -254,6 +261,7 @@ func newDockerProvider(cfg *config.ProviderConfig) (Provider, error) {
 		runPrivileged:   privileged,
 		runCmd:          cmd,
 		runBinds:        binds,
+		setSecurityOpt:  securityOpt,
 		runMemory:       memory,
 		runShm:          shm,
 		runCPUs:         uint(cpus),
@@ -433,7 +441,10 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 		Resources: dockercontainer.Resources{
 			Memory: int64(p.runMemory),
 		},
-		SecurityOpt: []string{"seccomp=unconfined"},
+	}
+
+	if len(p.setSecurityOpt) > 0 {
+		dockerHostConfig.SecurityOpt = p.setSecurityOpt
 	}
 
 	useCPUSets := p.runCPUs != uint(0)

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -46,7 +46,7 @@ var (
 	defaultDockerSSHDialTimeout                = 5 * time.Second
 	defaultInspectInterval                     = 500 * time.Millisecond
 	defaultExecCmd                             = "bash /home/travis/build.sh"
-	defaultTmpfsMap                            = map[string]string{/run": "rw,nosuid,nodev,exec,noatime,size=65536k", "/run/lock": "rw,nosuid,nodev,exec,noatime,size=65536k"}
+	defaultTmpfsMap                            = map[string]string{"/run": "rw,nosuid,nodev,exec,noatime,size=65536k", "/run/lock": "rw,nosuid,nodev,exec,noatime,size=65536k"}
 	dockerHelp                                 = map[string]string{
 		"ENDPOINT / HOST":     "[REQUIRED] tcp or unix address for connecting to Docker",
 		"CERT_PATH":           "directory where ca.pem, cert.pem, and key.pem are located (default \"\")",

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -46,7 +46,7 @@ var (
 	defaultDockerSSHDialTimeout                = 5 * time.Second
 	defaultInspectInterval                     = 500 * time.Millisecond
 	defaultExecCmd                             = "bash /home/travis/build.sh"
-	defaultTmpfsMap                            = map[string]string{"/run": "rw,nosuid,nodev,exec,noatime,size=65536k"}
+	defaultTmpfsMap                            = map[string]string{/run": "rw,nosuid,nodev,exec,noatime,size=65536k", "/run/lock": "rw,nosuid,nodev,exec,noatime,size=65536k"}
 	dockerHelp                                 = map[string]string{
 		"ENDPOINT / HOST":     "[REQUIRED] tcp or unix address for connecting to Docker",
 		"CERT_PATH":           "directory where ca.pem, cert.pem, and key.pem are located (default \"\")",

--- a/backend/docker.go
+++ b/backend/docker.go
@@ -433,7 +433,7 @@ func (p *dockerProvider) Start(ctx gocontext.Context, startAttributes *StartAttr
 		Resources: dockercontainer.Resources{
 			Memory: int64(p.runMemory),
 		},
-		SecurityOpts: []string{"seccomp=unconfined"},
+		SecurityOpt: []string{"seccomp=unconfined"},
 	}
 
 	useCPUSets := p.runCPUs != uint(0)

--- a/backend/package.go
+++ b/backend/package.go
@@ -130,11 +130,11 @@ func asBool(s string) bool {
 	}
 }
 
-func str2map(s string) map[string]string {
+func str2map(s, separators string) map[string]string {
 	ret := map[string]string{}
 
 	f := func(r rune) bool {
-		return r == ' ' || r == ','
+		return strings.ContainsAny(string(r), separators)
 	}
 
 	for _, kv := range strings.FieldsFunc(s, f) {

--- a/backend/package_test.go
+++ b/backend/package_test.go
@@ -57,7 +57,7 @@ func Test_hostnameFromContext(t *testing.T) {
 
 func Test_str2Map(t *testing.T) {
 	s := "foo:bar,bang:baz Hello:World, extra space:justBecause sillychars:butwhy%3F encodedspace:yup+, colonInside:why%3Anot"
-	m := str2map(s)
+	m := str2map(s, " ,")
 	e := map[string]string{
 		"foo":          "bar",
 		"bang":         "baz",


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Builds which uses services can not start via systemctl because of some profile permission issue in docker.
`System has not been booted with systemd as init system (PID 1). Can't operate.`

Solution requires to have support to set following envs:
`TRAVIS_WORKER_DOCKER_BINDS`
`TRAVIS_WORKER_DOCKER_SECURITY_OPT`
`TRAVIS_WORKER_DOCKER_TMPFS_MAP`

Issue is related to Travis CI Enterprise docker solution.
Internal ticket:
https://travisci.assembla.com/spaces/Enterprise/tickets/realtime_cardwall?ticket=37

## What approach did you choose and why?
Solution based on information from https://github.com/defn/docker-systemd

## How can you test this?
Install worker with bionic support for Travis CI Enterprise docker solution.
https://docs.travis-ci.com/user/enterprise/setting-up-travis-ci-enterprise/