### PR TITLE
Remove `trace` package import

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -21,7 +21,6 @@ import (
 
 	gocontext "context"
 
-	googlecloudtrace "cloud.google.com/go/trace"
 	"contrib.go.opencensus.io/exporter/stackdriver"
 	"go.opencensus.io/trace"
 	"golang.org/x/oauth2/google"
@@ -39,6 +38,10 @@ import (
 	"github.com/travis-ci/worker/context"
 	travismetrics "github.com/travis-ci/worker/metrics"
 	cli "gopkg.in/urfave/cli.v1"
+)
+
+const (
+	ScopeTraceAppend = "https://www.googleapis.com/auth/trace.append"
 )
 
 var (
@@ -349,7 +352,7 @@ func (i *CLI) setupMetrics() {
 
 func loadStackdriverTraceJSON(ctx gocontext.Context, stackdriverTraceAccountJSON string) (*google.Credentials, error) {
 	if stackdriverTraceAccountJSON == "" {
-		creds, err := google.FindDefaultCredentials(ctx, googlecloudtrace.ScopeTraceAppend)
+		creds, err := google.FindDefaultCredentials(ctx, ScopeTraceAppend)
 		return creds, errors.Wrap(err, "could not build default client")
 	}
 
@@ -358,7 +361,7 @@ func loadStackdriverTraceJSON(ctx gocontext.Context, stackdriverTraceAccountJSON
 		return nil, err
 	}
 
-	creds, err := google.CredentialsFromJSON(ctx, credBytes, googlecloudtrace.ScopeTraceAppend)
+	creds, err := google.CredentialsFromJSON(ctx, credBytes, ScopeTraceAppend)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/getsentry/raven-go v0.0.0-20180903072508-084a9de9eb03
 	github.com/gogo/protobuf v1.2.1 // indirect
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
-	github.com/google/martian v2.0.0-beta.2.0.20180813215018-c223d6f7955e+incompatible // indirect
 	github.com/google/uuid v1.1.0 // indirect
 	github.com/googleapis/gax-go v2.0.0+incompatible // indirect
 	github.com/gorilla/mux v0.0.0-20181012153151-deb579d6e030

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,6 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42 h1:q3pnF5JFBNRz8sRD+IRj7Y6DMyYGTNqnZ9axTbSfoNI=
 github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/martian v2.0.0-beta.2.0.20180813215018-c223d6f7955e+incompatible h1:NpYJkB0EcEQF9J8ugxjYyENaRP3ixdr53NJer4p5HIg=
-github.com/google/martian v2.0.0-beta.2.0.20180813215018-c223d6f7955e+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.0 h1:Jf4mxPC/ziBnoPIdpQdPJ9OeiomAUHLvxmPRSPH9m4s=
 github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Snapcraft always runs `go get` by default which updates trace package and breaks the build,  because `go build` uses updated package instead of the vendored one.

## What approach did you choose and why?
Because it's not possible to disable `go get` in Scapcraft go plugin, we will remove direct import of `trace` package

## How can you test this?
Run a build on Snapcraft

## What feedback would you like, if any?
