### PR TITLE
Use go 1.12, build failed with latest stable go

### DIFF
--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -21,6 +21,8 @@ parts:
     build-packages:
       - gcc
     plugin: go
+    build-snaps:
+      - go/1.12/stable
     go-packages:
       - github.com/travis-ci/worker/cmd/travis-worker
     go-importpath: github.com/travis-ci/worker


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

With the latest go version 1.13 build is falling we have to use 1.12.

## What approach did you choose and why?

## How can you test this?

https://build.snapcraft.io/user/DamianSzymanski/worker

## What feedback would you like, if any?
