### PR TITLE
Don't use underscore in storage volume name

### DIFF
--- a/backend/lxd.go
+++ b/backend/lxd.go
@@ -511,7 +511,7 @@ func (p *lxdProvider) Start(ctx gocontext.Context, startAttributes *StartAttribu
 		}
 
 		if p.dockerPool != "" {
-			err := p.client.DeleteStoragePoolVolume(p.dockerPool, "custom", fmt.Sprintf("%s_docker", containerName))
+			err := p.client.DeleteStoragePoolVolume(p.dockerPool, "custom", fmt.Sprintf("%s-docker", containerName))
 			if err != nil {
 				logger.WithField("err", err).Error("couldn't remove the container Docker storage volume")
 				return nil, err
@@ -528,7 +528,7 @@ func (p *lxdProvider) Start(ctx gocontext.Context, startAttributes *StartAttribu
 	// Create the Docker volume
 	if p.dockerPool != "" {
 		vol := lxdapi.StorageVolumesPost{
-			Name: fmt.Sprintf("%s_docker", containerName),
+			Name: fmt.Sprintf("%s-docker", containerName),
 			Type: "custom",
 		}
 		vol.Config = map[string]string{
@@ -608,7 +608,7 @@ func (p *lxdProvider) Start(ctx gocontext.Context, startAttributes *StartAttribu
 	if p.dockerPool != "" {
 		container.Devices["docker"] = map[string]string{
 			"type":   "disk",
-			"source": fmt.Sprintf("%s_docker", containerName),
+			"source": fmt.Sprintf("%s-docker", containerName),
 			"pool":   p.dockerPool,
 			"path":   "/var/lib/docker",
 		}
@@ -855,7 +855,7 @@ func (i *lxdInstance) Stop(ctx gocontext.Context) error {
 	}
 
 	if i.provider.dockerPool != "" {
-		err := i.client.DeleteStoragePoolVolume(i.provider.dockerPool, "custom", fmt.Sprintf("%s_docker", container.Name))
+		err := i.client.DeleteStoragePoolVolume(i.provider.dockerPool, "custom", fmt.Sprintf("%s-docker", container.Name))
 		if err != nil {
 			logger.WithField("err", err).Error("couldn't remove the container Docker storage volume")
 			return err


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The latest version of lxd fails with an error "Failed to get volume ID for project", lxd team added the possibility for the project name to be encoded into the volume name in the format `<project>_<volume>`. In this case we can't use underscore.
https://github.com/lxc/lxd/commit/d14390bfabc5500b0e84a1786608e828a2117e21#diff-0f4206d46c1d5de5381d7418858eb10bR33

## What approach did you choose and why?

Use dash instead of the underscore.

## How can you test this?

Run travis worker with lxd backend

## What feedback would you like, if any?

any