### PR TITLE
[Snap] Allow worker to bind to network

### DIFF
--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -14,6 +14,7 @@ apps:
     plugs:
       - lxd
       - network
+      - network-bind
 
 parts:
   travis-worker:


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
When running worker under snap the remote interface is unable to bind to the network
## What approach did you choose and why?
Allow `network-bind`
## How can you test this?
Deploy and test
## What feedback would you like, if any?
