### PR TITLE
snapcraft: fix build using golang 1.13+

### DIFF
--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -22,11 +22,12 @@ parts:
     build-packages:
       - gcc
     plugin: go
-    build-snaps:
-      - go/1.13/stable
+    build-environment:
+      - GO111MODULE: "off"
     go-packages:
       - github.com/travis-ci/worker/cmd/travis-worker
     go-importpath: github.com/travis-ci/worker
+    go-channel: 1.13/stable
     prime:
       - bin/travis-worker
     override-build: |-


### PR DESCRIPTION
golang 1.13 and 1.14 will both fail with different errors when
attempting `go get` commands.  Since full support of go.mod is
not yet available in snapcraft 3.9 (stable), this commit will
disable go modules until it can be enabled (v3.10+). Modules
are disabled by setting GO111MODULE=off in the build environment.

The current yaml specifies the go version in `build-snaps`.  However,
the go plugin has a property `go-channel` which sets the go snap
version.   The default value is `latest/stable` which is currently
go 1.13.  If a different version is specified in `build-snaps`, the
go snap will be updated/overridden to the version (implicitly) specified
by the `go-channel`.  An example log snippet shows this behavior:

```
<snip>
go (1.12/stable) 1.12.17 from Michael Hudson-Doyle (mwhudson) installed
snapd is not logged in, snap install commands will use sudo
go 1.13.8 from Michael Hudson-Doyle (mwhudson) refreshed
<snip>
```

This is why the behavior probably only recently manifested itself,
assuming the go snap's `latest/stable` was updated to point to 1.13.8.
Local builds would also work if using snapcraft v3.10 or newer (found
on `candidate` and `edge` channels).

In short:

- Lock in the go version to 1.13 using `go-channel`.

- Disable go modules until properly supported by snapcraft (v3.10+)
  using GO111MODULE=off.

Signed-off-by: Chris Patterson <chris.patterson@canonical.com>

## How can you test this?

I tested on build.snapcraft.io using:
https://github.com/cjp256/worker/commit/e54cb08d4a439d96933b09300e76219050c350ca

With a build log:
https://build.snapcraft.io/user/cjp256/worker/850763

The build log shows that it builds, but does not release because I can't release your snap :wink: 
