### PR TITLE
[LXD] Allow arch override to ensure that correct image is selected fo…

### DIFF
--- a/backend/lxd.go
+++ b/backend/lxd.go
@@ -95,9 +95,10 @@ type lxdProvider struct {
 	limitNetwork  string
 	limitProcess  string
 
-	image  string
-	runCmd []string
-	runUID int64
+	archOverride string
+	image        string
+	runCmd       []string
+	runUID       int64
 
 	imageSelectorType string
 	imageSelector     image.Selector


### PR DESCRIPTION
…r sub-arch

## What is the problem that this PR is trying to fix?
We want to use sub-arch for some infras, (e.g.: `arch: arm64-graviton` for AWS instances), but job-board should return image for `arm64` arch.

## What approach did you choose and why?
Override `arch` in worker config

## How can you test this?
Deploy and run a build

## What feedback would you like, if any?
