### PR TITLE
Only replace first occurence of IMAGE_

### DIFF
--- a/image/env_selector.go
+++ b/image/env_selector.go
@@ -26,7 +26,7 @@ func (es *EnvSelector) buildLookup() {
 
 	es.c.Each(func(key, value string) {
 		if strings.HasPrefix(key, "IMAGE_") {
-			lookup[strings.ToLower(strings.Replace(key, "IMAGE_", "", -1))] = value
+			lookup[strings.ToLower(strings.Replace(key, "IMAGE_", "", 1))] = value
 		}
 	})
 


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
The replace is too greedy and leads to this situation while using image aliases for selector osx_image:
IMAGE_OSX_IMAGE_XCODE10 => osx_xcode10

This never matches as buildCandidateKeys() represents it as osx_image_xcode10. This PR will only replace leading IMAGE_ and allow the matching to succeed

## What approach did you choose and why?

## How can you test this?

## What feedback would you like, if any?
