### PR TITLE
Fix for multiple vm's started by worker

### DIFF
--- a/backend/ec2.go
+++ b/backend/ec2.go
@@ -516,9 +516,6 @@ func (p *ec2Provider) Start(ctx gocontext.Context, startAttributes *StartAttribu
 						instanceChan <- instance
 						return
 					}
-					if reservation.Instances[0].InstanceId != nil {
-                        logger.Debugf("instance %s is not ready", *reservation.Instances[0].InstanceId)
-                    }
 				}
 			}
 			errCount++
@@ -526,6 +523,9 @@ func (p *ec2Provider) Start(ctx gocontext.Context, startAttributes *StartAttribu
 				instanceChan <- nil
 				return
 			}
+			if reservation.Instances[0].InstanceId != nil {
+                logger.Debugf("instance %s is not ready", *reservation.Instances[0].InstanceId)
+            }
 			time.Sleep(500 * time.Millisecond)
 		}
 	}()

--- a/backend/ec2.go
+++ b/backend/ec2.go
@@ -524,8 +524,8 @@ func (p *ec2Provider) Start(ctx gocontext.Context, startAttributes *StartAttribu
 				return
 			}
 			if reservation.Instances[0].InstanceId != nil {
-                logger.Debugf("instance %s is not ready", *reservation.Instances[0].InstanceId)
-            }
+				logger.Debugf("instance %s is not ready", *reservation.Instances[0].InstanceId)
+			}
 			time.Sleep(500 * time.Millisecond)
 		}
 	}()

--- a/backend/ec2.go
+++ b/backend/ec2.go
@@ -504,7 +504,7 @@ func (p *ec2Provider) Start(ctx gocontext.Context, startAttributes *StartAttribu
 			}
 
 			instances, lastErr = svc.DescribeInstances(describeInstancesInput)
-			if instances != nil {
+			if instances != nil && len(instances.Reservations) > 0 && len(instances.Reservations
 				instance := instances.Reservations[0].Instances[0]
 				address := *instance.PrivateIpAddress
 				if instance.PublicIpAddress != nil && p.publicIPConnect {
@@ -516,6 +516,9 @@ func (p *ec2Provider) Start(ctx gocontext.Context, startAttributes *StartAttribu
 						instanceChan <- instance
 						return
 					}
+					if reservation.Instances[0].InstanceId != nil {
+                        logger.Debugf("instance %s is not ready", *reservation.Instances[0].InstanceId)
+                    }
 				}
 			}
 			errCount++

--- a/backend/ec2.go
+++ b/backend/ec2.go
@@ -504,7 +504,7 @@ func (p *ec2Provider) Start(ctx gocontext.Context, startAttributes *StartAttribu
 			}
 
 			instances, lastErr = svc.DescribeInstances(describeInstancesInput)
-			if instances != nil && len(instances.Reservations) > 0 && len(instances.Reservations
+			if instances != nil && len(instances.Reservations) > 0 && len(instances.Reservations[0].Instances) > 0 {
 				instance := instances.Reservations[0].Instances[0]
 				address := *instance.PrivateIpAddress
 				if instance.PublicIpAddress != nil && p.publicIPConnect {


### PR DESCRIPTION
Sometimes worker was starting instance, crashing and then starting the same instance again. 
thanks to @pavel-d 
