### PR TITLE
Write optional job cancellation reason to job log

### DIFF
--- a/amqp_canceller.go
+++ b/amqp_canceller.go
@@ -15,6 +15,7 @@ type cancelCommand struct {
 	Type   string `json:"type"`
 	JobID  uint64 `json:"job_id"`
 	Source string `json:"source"`
+	Reason string `json:"reason"`
 }
 
 // AMQPCanceller is responsible for listening to a command queue on AMQP and
@@ -113,7 +114,7 @@ func (d *AMQPCanceller) processCommand(delivery amqp.Delivery) error {
 		return nil
 	}
 
-	d.cancellationBroadcaster.Broadcast(command.JobID)
+	d.cancellationBroadcaster.Broadcast(command.JobID, CancellationCommand{Reason: command.Reason})
 
 	return nil
 }

--- a/amqp_canceller.go
+++ b/amqp_canceller.go
@@ -114,7 +114,7 @@ func (d *AMQPCanceller) processCommand(delivery amqp.Delivery) error {
 		return nil
 	}
 
-	d.cancellationBroadcaster.Broadcast(command.JobID, CancellationCommand{Reason: command.Reason})
+	d.cancellationBroadcaster.Broadcast(CancellationCommand{JobID: command.JobID, Reason: command.Reason})
 
 	return nil
 }

--- a/canceller_test.go
+++ b/canceller_test.go
@@ -1,6 +1,8 @@
 package worker
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestCancellationBroadcaster(t *testing.T) {
 	cb := NewCancellationBroadcaster()
@@ -12,23 +14,27 @@ func TestCancellationBroadcaster(t *testing.T) {
 
 	cb.Unsubscribe(1, ch1_2)
 
-	cb.Broadcast(1, CancellationCommand{})
-	cb.Broadcast(1, CancellationCommand{})
+	cb.Broadcast(CancellationCommand{JobID: 1, Reason: "42"})
+	cb.Broadcast(CancellationCommand{JobID: 1, Reason: "42"})
 
-	assertClosed(t, "ch1_1", ch1_1)
+	assertReceived(t, "ch1_1", ch1_1, CancellationCommand{JobID: 1, Reason: "42"})
 	assertWaiting(t, "ch1_2", ch1_2)
-	assertClosed(t, "ch1_3", ch1_3)
+	assertReceived(t, "ch1_3", ch1_3, CancellationCommand{JobID: 1, Reason: "42"})
 	assertWaiting(t, "ch2", ch2)
 }
 
-func assertClosed(t *testing.T, name string, ch <-chan CancellationCommand) {
+func assertReceived(t *testing.T, name string, ch <-chan CancellationCommand, expected CancellationCommand) {
 	select {
-	case _, ok := (<-ch):
+	case val, ok := (<-ch):
 		if ok {
-			t.Errorf("expected %s to be closed, but it received a value", name)
+			if expected != val {
+				t.Errorf("expected to receive %v, got %v", expected, val)
+			}
+		} else {
+			t.Errorf("expected %s to not be closed, but it was closed", name)
 		}
 	default:
-		t.Errorf("expected %s to be closed, but it wasn't", name)
+		t.Errorf("expected %s to receive a value, but it didn't", name)
 	}
 }
 
@@ -36,9 +42,9 @@ func assertWaiting(t *testing.T, name string, ch <-chan CancellationCommand) {
 	select {
 	case _, ok := (<-ch):
 		if ok {
-			t.Errorf("expected %s to be not be closed and not have a value, but it received a value", name)
+			t.Errorf("expected %s to not be closed and not have a value, but it received a value", name)
 		} else {
-			t.Errorf("expected %s to be not be closed and not have a value, but it was closed", name)
+			t.Errorf("expected %s to not be closed and not have a value, but it was closed", name)
 		}
 	default:
 	}

--- a/canceller_test.go
+++ b/canceller_test.go
@@ -12,8 +12,8 @@ func TestCancellationBroadcaster(t *testing.T) {
 
 	cb.Unsubscribe(1, ch1_2)
 
-	cb.Broadcast(1)
-	cb.Broadcast(1)
+	cb.Broadcast(1, CancellationCommand{})
+	cb.Broadcast(1, CancellationCommand{})
 
 	assertClosed(t, "ch1_1", ch1_1)
 	assertWaiting(t, "ch1_2", ch1_2)
@@ -21,7 +21,7 @@ func TestCancellationBroadcaster(t *testing.T) {
 	assertWaiting(t, "ch2", ch2)
 }
 
-func assertClosed(t *testing.T, name string, ch <-chan struct{}) {
+func assertClosed(t *testing.T, name string, ch <-chan CancellationCommand) {
 	select {
 	case _, ok := (<-ch):
 		if ok {
@@ -32,7 +32,7 @@ func assertClosed(t *testing.T, name string, ch <-chan struct{}) {
 	}
 }
 
-func assertWaiting(t *testing.T, name string, ch <-chan struct{}) {
+func assertWaiting(t *testing.T, name string, ch <-chan CancellationCommand) {
 	select {
 	case _, ok := (<-ch):
 		if ok {

--- a/http_job_queue.go
+++ b/http_job_queue.go
@@ -385,7 +385,7 @@ func (q *HTTPJobQueue) fetchJob(ctx gocontext.Context, jobID uint64) (Job, <-cha
 			return q.deleteJob(ctx, jobID)
 		},
 		cancelSelf: func(ctx gocontext.Context) {
-			q.cb.Broadcast(jobID, CancellationCommand{})
+			q.cb.Broadcast(CancellationCommand{JobID: jobID})
 		},
 	}
 	startAttrs := &httpJobPayloadStartAttrs{
@@ -495,7 +495,7 @@ func (q *HTTPJobQueue) generateJobRefreshClaimFunc(jobID uint64) (func(gocontext
 					"err":    err,
 					"job_id": jobID,
 				}).Error("cancelling")
-				q.cb.Broadcast(jobID, CancellationCommand{})
+				q.cb.Broadcast(CancellationCommand{JobID: jobID})
 				return
 			}
 

--- a/http_job_queue.go
+++ b/http_job_queue.go
@@ -385,7 +385,7 @@ func (q *HTTPJobQueue) fetchJob(ctx gocontext.Context, jobID uint64) (Job, <-cha
 			return q.deleteJob(ctx, jobID)
 		},
 		cancelSelf: func(ctx gocontext.Context) {
-			q.cb.Broadcast(jobID)
+			q.cb.Broadcast(jobID, CancellationCommand{})
 		},
 	}
 	startAttrs := &httpJobPayloadStartAttrs{
@@ -495,7 +495,7 @@ func (q *HTTPJobQueue) generateJobRefreshClaimFunc(jobID uint64) (func(gocontext
 					"err":    err,
 					"job_id": jobID,
 				}).Error("cancelling")
-				q.cb.Broadcast(jobID)
+				q.cb.Broadcast(jobID, CancellationCommand{})
 				return
 			}
 

--- a/processor_test.go
+++ b/processor_test.go
@@ -120,7 +120,7 @@ func TestProcessor(t *testing.T) {
 		if tc.isCancelled {
 			go func(sl time.Duration, i uint64) {
 				time.Sleep(sl)
-				cancellationBroadcaster.Broadcast(i, CancellationCommand{})
+				cancellationBroadcaster.Broadcast(CancellationCommand{JobID: i})
 			}(tc.runSleep-1, jobID)
 		}
 

--- a/processor_test.go
+++ b/processor_test.go
@@ -120,7 +120,7 @@ func TestProcessor(t *testing.T) {
 		if tc.isCancelled {
 			go func(sl time.Duration, i uint64) {
 				time.Sleep(sl)
-				cancellationBroadcaster.Broadcast(i)
+				cancellationBroadcaster.Broadcast(i, CancellationCommand{})
 			}(tc.runSleep-1, jobID)
 		}
 

--- a/step_subscribe_cancellation.go
+++ b/step_subscribe_cancellation.go
@@ -18,8 +18,8 @@ func (s *stepSubscribeCancellation) Run(state multistep.StateBag) multistep.Step
 	defer span.End()
 
 	if s.cancellationBroadcaster == nil {
-		ch := make(chan struct{})
-		state.Put("cancelChan", (<-chan struct{})(ch))
+		ch := make(chan CancellationCommand)
+		state.Put("cancelChan", (<-chan CancellationCommand)(ch))
 		return multistep.ActionContinue
 	}
 
@@ -41,6 +41,6 @@ func (s *stepSubscribeCancellation) Cleanup(state multistep.StateBag) {
 	defer span.End()
 
 	buildJob := state.Get("buildJob").(Job)
-	ch := state.Get("cancelChan").(<-chan struct{})
+	ch := state.Get("cancelChan").(<-chan CancellationCommand)
 	s.cancellationBroadcaster.Unsubscribe(buildJob.Payload().Job.ID, ch)
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
When job is terminated due to insufficient credit balance, a log entry about jobs being terminated due to insufficient credits balance must be printed to job log

## What approach did you choose and why?
Pass a "reason" in the command payload

## How can you test this?
Send a cancelation message with a reason in the payload

## What feedback would you like, if any?
