### PR TITLE
added vm_size parameter for setting instance size from amqp (#646)

### DIFF
--- a/amqp_job.go
+++ b/amqp_job.go
@@ -184,6 +184,10 @@ func (j *amqpJob) createStateUpdateBody(ctx gocontext.Context, state string) map
 		body["meta"].(map[string]interface{})["uuid"] = uuid
 	}
 
+	if j.startAttributes.VMSize != "" {
+		body["vm_size"] = j.startAttributes.VMSize
+	}
+
 	if j.Payload().Job.QueuedAt != nil {
 		body["queued_at"] = j.Payload().Job.QueuedAt.UTC().Format(time.RFC3339)
 	}

--- a/amqp_job_queue.go
+++ b/amqp_job_queue.go
@@ -222,6 +222,7 @@ func (q *AMQPJobQueue) Jobs(ctx gocontext.Context) (outChan <-chan Job, err erro
 
 				buildJob.startAttributes = startAttrs.Config
 				buildJob.startAttributes.VMType = buildJob.payload.VMType
+				buildJob.startAttributes.VMSize = buildJob.payload.VMSize
 				buildJob.startAttributes.VMConfig = buildJob.payload.VMConfig
 				buildJob.startAttributes.Warmer = buildJob.payload.Warmer
 				buildJob.startAttributes.SetDefaults(q.DefaultLanguage, q.DefaultDist, q.DefaultArch, q.DefaultGroup, q.DefaultOS, VMTypeDefault, VMConfigDefault)

--- a/backend/start_attributes.go
+++ b/backend/start_attributes.go
@@ -29,6 +29,12 @@ type StartAttributes struct {
 	// the job payload, see the worker.JobPayload struct.
 	VMConfig VmConfig `json:"-"`
 
+
+	// The VMSize isn't stored in the config directly, but in the top level of
+	// the job payload, see the worker.JobPayload struct.
+	VMSize string `json:"-"`
+
+
 	// Warmer isn't stored in the config directly, but in the top level of
 	// the job payload, see the worker.JobPayload struct.
 	Warmer bool `json:"-"`

--- a/job.go
+++ b/job.go
@@ -36,6 +36,7 @@ type JobPayload struct {
 	Timeouts   TimeoutsPayload        `json:"timeouts,omitempty"`
 	VMType     string                 `json:"vm_type"`
 	VMConfig   backend.VmConfig       `json:"vm_config"`
+	VMSize     string                 `json:"vm_size"`
 	Meta       JobMetaPayload         `json:"meta"`
 	Queue      string                 `json:"queue"`
 	Trace      bool                   `json:"trace"`


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
This PR introduces the worker to spin up a vm defined in the config provided by the user in their `travis.yml` file
