### PR TITLE
Fix wrong assignment of PROCESS environment variable 

### DIFF
--- a/backend/lxd.go
+++ b/backend/lxd.go
@@ -244,7 +244,7 @@ func newLXDProvider(cfg *config.ProviderConfig) (Provider, error) {
 
 	limitProcess := lxdLimitProcess
 	if cfg.IsSet("PROCESS") {
-		limitNetwork = cfg.Get("PROCESS")
+		limitProcess = cfg.Get("PROCESS")
 	}
 
 	limitDisk := lxdLimitDisk


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
### Summary
In LXD backend, the PROCESS environment variable is assigned to the wrong golang variable (`limitNetwork` instead of `limitProcess`). This causes abnormal behavior in the worker when trying to change the default LXD process limit.

On travis-worker installed via snap (` v6.2.16+git30.2798f7f`), adding `export TRAVIS_WORKER_LXD_PROCESS="1000"` causes the `limitNetwork` property of LXD to change, instead of changing `limitProcess`:

```
limitNetwork:\"1000\", limitProcess:\"5000\"
```
---
On a travis-worker binary built from source with the necessary fix in place, adding `export TRAVIS_WORKER_LXD_PROCESS="1000"` applies the change to the right property i.e `limitProcess`:

```
limitNetwork:\"1Gbit\", limitProcess:\"1000\"
```

## What approach did you choose and why?
Assigned it to the correct variable.

## How can you test this?
- Clone this repo and and make the code change.
- Build the binary.
- Change the default LXD process limit in your `.env` file like so: `export TRAVIS_WORKER_LXD_PROCESS="10000"`
- Execute the binary. 

## What feedback would you like, if any?
