### PR TITLE
Add gpu to query tags

### DIFF
--- a/backend/gce.go
+++ b/backend/gce.go
@@ -1482,10 +1482,6 @@ func (p *gceProvider) imageSelect(ctx gocontext.Context, startAttributes *StartA
 	jobID, _ := context.JobIDFromContext(ctx)
 	repo, _ := context.RepositoryFromContext(ctx)
 	var gpuVMType = GPUType(startAttributes.VMSize)
-	fmt.Println("--- mk-debug-worker --- inside gce.go#imageSelect start")
-	fmt.Println("gpuVMType value:")
-	fmt.Printf("%v", gpuVMType)
-	fmt.Println("\n--- mk-debug-worker --- inside gce.go#imageSelect end")
 
 	if startAttributes.ImageName != "" {
 		imageName = startAttributes.ImageName

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -1481,6 +1481,7 @@ func (p *gceProvider) imageSelect(ctx gocontext.Context, startAttributes *StartA
 
 	jobID, _ := context.JobIDFromContext(ctx)
 	repo, _ := context.RepositoryFromContext(ctx)
+	var gpuVMType = GPUType(startAttributes.VMSize)
 
 	if startAttributes.ImageName != "" {
 		imageName = startAttributes.ImageName
@@ -1494,6 +1495,7 @@ func (p *gceProvider) imageSelect(ctx gocontext.Context, startAttributes *StartA
 			OS:       startAttributes.OS,
 			JobID:    jobID,
 			Repo:     repo,
+			GpuVMType: gpuVMType,
 		})
 
 		if err != nil {

--- a/backend/gce.go
+++ b/backend/gce.go
@@ -1482,6 +1482,10 @@ func (p *gceProvider) imageSelect(ctx gocontext.Context, startAttributes *StartA
 	jobID, _ := context.JobIDFromContext(ctx)
 	repo, _ := context.RepositoryFromContext(ctx)
 	var gpuVMType = GPUType(startAttributes.VMSize)
+	fmt.Println("--- mk-debug-worker --- inside gce.go#imageSelect start")
+	fmt.Println("gpuVMType value:")
+	fmt.Printf("%v", gpuVMType)
+	fmt.Println("\n--- mk-debug-worker --- inside gce.go#imageSelect end")
 
 	if startAttributes.ImageName != "" {
 		imageName = startAttributes.ImageName

--- a/image/api_selector.go
+++ b/image/api_selector.go
@@ -272,6 +272,7 @@ func (as *APISelector) buildCandidateTags(params *Params) ([]*tagSet, error) {
 	hasDist := params.Dist != ""
 	hasGroup := params.Group != ""
 	hasOS := params.OS != ""
+	hasGpuVMType := params.GpuVMType != ""
 
 	if params.OS == "osx" && params.OsxImage != "" {
 		addTags("osx_image:"+params.OsxImage, "os:osx")
@@ -296,6 +297,10 @@ func (as *APISelector) buildCandidateTags(params *Params) ([]*tagSet, error) {
 	if hasDist {
 		addTags("dist:" + params.Dist)
 	}
+
+	if hasGpuVMType {
+    	addTags("gpu:true")
+    }
 
 	if hasLang {
 		addDefaultTag("language_" + params.Language + ":true")

--- a/image/api_selector.go
+++ b/image/api_selector.go
@@ -50,10 +50,6 @@ func (as *APISelector) SetMaxElapsedTime(maxElapsedTime time.Duration) {
 
 func (as *APISelector) Select(ctx gocontext.Context, params *Params) (string, error) {
 	tagSets, err := as.buildCandidateTags(params)
-	fmt.Println("--- mk-debug-worker --- inside api_selector.go#Select start")
-	fmt.Println("params value:")
-	fmt.Printf("%v", params)
-	fmt.Println("\n--- mk-debug-worker --- inside api_selector.go#Select end")
 	if err != nil {
 		return "default", err
 	}
@@ -155,13 +151,6 @@ func (as *APISelector) queryWithTags(ctx gocontext.Context, infra string, tags [
 
 	bodyLines = append(bodyLines, qs.Encode())
 
-	fmt.Println("--- mk-debug-worker --- inside api_selector.go#queryWithTags start")
-	fmt.Println("tags value:")
-	fmt.Printf("%v", tags)
-	fmt.Println("bodyLines value:")
-	fmt.Printf("%v", bodyLines)
-	fmt.Println("\n--- mk-debug-worker --- inside api_selector.go#queryWithTags end")
-
 	u, err := url.Parse(as.baseURL.String())
 	if err != nil {
 		return "", err
@@ -195,11 +184,6 @@ func (as *APISelector) makeImageRequest(ctx gocontext.Context, urlString string,
 		"url":  urlString,
 		"body": bodyLines,
 	}).Debug("selecting image from job-board")
-
-	fmt.Println("--- mk-debug-worker --- inside api_selector.go#makeImageRequest start")
-	fmt.Println("bodyLines value:")
-	fmt.Printf("%v", strings.Join(bodyLines, "\n"))
-	fmt.Println("\n--- mk-debug-worker --- inside api_selector.go#makeImageRequest end")
 
 	err := backoff.Retry(func() error {
 		req, err := http.NewRequest("POST", urlString, strings.NewReader(strings.Join(bodyLines, "\n")+"\n"))
@@ -296,13 +280,6 @@ func (as *APISelector) buildCandidateTags(params *Params) ([]*tagSet, error) {
 	hasDist := params.Dist != ""
 	hasGroup := params.Group != ""
 	hasOS := params.OS != ""
-
-	fmt.Println("\n--- mk-debug-worker --- inside api_selector.go#buildCandidateTags start \n")
-	fmt.Println("params value:")
-	fmt.Printf("%v", params)
-	fmt.Println("candidateTags value:")
-	fmt.Printf("%v", candidateTags)
-	fmt.Println("\n--- mk-debug-worker --- inside api_selector#buildCandidateTags end \n")
 
 	if params.OS == "osx" && params.OsxImage != "" {
 		addTags("osx_image:"+params.OsxImage, "os:osx")

--- a/image/api_selector.go
+++ b/image/api_selector.go
@@ -50,6 +50,10 @@ func (as *APISelector) SetMaxElapsedTime(maxElapsedTime time.Duration) {
 
 func (as *APISelector) Select(ctx gocontext.Context, params *Params) (string, error) {
 	tagSets, err := as.buildCandidateTags(params)
+	fmt.Println("--- mk-debug-worker --- inside Select start")
+	fmt.Println("params value:")
+	fmt.Printf("%v", params)
+	fmt.Println("\n--- mk-debug-worker --- inside Select end")
 	if err != nil {
 		return "default", err
 	}
@@ -181,6 +185,11 @@ func (as *APISelector) makeImageRequest(ctx gocontext.Context, urlString string,
 		"body": bodyLines,
 	}).Debug("selecting image from job-board")
 
+	fmt.Println("--- mk-debug-worker --- inside makeImageRequest start")
+	fmt.Println("bodyLines value:")
+	fmt.Printf("%v", strings.Join(bodyLines, "\n"))
+	fmt.Println("\n--- mk-debug-worker --- inside makeImageRequest end")
+
 	err := backoff.Retry(func() error {
 		req, err := http.NewRequest("POST", urlString, strings.NewReader(strings.Join(bodyLines, "\n")+"\n"))
 		if err != nil {
@@ -273,6 +282,13 @@ func (as *APISelector) buildCandidateTags(params *Params) ([]*tagSet, error) {
 	hasGroup := params.Group != ""
 	hasOS := params.OS != ""
 	hasGpuVMType := params.GpuVMType != ""
+
+	fmt.Println("\n--- mk-debug-worker --- inside gce.go#imageSelect start \n")
+	fmt.Println("params value:")
+	fmt.Printf("%v", params)
+	fmt.Println("params value:")
+	fmt.Printf("%v", hasGpuVMType)
+	fmt.Println("\n--- mk-debug-worker --- inside gce.go#imageSelect end \n")
 
 	if params.OS == "osx" && params.OsxImage != "" {
 		addTags("osx_image:"+params.OsxImage, "os:osx")

--- a/image/params.go
+++ b/image/params.go
@@ -10,4 +10,5 @@ type Params struct {
 
 	JobID uint64
 	Repo  string
+	GpuVMType  string
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Worker will pass one more query param named "gpu_vm_type" to job-board which is needed for selection of image for GPU.

## What approach did you choose and why?
I added the gpu_vm_type param in api_selector.go class where the rest of the params (like tags, is_default, repo etc) are passed to the POST `/images/search` request. Its only meant for GCE so the GpuVmType info is only passed from ace.go to api_selector.gce.

## How can you test this?
deployed on staging

## What feedback would you like, if any?
none